### PR TITLE
Allow color-only nickname changes.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
@@ -78,6 +78,8 @@ public class Commandnick extends EssentialsLoopCommand {
             throw new Exception(tl("nickTooLong"));
         } else if (FormatUtil.stripFormat(newNick).length() < 1) {
             throw new Exception(tl("nickNamesAlpha"));
+        } else if (user != null && (user.isAuthorized("essentials.nick.changecolors") || user.isAuthorized("essentials.nick.changecolours")) && !FormatUtil.stripFormat(newNick).equals(user.getName())) {
+            throw new Exception(tl("nickNamesOnlyColorChanges"));
         }
         return newNick;
     }

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -261,6 +261,7 @@ nickChanged=\u00a76Nickname changed.
 nickDisplayName=\u00a74You have to enable change-displayname in Essentials config.
 nickInUse=\u00a74That name is already in use.
 nickNamesAlpha=\u00a74Nicknames must be alphanumeric.
+nickNamesOnlyColorChanges=\u00a74Nicknames can only have their colors changed.
 nickNoMore=\u00a76You no longer have a nickname.
 nickSet=\u00a76Your nickname is now \u00a7c{0}\u00a76.
 nickTooLong=\u00a74That nickname is too long.


### PR DESCRIPTION
Resolves #125.

The permission is `essentials.nick.changecolors` (or `essentials.nick.changecolours`). I can't test as EssentialsX won't compile.
