### PR TITLE
[Fix] Fixes drtshock/Essentials#188

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -58,6 +58,8 @@ public interface ISettings extends IConf {
 
     void addKit(String name, List<String> lines, long delay);
 
+    boolean isSkippingUsedOneTimeKitsFromKitList();
+
     String getLocale();
 
     String getNewbieSpawn();

--- a/Essentials/src/com/earth2me/essentials/Kit.java
+++ b/Essentials/src/com/earth2me/essentials/Kit.java
@@ -56,7 +56,10 @@ public class Kit {
                     }
 
                     Kit kit = new Kit(kitItem, ess);
-                    if (kit.getNextUse(user) != 0) {
+                    double nextUse = kit.getNextUse(user);
+                    if (nextUse == -1 && ess.getSettings().isSkippingUsedOneTimeKitsFromKitList()) {
+                        continue;
+                    } else if (nextUse != 0) {
                         name = tl("kitDelay", name);
                     }
 

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -351,6 +351,11 @@ public class Settings implements net.ess3.api.ISettings {
         config.save();
     }
 
+    @Override
+    public boolean isSkippingUsedOneTimeKitsFromKitList() {
+        return config.getBoolean("skip-used-one-time-kits-from-kit-list", false);
+    }
+
     private ChatColor operatorColor = null;
 
     @Override

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -246,6 +246,10 @@ player-commands:
   - worth
   - xmpp
 
+# When this option is enabled, one-time use kits (ie. delay < 0) will be
+# removed from the /kit list when a player can no longer use it
+skip-used-one-time-kits-from-kit-list: false
+
 # Note: All items MUST be followed by a quantity!
 # All kit names should be lower case, and will be treated as lower in permissions/costs.
 # Syntax: - itemID[:DataValue/Durability] Amount [Enchantment:Level].. [itemmeta:value]...


### PR DESCRIPTION
- Adds toggleable config option 'skip-used-one-time-kits-from-kit-list' to exclude used kits with delay < 0 from displaying in the /kit list
