### PR TITLE
Implement Command Cooldowns.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -4,6 +4,7 @@ import com.earth2me.essentials.textreader.IText;
 import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.textreader.TextInput;
 import com.earth2me.essentials.textreader.TextPager;
+import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.LocationUtil;
 import net.ess3.api.IEssentials;
 import org.bukkit.GameMode;
@@ -26,11 +27,15 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
 import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -399,9 +404,47 @@ public class EssentialsPlayerListener implements Listener {
                     broadcast = false;
             }
         }
+        final User user = ess.getUser(player);
         if (update) {
-            final User user = ess.getUser(player);
             user.updateActivity(broadcast);
+        }
+
+        if (ess.getSettings().isCommandCooldownsEnabled() && pluginCommand != null) {
+            int argStartIndex = event.getMessage().indexOf(" ");
+            String args = argStartIndex == -1 ? event.getMessage() // No arguments present 
+                : event.getMessage().substring(argStartIndex); // arguments start at argStartIndex; substring from there.
+            String fullCommand = pluginCommand.getName() + " " + args;
+
+            // Used to determine whether a user already has an existing cooldown
+            // If so, no need to check for (and write) new ones.
+            boolean cooldownFound = false;
+            
+            // Iterate over a copy of getCommandCooldowns in case of concurrent modifications
+            for (Entry<Pattern, Long> entry : new HashMap<>(user.getCommandCooldowns()).entrySet()) {
+                // Remove any expired cooldowns
+                if (entry.getValue() <= System.currentTimeMillis()) {
+                    user.clearCommandCooldown(entry.getKey());
+                    // Don't break in case there are other command cooldowns left to clear.
+                } else if (entry.getKey().matcher(fullCommand).matches()) {
+                    // User's current cooldown hasn't expired, inform and terminate cooldown code.
+                    if (entry.getValue() > System.currentTimeMillis()) {
+                        String commandCooldownTime = DateUtil.formatDateDiff(entry.getValue());
+                        user.sendMessage(tl("commandCooldown", commandCooldownTime));
+                        cooldownFound = true;
+                        event.setCancelled(true);
+                        break;
+                    }
+                }
+            }
+
+            if (!cooldownFound) {
+                Entry<Pattern, Long> cooldownEntry = ess.getSettings().getCommandCooldownEntry(fullCommand);
+
+                if (cooldownEntry != null) {
+                    Date expiry = new Date(System.currentTimeMillis() + cooldownEntry.getValue());
+                    user.addCommandCooldown(cooldownEntry.getKey(), expiry, ess.getSettings().isCommandCooldownPersistent(fullCommand));
+                }
+            }
         }
     }
 

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -10,7 +10,9 @@ import org.bukkit.event.EventPriority;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 
 public interface ISettings extends IConf {
@@ -247,4 +249,12 @@ public interface ISettings extends IConf {
     boolean isSpawnOnJoin();
     
     boolean isTeleportToCenterLocation();
+    
+    boolean isCommandCooldownsEnabled();
+    
+    long getCommandCooldownMs(String label);
+
+    Entry<Pattern, Long> getCommandCooldownEntry(String label);
+    
+    boolean isCommandCooldownPersistent(String label);
 }

--- a/Essentials/src/com/earth2me/essentials/IUser.java
+++ b/Essentials/src/com/earth2me/essentials/IUser.java
@@ -7,9 +7,11 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 
 public interface IUser {
@@ -138,6 +140,14 @@ public interface IUser {
     Map<String, Object> getConfigMap();
 
     Map<String, Object> getConfigMap(String node);
+    
+    Map<Pattern, Long> getCommandCooldowns();
+
+    Date getCommandCooldownExpiry(String label);
+    
+    void addCommandCooldown(Pattern pattern, Date expiresAt, boolean save);
+    
+    boolean clearCommandCooldown(Pattern pattern);
 
     /*
      *  PlayerExtension

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -16,6 +16,7 @@ import org.bukkit.inventory.ItemStack;
 import java.io.File;
 import java.math.BigDecimal;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1257,6 +1257,6 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean isCommandCooldownPersistent(String label) {
         // TODO: enable per command cooldown specification for persistence.
-        return config.getBoolean("command-cooldown-persistence", false);
+        return config.getBoolean("command-cooldown-persistence", true);
     }
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -20,6 +20,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.earth2me.essentials.I18n.tl;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 
 public class Settings implements net.ess3.api.ISettings {
@@ -532,6 +534,7 @@ public class Settings implements net.ess3.api.ISettings {
         customQuitMessage = _getCustomQuitMessage();
         isCustomQuitMessage = !customQuitMessage.equals("none");
         muteCommands = _getMuteCommands();
+        commandCooldowns = _getCommandCooldowns();
     }
 
     private List<Integer> itemSpawnBl = new ArrayList<Integer>();
@@ -1172,5 +1175,87 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean isTeleportToCenterLocation() {
         return config.getBoolean("teleport-to-center", true);
+    }
+
+
+    private Map<Pattern, Long> commandCooldowns;
+
+    private Map<Pattern, Long> _getCommandCooldowns() {
+        if (!config.isConfigurationSection("command-cooldowns")) {
+            return null;
+        }
+        ConfigurationSection section = config.getConfigurationSection("command-cooldowns");
+        Map<Pattern, Long> result = new LinkedHashMap<>();
+        for (String cmdEntry : section.getKeys(false)) {
+            Pattern pattern = null;
+
+            /* ================================
+             * >> Regex
+             * ================================ */
+            if (cmdEntry.startsWith("^")) {
+                try {
+                    pattern = Pattern.compile(cmdEntry.substring(1));
+                } catch (PatternSyntaxException e) {
+                    ess.getLogger().warning("Command cooldown error: " + e.getMessage());
+                }
+            } else {
+                // Escape above Regex
+                if (cmdEntry.startsWith("\\^")) {
+                    cmdEntry = cmdEntry.substring(1);
+                }
+                String cmd = cmdEntry
+                    .replaceAll("\\*", ".*"); // Wildcards are accepted as asterisk * as known universally.
+                pattern = Pattern.compile(cmd + "( .*)?"); // This matches arguments, if present, to "ignore" them from the feature.
+            }
+            
+            /* ================================
+             * >> Process cooldown value
+             * ================================ */
+            Object value = section.get(cmdEntry);
+            if (!(value instanceof Number) && value instanceof String) {
+                try {
+                    value = Double.parseDouble(value.toString());
+                } catch (NumberFormatException ignored) {
+                }
+            }
+            if (!(value instanceof Number)) {
+                ess.getLogger().warning("Command cooldown error: '" + value + "' is not a valid cooldown");
+                continue;
+            }
+            double cooldown = ((Number) value).doubleValue();
+
+            result.put(pattern, (long) cooldown * 1000); // convert to milliseconds
+        }
+        return result;
+    }
+
+    @Override
+    public boolean isCommandCooldownsEnabled() {
+        return commandCooldowns != null;
+    }
+
+    @Override
+    public long getCommandCooldownMs(String label) {
+        Entry<Pattern, Long> result = getCommandCooldownEntry(label);
+        return result != null ? result.getValue() : -1; // return cooldown in milliseconds
+    }
+
+    @Override
+    public Entry<Pattern, Long> getCommandCooldownEntry(String label) {
+        if (isCommandCooldownsEnabled()) {
+            for (Entry<Pattern, Long> entry : this.commandCooldowns.entrySet()) {
+                // Check if label matches current pattern (command-cooldown in config)
+                if (entry.getKey().matcher(label).matches()) {
+                    return entry;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCommandCooldownPersistent(String label) {
+        // TODO: enable per command cooldown specification for persistence.
+        return config.getBoolean("command-cooldown-persistence", false);
     }
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1224,6 +1224,9 @@ public class Settings implements net.ess3.api.ISettings {
                 continue;
             }
             double cooldown = ((Number) value).doubleValue();
+            if (cooldown < 1) {
+                ess.getLogger().warning("Command cooldown with very short " + cooldown + " cooldown.");
+            }
 
             result.put(pattern, (long) cooldown * 1000); // convert to milliseconds
         }

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -869,7 +869,7 @@ public abstract class UserData extends PlayerExtension implements IConf {
                 continue;
             }
 
-            ImmutableMap<?, ?> map = ImmutableMap.builder()
+            Map<?, ?> map = ImmutableMap.builder()
                 .put("pattern", entry.getKey().pattern())
                 .put("expiry", entry.getValue())
                 .build();

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -2,6 +2,7 @@ package com.earth2me.essentials;
 
 import com.earth2me.essentials.utils.NumberUtil;
 import com.earth2me.essentials.utils.StringUtil;
+import com.google.common.collect.ImmutableMap;
 import net.ess3.api.IEssentials;
 import net.ess3.api.InvalidWorldException;
 import net.ess3.api.MaxMoneyException;
@@ -868,9 +869,10 @@ public abstract class UserData extends PlayerExtension implements IConf {
                 continue;
             }
 
-            HashMap<Object, Object> map = new HashMap<>();
-            map.put("pattern", entry.getKey().pattern());
-            map.put("expiry", entry.getValue());
+            ImmutableMap<?, ?> map = ImmutableMap.builder()
+                .put("pattern", entry.getKey().pattern())
+                .put("expiry", entry.getValue())
+                .build();
             serialized.add(map);
         }
         config.setProperty("timestamps.command-cooldowns", serialized);

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -490,7 +490,7 @@ world-time-permissions: false
 # Wildcards are supported. E.g.
 # - '*i*': 50
 # adds a 50 second cooldown to all commands that include the letter i
-#command-cooldowns:
+command-cooldowns:
 #  feed: 100 # 100 second cooldown on /feed command
 #  '*': 5 # 5 Second cooldown on all commands
 

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -490,6 +490,11 @@ world-time-permissions: false
 # Wildcards are supported. E.g.
 # - '*i*': 50
 # adds a 50 second cooldown to all commands that include the letter i
+#
+# EssentialsX supports regex by starting the command with a caret ^
+# For example, to target commands starting with ban and not banip the following would be used:
+#  '^ban([^ip])( .*)?': 60 # 60 seconds /ban cooldown.
+# Note: If you have a command that starts with ^, then you can escape it using backslash (\). e.g. \^command: 123
 command-cooldowns:
 #  feed: 100 # 100 second cooldown on /feed command
 #  '*': 5 # 5 Second cooldown on all commands

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -484,6 +484,19 @@ send-fly-enable-on-join: true
 # Give someone permission to teleport to a world with essentials.time.world.<worldname>.
 world-time-permissions: false
 
+# Specify cooldown for both Essentials commands and external commands as well.
+# All commands do not start with a Forward Slash (/). Instead of /msg, write msg
+#
+# Wildcards are supported. E.g.
+# - '*i*': 50
+# adds a 50 second cooldown to all commands that include the letter i
+#command-cooldowns:
+#  msg: 10 # 10 second cooldown on msg command
+#  '*': 5 # 5 Second cooldown on all commands 
+
+# Whether command cooldowns should be persistent past server shutdowns
+#command-cooldown-persistence: false
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                   EssentialsHome                     | #

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -491,8 +491,8 @@ world-time-permissions: false
 # - '*i*': 50
 # adds a 50 second cooldown to all commands that include the letter i
 #command-cooldowns:
-#  msg: 10 # 10 second cooldown on msg command
-#  '*': 5 # 5 Second cooldown on all commands 
+#  feed: 100 # 100 second cooldown on /feed command
+#  '*': 5 # 5 Second cooldown on all commands
 
 # Whether command cooldowns should be persistent past server shutdowns
 #command-cooldown-persistence: false

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -495,7 +495,7 @@ world-time-permissions: false
 #  '*': 5 # 5 Second cooldown on all commands
 
 # Whether command cooldowns should be persistent past server shutdowns
-#command-cooldown-persistence: false
+command-cooldown-persistence: true
 
 ############################################################
 # +------------------------------------------------------+ #

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -573,3 +573,4 @@ msgEnabled=\u00a76Receiving messages \u00a7cenabled\u00a76.
 msgEnabledFor=\u00a76Receiving messages \u00a7cenabled \u00a76for \u00a7c{0}\u00a76.
 msgIgnore=\u00a7c{0} \u00a74has messages disabled.
 minimumPayAmount=\u00a7cThe minimum amount you can pay is {0}.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_cs.properties
+++ b/Essentials/src/messages_cs.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_da.properties
+++ b/Essentials/src/messages_da.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_de.properties
+++ b/Essentials/src/messages_de.properties
@@ -566,3 +566,4 @@ spectator=Zuschauer
 kitContains=\u00a76Ausr\u00fcstung \u00a7c{0} \u00a76enth\u00e4lt:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Ung\u00fcltige Banner-Syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -566,3 +566,4 @@ msgDisabled=\u00a76Receiving messages \u00a7cdisabled\u00a76.
 msgDisabledFor=\u00a76Receiving messages \u00a7cdisabled \u00a76for \u00a7c{0}\u00a76.
 msgEnabled=\u00a76Receiving messages \u00a7cenabled\u00a76.
 msgEnabledFor=\u00a76Receiving messages \u00a7cenabled \u00a76for \u00a7c{0}\u00a76.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_es.properties
+++ b/Essentials/src/messages_es.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_et.properties
+++ b/Essentials/src/messages_et.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_fi.properties
+++ b/Essentials/src/messages_fi.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_fr.properties
+++ b/Essentials/src/messages_fr.properties
@@ -567,3 +567,4 @@ msgDisabled=\u00a76R\u00e9ception des messages \u00a7cd\u00e9sactiv\u00e9e\u00a7
 msgDisabledFor=\u00a76R\u00e9ception des messages \u00a7cd\u00e9sactiv\u00e9e \u00a76pour \u00a7c{0}\u00a76.
 msgEnabled=\u00a76R\u00e9ception des messages \u00a7cactiv\u00e9e\u00a76.
 msgEnabledFor=\u00a76R\u00e9ception des messages \u00a7cactiv\u00e9e \u00a76pour \u00a7c{0}\u00a76.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_hu.properties
+++ b/Essentials/src/messages_hu.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_it.properties
+++ b/Essentials/src/messages_it.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_ko.properties
+++ b/Essentials/src/messages_ko.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_lt.properties
+++ b/Essentials/src/messages_lt.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_nl.properties
+++ b/Essentials/src/messages_nl.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_pl.properties
+++ b/Essentials/src/messages_pl.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_pt.properties
+++ b/Essentials/src/messages_pt.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_pt_BR.properties
+++ b/Essentials/src/messages_pt_BR.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_ro.properties
+++ b/Essentials/src/messages_ro.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_ru.properties
+++ b/Essentials/src/messages_ru.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_sv.properties
+++ b/Essentials/src/messages_sv.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_tr.properties
+++ b/Essentials/src/messages_tr.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_zh.properties
+++ b/Essentials/src/messages_zh.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_zh_HK.properties
+++ b/Essentials/src/messages_zh_HK.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.

--- a/Essentials/src/messages_zh_TW.properties
+++ b/Essentials/src/messages_zh_TW.properties
@@ -562,3 +562,4 @@ spectator=spectator
 kitContains=\u00a76Kit \u00a7c{0} \u00a76contains:
 kitItem=\u00a76- \u00a7f{0}
 invalidBanner=\u00a74Invalid banner syntax.
+commandCooldown=\u00a7cYou cannot type that command for {0}.


### PR DESCRIPTION
This PR resolves #110 which requests that EssentialsX provide the ability to apply cooldowns to commands. Command cooldowns can be applied in the config.yml under the `command-cooldowns` property which is thought to be sufficiently documented.
# `command-cooldowns`

`command-cooldowns` accepts simple command names such as:

``` yaml
command-cooldowns:
  feed: 100
```

Where players that use the /feed command are given a 100 second cooldown. (Decimals are allowed)

But it also accepts more **complex commands** such as:

``` yaml
command-cooldowns:
  ban*: 600
```

Where players that use the /ban command are given a 600 second cooldown. On top of that the asterisk acts as a wildcard where - in this case - if a command starts with ban it will match it; `/banip`, `/baneveryone`, etc.

It goes a step further and allows for the possibility to match regex when it starts with a caret `^`:

``` yaml
command-cooldowns:
  '^ban([^ip])( .*)?': 600
```

Where commands starting with `ban` will match but starting with `banip` will NOT match.
# `command-cooldown-persistence`

By default, command cooldowns are not persistent between server sessions. This means if a player has a cooldown for the `/feed` command and the server restarts, the player will lose that cooldown and will be able to immediately use the `/feed` command once again.

If `command-cooldown-persistence` is set to `true`, meaning cooldowns are carried over server sessions. The relevant data will become available in the player's userdata file, if necessary. That is, when the player has a command cooldown present.
# Locales

This PR adds only one message: `commandCooldown`.
`commandCooldown=\u00a7cYou cannot type that command for {0}.`
The first and only argument currently is the duration till expiry formatted using the `DateUtil` class as per similar utilization across Essentials.
# Lacking

This PR lacks the ability to specify which commands should specifically be persistent. However, I have written the API to support this feature in the future, but because it is 4AM, I am too lazy to figure it out. It currently depends on `command-cooldown-persistence`'s value.

pls accept @drtshock kthx
