### PR TITLE
Fix Issue #91

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandtp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtp.java
@@ -38,9 +38,9 @@ public class Commandtp extends EssentialsCommand {
                 if (!user.isAuthorized("essentials.tp.position")) {
                     throw new Exception(tl("noPerm", "essentials.tp.position"));
                 }
-                final double x2 = args[0].startsWith("~") ? user.getLocation().getX() + Integer.parseInt(args[0].substring(1)) : Integer.parseInt(args[0]);
-                final double y2 = args[1].startsWith("~") ? user.getLocation().getY() + Integer.parseInt(args[1].substring(1)) : Integer.parseInt(args[1]);
-                final double z2 = args[2].startsWith("~") ? user.getLocation().getZ() + Integer.parseInt(args[2].substring(1)) : Integer.parseInt(args[2]);
+                final double x2 = args[0].startsWith("~") ? user.getLocation().getX() + (args[0].length() > 1 ? Integer.parseInt(args[0].substring(1)) : 0) : Integer.parseInt(args[0]);
+                final double y2 = args[1].startsWith("~") ? user.getLocation().getY() + (args[1].length() > 1 ? Integer.parseInt(args[1].substring(1)) : 0) : Integer.parseInt(args[1]);
+                final double z2 = args[2].startsWith("~") ? user.getLocation().getZ() + (args[2].length() > 1 ? Integer.parseInt(args[2].substring(1)) : 0) : Integer.parseInt(args[2]);
                 if (x2 > 30000000 || y2 > 30000000 || z2 > 30000000 || x2 < -30000000 || y2 < -30000000 || z2 < -30000000) {
                     throw new NotEnoughArgumentsException(tl("teleportInvalidLocation"));
                 }
@@ -56,9 +56,9 @@ public class Commandtp extends EssentialsCommand {
                     throw new Exception(tl("noPerm", "essentials.tp.position"));
                 }
                 final User target2 = getPlayer(server, user, args, 0);
-                final double x = args[1].startsWith("~") ? target2.getLocation().getX() + Integer.parseInt(args[1].substring(1)) : Integer.parseInt(args[1]);
-                final double y = args[2].startsWith("~") ? target2.getLocation().getY() + Integer.parseInt(args[2].substring(1)) : Integer.parseInt(args[2]);
-                final double z = args[3].startsWith("~") ? target2.getLocation().getZ() + Integer.parseInt(args[3].substring(1)) : Integer.parseInt(args[3]);
+                final double x = args[1].startsWith("~") ? target2.getLocation().getX() + (args[1].length() > 1 ? Integer.parseInt(args[1].substring(1)) : 0) : Integer.parseInt(args[1]);
+                final double y = args[2].startsWith("~") ? target2.getLocation().getY() + (args[2].length() > 1 ? Integer.parseInt(args[2].substring(1)) : 0) : Integer.parseInt(args[2]);
+                final double z = args[3].startsWith("~") ? target2.getLocation().getZ() + (args[3].length() > 1 ? Integer.parseInt(args[3].substring(1)) : 0) : Integer.parseInt(args[3]);
                 if (x > 30000000 || y > 30000000 || z > 30000000 || x < -30000000 || y < -30000000 || z < -30000000) {
                     throw new NotEnoughArgumentsException(tl("teleportInvalidLocation"));
                 }
@@ -104,9 +104,9 @@ public class Commandtp extends EssentialsCommand {
             target.sendMessage(tl("teleportAtoB", Console.NAME, toPlayer.getDisplayName()));
             target.getTeleport().now(toPlayer.getBase(), false, TeleportCause.COMMAND);
         } else if (args.length > 3) {
-            final double x = args[1].startsWith("~") ? target.getLocation().getX() + Integer.parseInt(args[1].substring(1)) : Integer.parseInt(args[1]);
-            final double y = args[2].startsWith("~") ? target.getLocation().getY() + Integer.parseInt(args[2].substring(1)) : Integer.parseInt(args[2]);
-            final double z = args[3].startsWith("~") ? target.getLocation().getZ() + Integer.parseInt(args[3].substring(1)) : Integer.parseInt(args[3]);
+            final double x = args[1].startsWith("~") ? target.getLocation().getX() + (args[1].length() > 1 ? Integer.parseInt(args[1].substring(1)) : 0) : Integer.parseInt(args[1]);
+            final double y = args[2].startsWith("~") ? target.getLocation().getY() + (args[2].length() > 1 ? Integer.parseInt(args[2].substring(1)) : 0) : Integer.parseInt(args[2]);
+            final double z = args[3].startsWith("~") ? target.getLocation().getZ() + (args[3].length() > 1 ? Integer.parseInt(args[3].substring(1)) : 0) : Integer.parseInt(args[3]);
             if (x > 30000000 || y > 30000000 || z > 30000000 || x < -30000000 || y < -30000000 || z < -30000000) {
                 throw new NotEnoughArgumentsException(tl("teleportInvalidLocation"));
             }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
@@ -26,11 +26,15 @@ public class Commandtppos extends EssentialsCommand {
         final double y = args[1].startsWith("~") ? user.getLocation().getY() + (args[1].length() > 1 ? Integer.parseInt(args[1].substring(1)) : 0) : Integer.parseInt(args[1]);
         final double z = args[2].startsWith("~") ? user.getLocation().getZ() + (args[2].length() > 1 ? Integer.parseInt(args[2].substring(1)) : 0) : Integer.parseInt(args[2]);
         final Location loc = new Location(user.getWorld(), x, y, z, user.getLocation().getYaw(), user.getLocation().getPitch());
-        if (args.length > 3) {
-            loc.setYaw((FloatUtil.parseFloat(args[3]) + 180 + 360) % 360);
+        if (args.length == 4) {
+            loc.setWorld(ess.getWorld(args[3]));
         }
         if (args.length > 4) {
+            loc.setYaw((FloatUtil.parseFloat(args[3]) + 180 + 360) % 360);
             loc.setPitch(FloatUtil.parseFloat(args[4]));
+        }
+        if (args.length > 5) {
+            loc.setWorld(ess.getWorld(args[5]));
         }
         if (x > 30000000 || y > 30000000 || z > 30000000 || x < -30000000 || y < -30000000 || z < -30000000) {
             throw new NotEnoughArgumentsException(tl("teleportInvalidLocation"));
@@ -53,11 +57,15 @@ public class Commandtppos extends EssentialsCommand {
         final double y = args[2].startsWith("~") ? user.getLocation().getY() + (args[2].length() > 1 ? Integer.parseInt(args[2].substring(1)) : 0) : Integer.parseInt(args[2]);
         final double z = args[3].startsWith("~") ? user.getLocation().getZ() + (args[3].length() > 1 ? Integer.parseInt(args[3].substring(1)) : 0) : Integer.parseInt(args[3]);
         final Location loc = new Location(user.getWorld(), x, y, z, user.getLocation().getYaw(), user.getLocation().getPitch());
+        if (args.length == 4) {
+            loc.setWorld(ess.getWorld(args[3]));
+        }
         if (args.length > 4) {
             loc.setYaw((FloatUtil.parseFloat(args[4]) + 180 + 360) % 360);
+            loc.setPitch(FloatUtil.parseFloat(args[5]));
         }
         if (args.length > 5) {
-            loc.setPitch(FloatUtil.parseFloat(args[5]));
+            loc.setWorld(ess.getWorld(args[5]));
         }
         if (x > 30000000 || y > 30000000 || z > 30000000 || x < -30000000 || y < -30000000 || z < -30000000) {
             throw new NotEnoughArgumentsException(tl("teleportInvalidLocation"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
@@ -57,15 +57,15 @@ public class Commandtppos extends EssentialsCommand {
         final double y = args[2].startsWith("~") ? user.getLocation().getY() + (args[2].length() > 1 ? Integer.parseInt(args[2].substring(1)) : 0) : Integer.parseInt(args[2]);
         final double z = args[3].startsWith("~") ? user.getLocation().getZ() + (args[3].length() > 1 ? Integer.parseInt(args[3].substring(1)) : 0) : Integer.parseInt(args[3]);
         final Location loc = new Location(user.getWorld(), x, y, z, user.getLocation().getYaw(), user.getLocation().getPitch());
-        if (args.length == 4) {
-            loc.setWorld(ess.getWorld(args[3]));
+        if (args.length == 5) {
+            loc.setWorld(ess.getWorld(args[4]));
         }
-        if (args.length > 4) {
+        if (args.length > 5) {
             loc.setYaw((FloatUtil.parseFloat(args[4]) + 180 + 360) % 360);
             loc.setPitch(FloatUtil.parseFloat(args[5]));
         }
-        if (args.length > 5) {
-            loc.setWorld(ess.getWorld(args[5]));
+        if (args.length > 6) {
+            loc.setWorld(ess.getWorld(args[6]));
         }
         if (x > 30000000 || y > 30000000 || z > 30000000 || x < -30000000 || y < -30000000 || z < -30000000) {
             throw new NotEnoughArgumentsException(tl("teleportInvalidLocation"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
@@ -22,9 +22,9 @@ public class Commandtppos extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
 
-        final double x = args[0].startsWith("~") ? user.getLocation().getX() + Integer.parseInt(args[0].substring(1)) : Integer.parseInt(args[0]);
-        final double y = args[1].startsWith("~") ? user.getLocation().getY() + Integer.parseInt(args[1].substring(1)) : Integer.parseInt(args[1]);
-        final double z = args[2].startsWith("~") ? user.getLocation().getZ() + Integer.parseInt(args[2].substring(1)) : Integer.parseInt(args[2]);
+        final double x = args[0].startsWith("~") ? user.getLocation().getX() + (args[0].length() > 1 ? Integer.parseInt(args[0].substring(1)) : 0) : Integer.parseInt(args[0]);
+        final double y = args[1].startsWith("~") ? user.getLocation().getY() + (args[1].length() > 1 ? Integer.parseInt(args[1].substring(1)) : 0) : Integer.parseInt(args[1]);
+        final double z = args[2].startsWith("~") ? user.getLocation().getZ() + (args[2].length() > 1 ? Integer.parseInt(args[2].substring(1)) : 0) : Integer.parseInt(args[2]);
         final Location loc = new Location(user.getWorld(), x, y, z, user.getLocation().getYaw(), user.getLocation().getPitch());
         if (args.length > 3) {
             loc.setYaw((FloatUtil.parseFloat(args[3]) + 180 + 360) % 360);
@@ -49,9 +49,9 @@ public class Commandtppos extends EssentialsCommand {
         }
 
         User user = getPlayer(server, args, 0, true, false);
-        final double x = args[1].startsWith("~") ? user.getLocation().getX() + Integer.parseInt(args[1].substring(1)) : Integer.parseInt(args[1]);
-        final double y = args[2].startsWith("~") ? user.getLocation().getY() + Integer.parseInt(args[2].substring(1)) : Integer.parseInt(args[2]);
-        final double z = args[3].startsWith("~") ? user.getLocation().getZ() + Integer.parseInt(args[3].substring(1)) : Integer.parseInt(args[3]);
+        final double x = args[1].startsWith("~") ? user.getLocation().getX() + (args[1].length() > 1 ? Integer.parseInt(args[1].substring(1)) : 0) : Integer.parseInt(args[1]);
+        final double y = args[2].startsWith("~") ? user.getLocation().getY() + (args[2].length() > 1 ? Integer.parseInt(args[2].substring(1)) : 0) : Integer.parseInt(args[2]);
+        final double z = args[3].startsWith("~") ? user.getLocation().getZ() + (args[3].length() > 1 ? Integer.parseInt(args[3].substring(1)) : 0) : Integer.parseInt(args[3]);
         final Location loc = new Location(user.getWorld(), x, y, z, user.getLocation().getYaw(), user.getLocation().getPitch());
         if (args.length > 4) {
             loc.setYaw((FloatUtil.parseFloat(args[4]) + 180 + 360) % 360);


### PR DESCRIPTION
Fixes relative coordinates in /tp and /tppos.
Adds world arguments to /tppos:
/tppos (X) (Y) (Z) (World)
/tppos (Player) (X) (Y) (Z) (World)
/tppos (X) (Y) (Z) (Yaw) (Pitch) (World)
/tppos (Player) (X) (Y) (Z) (Yaw) (Pitch) (World)
