### PR TITLE
Create VanishStatusChangeEvent class.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandvanish.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandvanish.java
@@ -6,6 +6,8 @@ import org.bukkit.Server;
 
 import static com.earth2me.essentials.I18n.tl;
 
+import net.ess3.api.events.VanishStatusChangeEvent;
+
 
 public class Commandvanish extends EssentialsToggleCommand {
     public Commandvanish() {
@@ -26,6 +28,13 @@ public class Commandvanish extends EssentialsToggleCommand {
     void togglePlayer(CommandSource sender, User user, Boolean enabled) throws NotEnoughArgumentsException {
         if (enabled == null) {
             enabled = !user.isVanished();
+        }
+
+        final User controller = sender.isPlayer() ? ess.getUser(sender.getPlayer()) : null;
+        VanishStatusChangeEvent vanishEvent = new VanishStatusChangeEvent(controller, user, enabled);
+        ess.getServer().getPluginManager().callEvent(vanishEvent);
+        if (vanishEvent.isCancelled()) {
+            return;
         }
 
         user.setVanished(enabled);

--- a/Essentials/src/net/ess3/api/events/VanishStatusChangeEvent.java
+++ b/Essentials/src/net/ess3/api/events/VanishStatusChangeEvent.java
@@ -1,0 +1,12 @@
+package net.ess3.api.events;
+
+import net.ess3.api.IUser;
+
+/**
+ * Called only in Commandvanish. For other events please use classes such as PlayerJoinEvent and eventually {@link IUser#isVanished()}.
+ */
+public class VanishStatusChangeEvent extends StatusChangeEvent {
+    public VanishStatusChangeEvent(IUser affected, IUser controller, boolean value) {
+        super(affected, controller, value);
+    }
+}


### PR DESCRIPTION
This commit creates a class called VanishStatusChangeEvent which is called only in Commandvanish when the `/vanish` command is executed.

This is being implemented as a request of #651.

This PR has been tested and functions as expected.
