### PR TITLE
Extra permissions for /seen and /whois information

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandseen.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandseen.java
@@ -27,16 +27,16 @@ public class Commandseen extends EssentialsCommand {
 
     @Override
     protected void run(final Server server, final CommandSource sender, final String commandLabel, final String[] args) throws Exception {
-        seen(server, sender, commandLabel, args, true, true, true);
+        seen(server, sender, commandLabel, args, true, true, true, true);
     }
 
     @Override
     protected void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
-        seen(server, user.getSource(), commandLabel, args, user.isAuthorized("essentials.seen.banreason"), user.isAuthorized("essentials.seen.extra"), user.isAuthorized("essentials.seen.ipsearch"));
+        seen(server, user.getSource(), commandLabel, args, user.isAuthorized("essentials.seen.banreason"), user.isAuthorized("essentials.seen.ip"), user.isAuthorized("essentials.seen.location"), user.isAuthorized("essentials.seen.ipsearch"));
     }
 
     protected void seen(final Server server, final CommandSource sender, final String commandLabel, final String[] args,
-                        final boolean showBan, final boolean extra, final boolean ipLookup) throws Exception {
+                        final boolean showBan, final boolean showIp, final boolean showLocation, final boolean ipLookup) throws Exception {
         if (args.length < 1) {
             throw new NotEnoughArgumentsException();
         }
@@ -79,23 +79,23 @@ public class Commandseen extends EssentialsCommand {
                     if (user == null) {
                         throw new PlayerNotFoundException();
                     }
-                    showSeenMessage(server, sender, user, showBan, extra);
+                    showSeenMessage(server, sender, user, showBan, showIp, showLocation);
                 }
             });
         } else {
-            showSeenMessage(server, sender, player, showBan, extra);
+            showSeenMessage(server, sender, player, showBan, showIp, showLocation);
         }
     }
 
-    private void showSeenMessage(Server server, CommandSource sender, User player, boolean showBan, boolean extra)  throws Exception {
+    private void showSeenMessage(Server server, CommandSource sender, User player, boolean showBan, boolean showIp, boolean showLocation)  throws Exception {
         if (player.getBase().isOnline() && canInteractWith(sender, player)) {
-            seenOnline(server, sender, player, showBan, extra);
+            seenOnline(server, sender, player, showBan, showIp, showLocation);
         } else {
-            seenOffline(server, sender, player, showBan, extra);
+            seenOffline(server, sender, player, showBan, showIp, showLocation);
         }
     }
 
-    private void seenOnline(final Server server, final CommandSource sender, final User user, final boolean showBan, final boolean extra) throws Exception {
+    private void seenOnline(final Server server, final CommandSource sender, final User user, final boolean showBan, final boolean showIp, final boolean showLocation) throws Exception {
 
         user.setDisplayNick();
         sender.sendMessage(tl("seenOnline", user.getDisplayName(), DateUtil.formatDateDiff(user.getLastLogin())));
@@ -122,12 +122,12 @@ public class Commandseen extends EssentialsCommand {
         if (location != null && (!(sender.isPlayer()) || ess.getUser(sender.getPlayer()).isAuthorized("essentials.geoip.show"))) {
             sender.sendMessage(tl("whoisGeoLocation", location));
         }
-        if (extra) {
+        if (showIp) {
             sender.sendMessage(tl("whoisIPAddress", user.getBase().getAddress().getAddress().toString()));
         }
     }
 
-    private void seenOffline(final Server server, final CommandSource sender, User user, final boolean showBan, final boolean extra) throws Exception {
+    private void seenOffline(final Server server, final CommandSource sender, User user, final boolean showBan, final boolean showIp, final boolean showLocation) throws Exception {
         user.setDisplayNick();
         if (user.getLastLogout() > 0) {
             sender.sendMessage(tl("seenOffline", user.getName(), DateUtil.formatDateDiff(user.getLastLogout())));
@@ -162,10 +162,12 @@ public class Commandseen extends EssentialsCommand {
         if (location != null && (!(sender.isPlayer()) || ess.getUser(sender.getPlayer()).isAuthorized("essentials.geoip.show"))) {
             sender.sendMessage(tl("whoisGeoLocation", location));
         }
-        if (extra) {
+        if (showIp) {
             if (!user.getLastLoginAddress().isEmpty()) {
                 sender.sendMessage(tl("whoisIPAddress", user.getLastLoginAddress()));
             }
+        }
+        if (showLocation) {
             final Location loc = user.getLogoutLocation();
             if (loc != null) {
                 sender.sendMessage(tl("whoisLocation", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandwhois.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandwhois.java
@@ -35,7 +35,9 @@ public class Commandwhois extends EssentialsCommand {
         if (!ess.getSettings().isEcoDisabled()) {
             sender.sendMessage(tl("whoisMoney", NumberUtil.displayCurrency(user.getMoney(), ess)));
         }
-        sender.sendMessage(tl("whoisIPAddress", user.getBase().getAddress().getAddress().toString()));
+        if (!sender.isPlayer() || ess.getUser(sender.getPlayer()).isAuthorized("essentials.whois.ip")) {
+            sender.sendMessage(tl("whoisIPAddress", user.getBase().getAddress().getAddress().toString()));
+        }
         final String location = user.getGeoLocation();
         if (location != null && (!sender.isPlayer() || ess.getUser(sender.getPlayer()).isAuthorized("essentials.geoip.show"))) {
             sender.sendMessage(tl("whoisGeoLocation", location));

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -515,3 +515,8 @@ permissions:
       essentials.gamemode: true
       essentials.gamemode.others: true
       essentials.gamemode.all: true
+  essentials.seen.extra:
+    default: op
+    children:
+      essentials.seen.ip: true
+      essentials.seen.location: true


### PR DESCRIPTION
This PR adds three new permissions to specify which information gets displayed in the /seen and /whois commands. 

It's focused on requiring an extra permission for IP address information and splits the vague essentials.seen.extra permission into two specific ones: `essentials.seen.ip` for the IP address and `essentials.seen.location` for the logout location. It keeps `essentials.seen.extra` as a parent of these too to keep old permission setups working as before.

Another new permission (`essentials.whois.ip`) was also added to the /whois command to give access to a player's ip.
