### PR TITLE
Prevent extra colour codes from creating Essentials signs

### DIFF
--- a/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
@@ -86,7 +86,7 @@ public class SignBlockListener implements Listener {
         //We loop through all sign types here to prevent clashes with preexisting signs later
         for (Signs signs : Signs.values()) {
             final EssentialsSign sign = signs.getSign();
-            if (topLine.equalsIgnoreCase(sign.getSuccessName())) {
+            if (topLine.endsWith(sign.getSuccessName()) && ChatColor.stripColor(topLine).equalsIgnoreCase(ChatColor.stripColor(sign.getSuccessName()))) {
                 event.setLine(0, ChatColor.stripColor(topLine));
             }
         }


### PR DESCRIPTION
This fixes #325. As is explained in the issue, you can create Essentials signs regardless of permissions by using duplicate colour codes. This happens as the current check will only prevent the sign from being created if it matches the format exactly (i.e. one colour code). Once the sign is created, Minecraft will automatically strip unnecessary colour codes, changing it to the Essentials sign.
