### PR TITLE
Create `/itemname` command that names held items.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commanditemname.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanditemname.java
@@ -1,0 +1,36 @@
+package com.earth2me.essentials.commands;
+
+import static com.earth2me.essentials.I18n.tl;
+
+import com.earth2me.essentials.CommandSource;
+import com.earth2me.essentials.I18n;
+import com.earth2me.essentials.User;
+import com.earth2me.essentials.utils.FormatUtil;
+
+import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Locale;
+
+public class Commanditemname extends EssentialsCommand {
+    
+    public Commanditemname() {
+        super("itemname");
+    }
+
+    @Override
+    protected void run(Server server, User user, String commandLabel, String[] args) throws Exception {
+        ItemStack item = user.getBase().getItemInHand();
+        if (item.getType() != Material.AIR) {
+            String name = FormatUtil.formatString(user, "essentials.itemname", getFinalArg(args, 0));
+            ItemMeta im = item.getItemMeta();
+            im.setDisplayName(name);
+            item.setItemMeta(im);
+            user.sendMessage(tl("itemnameSuccess", name));
+            return;
+        }
+        user.sendMessage(tl("itemnameInvalidItem", item.getType().toString().toLowerCase(Locale.ENGLISH).replace('_', ' ')));
+    }
+}

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -573,5 +573,5 @@ msgEnabled=\u00a76Receiving messages \u00a7cenabled\u00a76.
 msgEnabledFor=\u00a76Receiving messages \u00a7cenabled \u00a76for \u00a7c{0}\u00a76.
 msgIgnore=\u00a7c{0} \u00a74has messages disabled.
 minimumPayAmount=\u00a7cThe minimum amount you can pay is {0}.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -573,3 +573,5 @@ msgEnabled=\u00a76Receiving messages \u00a7cenabled\u00a76.
 msgEnabledFor=\u00a76Receiving messages \u00a7cenabled \u00a76for \u00a7c{0}\u00a76.
 msgIgnore=\u00a7c{0} \u00a74has messages disabled.
 minimumPayAmount=\u00a7cThe minimum amount you can pay is {0}.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_cs.properties
+++ b/Essentials/src/messages_cs.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_cs.properties
+++ b/Essentials/src/messages_cs.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_da.properties
+++ b/Essentials/src/messages_da.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_da.properties
+++ b/Essentials/src/messages_da.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_de.properties
+++ b/Essentials/src/messages_de.properties
@@ -566,3 +566,5 @@ spectator=Zuschauer
 kitContains=\u00a76Ausr\u00fcstung \u00a7c{0} \u00a76enth\u00e4lt:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Ung\u00fcltige Banner-Syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_de.properties
+++ b/Essentials/src/messages_de.properties
@@ -566,5 +566,5 @@ spectator=Zuschauer
 kitContains=\u00a76Ausr\u00fcstung \u00a7c{0} \u00a76enth\u00e4lt:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Ung\u00fcltige Banner-Syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -566,3 +566,5 @@ msgDisabled=\u00a76Receiving messages \u00a7cdisabled\u00a76.
 msgDisabledFor=\u00a76Receiving messages \u00a7cdisabled \u00a76for \u00a7c{0}\u00a76.
 msgEnabled=\u00a76Receiving messages \u00a7cenabled\u00a76.
 msgEnabledFor=\u00a76Receiving messages \u00a7cenabled \u00a76for \u00a7c{0}\u00a76.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -566,5 +566,5 @@ msgDisabled=\u00a76Receiving messages \u00a7cdisabled\u00a76.
 msgDisabledFor=\u00a76Receiving messages \u00a7cdisabled \u00a76for \u00a7c{0}\u00a76.
 msgEnabled=\u00a76Receiving messages \u00a7cenabled\u00a76.
 msgEnabledFor=\u00a76Receiving messages \u00a7cenabled \u00a76for \u00a7c{0}\u00a76.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_es.properties
+++ b/Essentials/src/messages_es.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_es.properties
+++ b/Essentials/src/messages_es.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_et.properties
+++ b/Essentials/src/messages_et.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_et.properties
+++ b/Essentials/src/messages_et.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_fi.properties
+++ b/Essentials/src/messages_fi.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_fi.properties
+++ b/Essentials/src/messages_fi.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_fr.properties
+++ b/Essentials/src/messages_fr.properties
@@ -567,3 +567,5 @@ msgDisabled=\u00a76R\u00e9ception des messages \u00a7cd\u00e9sactiv\u00e9e\u00a7
 msgDisabledFor=\u00a76R\u00e9ception des messages \u00a7cd\u00e9sactiv\u00e9e \u00a76pour \u00a7c{0}\u00a76.
 msgEnabled=\u00a76R\u00e9ception des messages \u00a7cactiv\u00e9e\u00a76.
 msgEnabledFor=\u00a76R\u00e9ception des messages \u00a7cactiv\u00e9e \u00a76pour \u00a7c{0}\u00a76.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_fr.properties
