### PR TITLE
Comma seperated money across the plugin

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -231,4 +231,6 @@ public interface ISettings extends IConf {
     boolean isLastMessageReplyRecipient();
     
     BigDecimal getMinimumPayAmount();
+    
+    boolean useCommaSeparatedMoney();
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1125,4 +1125,9 @@ public class Settings implements net.ess3.api.ISettings {
     @Override public BigDecimal getMinimumPayAmount() {
         return new BigDecimal(config.getString("minimum-pay-amount", "0.001"));
     }
+
+    @Override
+    public boolean useCommaSeparatedMoney() {
+        return config.getBoolean("use-comma-separated-money", false);
+    }
 }

--- a/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
@@ -13,7 +13,7 @@ import static com.earth2me.essentials.I18n.tl;
 
 public class NumberUtil {
     static DecimalFormat twoDPlaces = new DecimalFormat("#,###.##");
-    static DecimalFormat currencyFormat = new DecimalFormat("#,###.00", DecimalFormatSymbols.getInstance(Locale.US));
+    static DecimalFormat currencyFormat = new DecimalFormat("#,##0.00", DecimalFormatSymbols.getInstance(Locale.US));
 
     public static String shortCurrency(final BigDecimal value, final IEssentials ess) {
         return ess.getSettings().getCurrencySymbol() + formatAsCurrency(value);

--- a/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
@@ -10,16 +10,16 @@ import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
 
-
 public class NumberUtil {
-    static DecimalFormat twoDPlaces = new DecimalFormat("#,###.##");
-    if (ess.getSettings().useCommaSeparatedMoney()) {
-        // Uses comma separated money
-        static DecimalFormat currencyFormat = new DecimalFormat("#,##0.00", DecimalFormatSymbols.getInstance(Locale.US));
-    } else {
-        // Doesn't use comma separated money
-        static DecimalFormat currencyFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.US));
+    {
+       if (ess.getSettings().useCommaSeparatedMoney()) {
+           DecimalFormat currencyFormat = new DecimalFormat("#,##0.00", DecimalFormatSymbols.getInstance(Locale.US));
+        } else {
+           DecimalFormat currencyFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.US));
+        }
     }
+    
+    static DecimalFormat twoDPlaces = new DecimalFormat("#,###.##");
 
     public static String shortCurrency(final BigDecimal value, final IEssentials ess) {
         return ess.getSettings().getCurrencySymbol() + formatAsCurrency(value);

--- a/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
@@ -13,7 +13,13 @@ import static com.earth2me.essentials.I18n.tl;
 
 public class NumberUtil {
     static DecimalFormat twoDPlaces = new DecimalFormat("#,###.##");
-    static DecimalFormat currencyFormat = new DecimalFormat("#,##0.00", DecimalFormatSymbols.getInstance(Locale.US));
+    if (ess.getSettings().useCommaSeparatedMoney()) {
+        // Uses comma separated money
+        static DecimalFormat currencyFormat = new DecimalFormat("#,##0.00", DecimalFormatSymbols.getInstance(Locale.US));
+    } else {
+        // Doesn't use comma separated money
+        static DecimalFormat currencyFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.US));
+    }
 
     public static String shortCurrency(final BigDecimal value, final IEssentials ess) {
         return ess.getSettings().getCurrencySymbol() + formatAsCurrency(value);

--- a/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
@@ -13,7 +13,7 @@ import static com.earth2me.essentials.I18n.tl;
 
 public class NumberUtil {
     static DecimalFormat twoDPlaces = new DecimalFormat("#,###.##");
-    static DecimalFormat currencyFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.US));
+    static DecimalFormat currencyFormat = new DecimalFormat("#,###.00", DecimalFormatSymbols.getInstance(Locale.US));
 
     public static String shortCurrency(final BigDecimal value, final IEssentials ess) {
         return ess.getSettings().getCurrencySymbol() + formatAsCurrency(value);

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -539,6 +539,10 @@ use-bukkit-permissions: false
 # Minimum acceptable amount to be used in /pay.
 minimum-pay-amount: 0.001
 
+# Use comma separated money? 
+# e.g. $12,345,678.90 instead of $12345678.90
+use-comma-separated-money: false
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                   EssentialsHelp                     | #

--- a/Essentials/test/com/earth2me/essentials/EconomyTest.java
+++ b/Essentials/test/com/earth2me/essentials/EconomyTest.java
@@ -69,7 +69,7 @@ public class EconomyTest extends TestCase {
         }
 
         //test Format
-        assertEquals("Format $1000", "$1000", Economy.format(1000.0));
+        assertEquals("Format $1,000", "$1,000", Economy.format(1000.0));
         assertEquals("Format $10", "$10", Economy.format(10.0));
         assertEquals("Format $10.10", "$10.10", Economy.format(10.10));
         assertEquals("Format $10.10", "$10.10", Economy.format(10.1000001));


### PR DESCRIPTION
So the other day, this one issue was bugging me. https://github.com/drtshock/Essentials/issues/231
When using economy functions within the plugin, it becomes hard to read without the money being comma seperated. There's also other plugins that were made to comma seperate money but they don't work all throughout essentials (only for the /bal command). Therefore, I decided to create this pull request. It's a very simple change.
