### PR TITLE
Extend Supervisor

### DIFF
--- a/Essentials/pom.xml
+++ b/Essentials/pom.xml
@@ -128,11 +128,21 @@
             <version>2.0.1</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.supaham.supervisor</groupId>
+            <artifactId>supervisor-bukkit</artifactId>
+            <version>1.3-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>
             <id>vault-repo</id>
             <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
+        </repository>
+        <repository>
+            <id>ender-zone-repo</id>
+            <url>http://ci.ender.zone/plugin/repository/everything/</url>
         </repository>
     </repositories>
 </project>

--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -24,6 +24,7 @@ import com.earth2me.essentials.register.payment.Methods;
 import com.earth2me.essentials.signs.SignBlockListener;
 import com.earth2me.essentials.signs.SignEntityListener;
 import com.earth2me.essentials.signs.SignPlayerListener;
+import com.earth2me.essentials.supervisor.EssentialsReportContext;
 import com.earth2me.essentials.textreader.IText;
 import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.textreader.SimpleTextInput;
@@ -230,6 +231,10 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 }
             } catch (IOException e) {
                 // Failed to submit the stats :-(
+            }
+
+            if (getServer().getPluginManager().getPlugin("Supervisor") != null) {
+                EssentialsReportContext.load(this);
             }
 
             final String timeroutput = execTimer.end();

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -802,4 +802,8 @@ public abstract class UserData extends PlayerExtension implements IConf {
     public void stopTransaction() {
         config.stopTransaction();
     }
+
+    public EssentialsUserConf getConfig() {
+        return config;
+    }
 }

--- a/Essentials/src/com/earth2me/essentials/supervisor/EssentialsReportContext.java
+++ b/Essentials/src/com/earth2me/essentials/supervisor/EssentialsReportContext.java
@@ -1,0 +1,98 @@
+package com.earth2me.essentials.supervisor;
+
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
+import com.earth2me.essentials.UserMap;
+import com.supaham.supervisor.bukkit.SupervisorPlugin;
+import com.supaham.supervisor.report.AbstractReportContextEntry;
+import com.supaham.supervisor.report.ReportContext;
+import com.supaham.supervisor.report.ReportContextEntry;
+import com.supaham.supervisor.report.ReportSpecifications;
+import com.supaham.supervisor.report.ReportSpecifications.ReportLevel;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+public class EssentialsReportContext extends ReportContext {
+
+    private static final Method getNamesMethod;
+    
+    private final Essentials ess;
+    
+    static {
+        try {
+            getNamesMethod = UserMap.class.getDeclaredMethod("getNames");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public static void load(Essentials ess) {
+        SupervisorPlugin.get().registerContext(ess, new EssentialsReportContext(ess));
+    }
+
+    public EssentialsReportContext(Essentials ess) {
+        super("essentialsx", "EssentialsX", "1");
+        this.ess = ess;
+    }
+
+    @Override
+    public ReportContextEntry createEntry(@Nonnull ReportSpecifications specs) {
+        return new EssentialsContext(this, specs);
+    }
+
+    private final class EssentialsContext extends AbstractReportContextEntry {
+
+        public EssentialsContext(@Nonnull ReportContext parentContext, @Nonnull ReportSpecifications reportSpecifications) {
+            super(parentContext, reportSpecifications);
+        }
+
+        @Override
+        public void run() {
+            append("users_count", ess.getUserMap().getUniqueUsers());
+            uuidMapCount();
+
+            if (getReportLevel() >= ReportLevel.NORMAL) {
+                userdata();
+            }
+
+            if (getReportLevel() > ReportLevel.BRIEF) {
+                config();
+            }
+        }
+
+        private void uuidMapCount() {
+            try {
+                getNamesMethod.setAccessible(true);
+                append("uuidmap_count", ((Map) getNamesMethod.invoke(ess.getUserMap())).size());
+                getNamesMethod.setAccessible(false);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+
+        private void userdata() {
+            for (User user : ess.getOnlineUsers()) {
+                File file = user.getConfig().getFile();
+                try {
+                    createPlainTextFile("userdata/" + file.getName(), user.getName() + " data").appendFile(file);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        
+        private void config() {
+            try {
+                createPlainTextFile("config.yml", "Essentials Configuration file").appendFile(new File(ess.getDataFolder(), "config.yml"));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supervisor is a Bukkit plugin that arms admins with a tool of data gathering for sharing with people such as developers in need of tracking down reported issues with their plugins. Essentials has a lot to gain from Supervisor in regards to issue squashing.

In this PR the EssentialsReportContext class is created which extends ReportContext and ReportContextEntry (for convenience) in order to provide details relevant to issues such as the config.yml and online user files.

Currently the following data is being logged:

| key | type | description |
| --- | --- | --- |
| users_count | integer | Total unique users that Essentials has information about. |
| uuidmap_count | integer | Total number of entries in the usermap.csv file. |

Files:

| filename | report level | description |
| --- | --- | --- |
| config.yml | >200 | A copy of the config.yml (from disk) |
| userdata/<uuid/name>.yml | >=400 | Every online user at the time of report has their file copied (from disk). |

Here's an example of a _brief_ report generated by Supervisor: https://gist.github.com/anonymous/7992db7eec6a6940a966

Here's an example of a more verbose (normal) report generated by Supervisor: https://gist.github.com/anonymous/f5afcb5452591a82e766

Default values may be tweaked for convenience.

This PR does **NOT** make Essentials depend on Supervisor, it is merely an optional extension.
