### PR TITLE
Add bypass permission to nick command

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
@@ -79,7 +79,7 @@ public class Commandnick extends EssentialsLoopCommand {
             throw new Exception(tl("nickTooLong"));
         } else if (FormatUtil.stripFormat(newNick).length() < 1) {
             throw new Exception(tl("nickNamesAlpha"));
-        } else if (user != null && (user.isAuthorized("essentials.nick.changecolors")) && !FormatUtil.stripFormat(newNick).equals(user.getName())) {
+        } else if (user != null && (user.isAuthorized("essentials.nick.changecolors") && !user.isAuthorized("essentials.nick.changecolors.bypass")) && !FormatUtil.stripFormat(newNick).equals(user.getName())) {
             throw new Exception(tl("nickNamesOnlyColorChanges"));
         }
         return newNick;


### PR DESCRIPTION
This is a simple solution to the problems cause by wildcard permissions, such as the one reported in #354. Users who have wildcard permissions will also have the bypass permission, and will be allowed to change their names as intended. Users who do not have wildcard permissions will not have the bypass permission, and will only be able to change colours.
