### PR TITLE
Add the option to disable disabled-sign name protection.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -257,4 +257,6 @@ public interface ISettings extends IConf {
     Entry<Pattern, Long> getCommandCooldownEntry(String label);
     
     boolean isCommandCooldownPersistent(String label);
+    
+    List<EssentialsSign> getUnprotectedSignNames();
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -536,6 +536,7 @@ public class Settings implements net.ess3.api.ISettings {
         isCustomQuitMessage = !customQuitMessage.equals("none");
         muteCommands = _getMuteCommands();
         commandCooldowns = _getCommandCooldowns();
+        unprotectedSigns = _getUnprotectedSign();
     }
 
     private List<Integer> itemSpawnBl = new ArrayList<Integer>();
@@ -1261,5 +1262,30 @@ public class Settings implements net.ess3.api.ISettings {
     public boolean isCommandCooldownPersistent(String label) {
         // TODO: enable per command cooldown specification for persistence.
         return config.getBoolean("command-cooldown-persistence", true);
+    }
+
+    private List<EssentialsSign> unprotectedSigns = Collections.emptyList();
+
+    @Override
+    public List<EssentialsSign> getUnprotectedSignNames() {
+        return this.unprotectedSigns;
+    }
+
+    private List<EssentialsSign> _getUnprotectedSign() {
+        List<EssentialsSign> newSigns = new ArrayList<>();
+
+        for (String signName : config.getStringList("unprotected-sign-names")) {
+            signName = signName.trim().toUpperCase(Locale.ENGLISH);
+            if (signName.isEmpty()) {
+                continue;
+            }
+            try {
+                newSigns.add(Signs.valueOf(signName).getSign());
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, tl("unknownItemInList", signName, "unprotected-sign-names"));
+                continue;
+            }
+        }
+        return newSigns;
     }
 }

--- a/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
@@ -91,11 +91,18 @@ public class SignBlockListener implements Listener {
         //We loop through all sign types here to prevent clashes with preexisting signs later
         for (Signs signs : Signs.values()) {
             final EssentialsSign sign = signs.getSign();
-            // If the top line contains any of the success name (excluding colors), just remove all colours from the first line.
+            // If the top sign line contains any of the success name (excluding colors), just remove all colours from the first line.
             // This is to ensure we are only modifying possible Essentials Sign and not just removing colors from the first line of all signs.
             // Top line and sign#getSuccessName() are both lowercased since contains is case-sensitive.
             String lSuccessName = ChatColor.stripColor(sign.getSuccessName().toLowerCase());
             if (lColorlessTopLine.contains(lSuccessName)) {
+
+                // If this sign is not enabled and it has been requested to not protect it's name (when disabled), then do not protect the name.
+                // By lower-casing it and stripping colours. 
+                if (!ess.getSettings().enabledSigns().contains(sign)
+                    && ess.getSettings().getUnprotectedSignNames().contains(sign)) {
+                    continue;
+                }
                 event.setLine(0, lColorlessTopLine);
             }
         }

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -325,6 +325,13 @@ enabledSigns:
 # Lower numbers will reduce the possibility of lag, but may annoy players.
 sign-use-per-second: 4
 
+# List of sign names Essentials should not protect. This feature is especially useful when
+# another plugin provides a sign that EssentialsX provides, but Essentials overrides.
+# For example, if a plugin provides a [kit] sign, and you wish to use theirs instead of
+# Essentials's, then simply add kit below and Essentials will not protect it.
+unprotected-sign-names:
+  #- kit
+
 # Backup runs a batch/bash command while saving is disabled.
 backup:
   # Interval in minutes.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -329,6 +329,8 @@ sign-use-per-second: 4
 # another plugin provides a sign that EssentialsX provides, but Essentials overrides.
 # For example, if a plugin provides a [kit] sign, and you wish to use theirs instead of
 # Essentials's, then simply add kit below and Essentials will not protect it.
+#
+# See https://github.com/drtshock/Essentials/pull/699 for more information.
 unprotected-sign-names:
   #- kit
 


### PR DESCRIPTION
This PR allows EssentialsX users to use other plugins that provide signs such as `[Kit]` and not have EssentialsX interfere with the final sign name.

Requested in #484 

Currently, when any one sign is enabled, EssentialsX will take precautions to make sure all of the disabled signs are not created at that time. This combats abuse at any time where a player figures this issue out and creates a sign before it becomes enabled at a later time.
# Problem

The problem we face, as demonstrated in #484, is that we started forcing our rules over other plugins despite the fact that the sign is disabled.

For example, if another plugin provides a `[Kit]` sign (specifically Kit), EssentialsX will convert that to `[kit]`. Making it impossible for another plugin to write `[Kit]`.
# Proposed solution

In order to resolve the aforementioned problem this PR introduces the `unprotected-sign-names` config option.

`unprotected-sign-names` is a list of strings with a very similar behaviour to `enabledSigns`. Each string must be a valid sign name otherwise an error will be printed to the console.

``` yaml
unprotected-sign-names:
  - kit #Don't protect [kit] signs.
  - buy # Don't protect [buy] signs.
```

This PR specifically provides the `unprotected-sign-names` behaviour for simplicity and control. If EssentialsX was to implement a new sign the user would simply just have to amend their config without effort being required anywhere else.

`unprotected-sign-names` only applies to disabled signs. This was done to further prevent any abuse from players who have access to sign colouring. Sadly there is no way I see to resolve this issue without the user having to disable EssentialsX's version of the sign.
