### PR TITLE
Synchronize the copy process of the user map.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/UUIDMap.java
+++ b/Essentials/src/com/earth2me/essentials/UUIDMap.java
@@ -96,8 +96,9 @@ public class UUIDMap {
     }
 
     public Future<?> _writeUUIDMap() {
+        Map<String, UUID> names;
         synchronized (pendingDiskWrites) {
-            Map<String, UUID> names = ess.getUserMap().getNames();
+            names = ess.getUserMap().getNames();
             if (names.size() < 1) {
                 return null;
             }


### PR DESCRIPTION
I still believe the race-condition is not fixed. (https://github.com/drtshock/Essentials/pull/213)
In the last commit `names = new HashMap<>(names);` was added but that part is not synchronized with `names.clear()`!
