### PR TITLE
Remove double locale set call.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -194,7 +194,6 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 execTimer.mark("Init(Usermap)");
                 upgrade.afterSettings();
                 execTimer.mark("Upgrade2");
-                i18n.updateLocale(settings.getLocale());
                 warps = new Warps(getServer(), this.getDataFolder());
                 confList.add(warps);
                 execTimer.mark("Init(Spawn/Warp)");


### PR DESCRIPTION
Fixes issue #809. The locale was being set in onEnable() twice, now it is only set once.
