### PR TITLE
Let people see what proxy the player is coming from.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandwhois.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandwhois.java
@@ -5,16 +5,33 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.SetExpFix;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.NumberUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.Server;
+import org.bukkit.entity.Player;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
 
 
 public class Commandwhois extends EssentialsCommand {
+
+    private Field bungeeField = null;
+
     public Commandwhois() {
         super("whois");
+
+        try {
+            Class spigotConfigClass = Class.forName( "org.spigotmc.SpigotConfig" );
+            this.bungeeField = spigotConfigClass.getDeclaredField("bungee");
+        } catch (ClassNotFoundException | NoSuchFieldException ex) {
+            // Yeah we don't need this.
+        }
+
     }
 
     @Override
@@ -48,5 +65,37 @@ public class Commandwhois extends EssentialsCommand {
         sender.sendMessage(tl("whoisJail", (user.isJailed() ? user.getJailTimeout() > 0 ? DateUtil.formatDateDiff(user.getJailTimeout()) : tl("true") : tl("false"))));
         sender.sendMessage(tl("whoisMuted", (user.isMuted() ? user.getMuteTimeout() > 0 ? DateUtil.formatDateDiff(user.getMuteTimeout()) : tl("true") : tl("false"))));
 
+        InetSocketAddress addr = getRawAddress(Bukkit.getServer().getPlayer(user.getConfigUUID()));
+        if( isBungeeCord() && addr != null ) {
+            sender.sendMessage(tl("whoisProxyAddress", addr.getAddress().toString()));
+        }
+
     }
+
+    public InetSocketAddress getRawAddress(Player player) {
+        if( player == null ) return null;
+        try {
+            Object obj = Player.class.getDeclaredMethod("spigot").invoke(player);
+
+            if(obj != null) {
+                Method method = obj.getClass().getDeclaredMethod("getRawAddress");
+                method.setAccessible(true);
+                return (InetSocketAddress) method.invoke(obj);
+            }
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException | ClassCastException e) {
+            // We'll leave this aswell.
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public boolean isBungeeCord() {
+        try {
+            return (boolean) bungeeField.get( null );
+        } catch (IllegalAccessException | ClassCastException e) {
+			e.printStackTrace();
+            return false;
+        }
+    }
+
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandwhois.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandwhois.java
@@ -63,8 +63,8 @@ public class Commandwhois extends EssentialsCommand {
         sender.sendMessage(tl("whoisJail", (user.isJailed() ? user.getJailTimeout() > 0 ? DateUtil.formatDateDiff(user.getJailTimeout()) : tl("true") : tl("false"))));
         sender.sendMessage(tl("whoisMuted", (user.isMuted() ? user.getMuteTimeout() > 0 ? DateUtil.formatDateDiff(user.getMuteTimeout()) : tl("true") : tl("false"))));
 
-        InetSocketAddress addr = getProxyAddress(Bukkit.getServer().getPlayer(user.getConfigUUID()));
-        if( isBungeeCord() && addr != null ) {
+        InetSocketAddress addr;
+        if( isBungeeCord() && (addr = getProxyAddress(Bukkit.getServer().getPlayer(user.getConfigUUID()))) != null ) {
             sender.sendMessage(tl("whoisProxyAddress", addr.getAddress().toString()));
         }
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandwhois.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandwhois.java
@@ -84,7 +84,6 @@ public class Commandwhois extends EssentialsCommand {
             }
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException | ClassCastException e) {
             // We'll leave this aswell.
-            e.printStackTrace();
         }
         return null;
     }
@@ -93,7 +92,6 @@ public class Commandwhois extends EssentialsCommand {
         try {
             return (boolean) bungeeField.get( null );
         } catch (IllegalAccessException | ClassCastException e) {
-			e.printStackTrace();
             return false;
         }
     }

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -490,6 +490,7 @@ weatherStorm=\u00a76You set the weather to \u00a7cstorm\u00a76 in\u00a7c {0}\u00
 weatherStormFor=\u00a76You set the weather to \u00a7cstorm\u00a76 in\u00a7c {0} \u00a76for {1} seconds.
 weatherSun=\u00a76You set the weather to \u00a7csun\u00a76 in\u00a7c {0}\u00a76.
 weatherSunFor=\u00a76You set the weather to \u00a7csun\u00a76 in\u00a7c {0} \u00a76for {1} seconds.
+whoisProxyAddress=\u00a76 - Proxy Address\:\u00a7r {0}
 whoisAFK=\u00a76 - AFK\:\u00a7r {0}
 whoisBanned=\u00a76 - Banned\:\u00a7r {0}
 whoisExp=\u00a76 - Exp\:\u00a7r {0} (Level {1})


### PR DESCRIPTION
So I would have put this in the nms provider but it seemed pointless since it's not real NMS and it would do the exact same there.

If the server is running spigot, and bungeecord: true in spigot.yml then this will have the connecting proxy/client IP separate to the forwarded one.

If it's not running spigot, then there's not a problem and nothing changes.

EDIT: Tested and works.
![Screen shot](http://i.imgur.com/8CRxQtd.png)