+++ b/Essentials/src/messages_fr.properties
@@ -567,5 +567,5 @@ msgDisabled=\u00a76R\u00e9ception des messages \u00a7cd\u00e9sactiv\u00e9e\u00a7
 msgDisabledFor=\u00a76R\u00e9ception des messages \u00a7cd\u00e9sactiv\u00e9e \u00a76pour \u00a7c{0}\u00a76.
 msgEnabled=\u00a76R\u00e9ception des messages \u00a7cactiv\u00e9e\u00a76.
 msgEnabledFor=\u00a76R\u00e9ception des messages \u00a7cactiv\u00e9e \u00a76pour \u00a7c{0}\u00a76.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_hu.properties
+++ b/Essentials/src/messages_hu.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_hu.properties
+++ b/Essentials/src/messages_hu.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_it.properties
+++ b/Essentials/src/messages_it.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_it.properties
+++ b/Essentials/src/messages_it.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_ko.properties
+++ b/Essentials/src/messages_ko.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_ko.properties
+++ b/Essentials/src/messages_ko.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_lt.properties
+++ b/Essentials/src/messages_lt.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_lt.properties
+++ b/Essentials/src/messages_lt.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_nl.properties
+++ b/Essentials/src/messages_nl.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_nl.properties
+++ b/Essentials/src/messages_nl.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_pl.properties
+++ b/Essentials/src/messages_pl.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_pl.properties
+++ b/Essentials/src/messages_pl.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_pt.properties
+++ b/Essentials/src/messages_pt.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_pt.properties
+++ b/Essentials/src/messages_pt.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_pt_BR.properties
+++ b/Essentials/src/messages_pt_BR.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_pt_BR.properties
+++ b/Essentials/src/messages_pt_BR.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_ro.properties
+++ b/Essentials/src/messages_ro.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_ro.properties
+++ b/Essentials/src/messages_ro.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_ru.properties
+++ b/Essentials/src/messages_ru.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_ru.properties
+++ b/Essentials/src/messages_ru.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_sv.properties
+++ b/Essentials/src/messages_sv.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_sv.properties
+++ b/Essentials/src/messages_sv.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_tr.properties
+++ b/Essentials/src/messages_tr.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_tr.properties
+++ b/Essentials/src/messages_tr.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_zh.properties
+++ b/Essentials/src/messages_zh.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_zh.properties
+++ b/Essentials/src/messages_zh.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_zh_HK.properties
+++ b/Essentials/src/messages_zh_HK.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_zh_HK.properties
+++ b/Essentials/src/messages_zh_HK.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_zh_TW.properties
+++ b/Essentials/src/messages_zh_TW.properties
@@ -562,3 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/messages_zh_TW.properties
+++ b/Essentials/src/messages_zh_TW.properties
@@ -562,5 +562,5 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
-itemnameInvalidItem=\u00a7cThat item material cannot be name.
+itemnameInvalidItem=\u00a7cThat item material cannot be renamed.
 itemnameSuccess=\u00a76You have renamed your held item to "{0}\u00a76".

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -199,6 +199,10 @@ commands:
     description: Searches for an item.
     usage: /<command> <item>
     aliases: [dura,edura,durability,edurability,eitemdb,itemno,eitemno]
+  itemname:
+    description: Names an item.
+    usage: /<command> <name...>
+    aliases: [iname, einame, eitemname, ]
   jails:
     description: List all jails.
     usage: /<command>

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -202,7 +202,7 @@ commands:
   itemname:
     description: Names an item.
     usage: /<command> <name...>
-    aliases: [iname, einame, eitemname, ]
+    aliases: [iname, einame, eitemname]
   jails:
     description: List all jails.
     usage: /<command>


### PR DESCRIPTION
This PR creates a class named `Commanditemname` alongside the addition in `plugin.yml`.

**Aliases**: [iname, einame, eitemname]

The command allows players to name their held items. It follows the conventions of `FormatUtil#formatString(IUser, String, String)`. Where the permBase string (1st arg) is `essentials.itemname`. This means in order to use colouring in itemname one must have the `essentials.itemname.color` permission.

This PR also adds two new translatable messages `itemnameInvalidItem` and `itemnameSuccess`.
