### PR TITLE
Implement configurable currency formatting.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -8,6 +8,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventPriority;
 
 import java.math.BigDecimal;
+import java.text.NumberFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -243,4 +244,6 @@ public interface ISettings extends IConf {
     boolean isSendFlyEnableOnJoin();
     
     boolean isWorldTimePermissions();
+    
+    NumberFormat getCurrencyFormat();
 }

--- a/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/NumberUtil.java
@@ -15,6 +15,9 @@ import static com.earth2me.essentials.I18n.tl;
 public class NumberUtil {
     static DecimalFormat twoDPlaces = new DecimalFormat("#,###.##");
     static DecimalFormat currencyFormat = new DecimalFormat("#0.00", DecimalFormatSymbols.getInstance(Locale.US));
+    
+    // This field is likely to be modified in com.earth2me.essentials.Settings when loading currency format.
+    // This ensures that we can supply a constant formatting.
     static final NumberFormat PRETTY_FORMAT = NumberFormat.getInstance(Locale.US);
 
     static {

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -560,6 +560,19 @@ use-bukkit-permissions: false
 # Minimum acceptable amount to be used in /pay.
 minimum-pay-amount: 0.001
 
+# The format of currency, excluding symbols. See currency-sumbol-format-locale for symbol configuration.
+#
+# "#,##0.00" is how the majority of countries display currency.
+#currency-format: "#,##0.00"
+
+# Format currency symbols. Some locales use , and . interchangeably.
+# Some formats do not display properly in-game due to faulty Minecraft font rendering.
+#
+# For 1.234,50 use de-DE
+# For 1,234.50 use en-US
+# For 1'234,50 use fr-ch
+#currency-symbol-format-locale: en-US
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                   EssentialsHelp                     | #


### PR DESCRIPTION
This commit enables users of different countries around the world to configure currency formatting displayed to users in a familiar manner.

Prior to this commit US formatting (symbols) was forced upon users. This is now configurable via locale values e.g. en-US, de, fr-ch.

This commit adds two new configurations:
- currency-format
- currency-symbol-format-locale

One method ISettings#getCurrencyFormat()

This resolves #432 and #504.
