### PR TITLE
Catch UnsupportedOperationException on server list ping (fixes #857)

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -282,9 +282,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             LOGGER.log(Level.INFO, "Registering Listeners");
         }
 
-        final EssentialsPluginListener serverListener = new EssentialsPluginListener(this);
-        pm.registerEvents(serverListener, this);
-        confList.add(serverListener);
+        final EssentialsPluginListener pluginListener = new EssentialsPluginListener(this);
+        pm.registerEvents(pluginListener, this);
+        confList.add(pluginListener);
 
         final EssentialsPlayerListener playerListener = new EssentialsPlayerListener(this);
         pm.registerEvents(playerListener, this);
@@ -306,6 +306,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
         final EssentialsWorldListener worldListener = new EssentialsWorldListener(this);
         pm.registerEvents(worldListener, this);
+
+        final EssentialsServerListener serverListener = new EssentialsServerListener(this);
+        pm.registerEvents(serverListener, this);
 
         pm.registerEvents(tntListener, this);
 

--- a/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.server.ServerListPingEvent;
 
 import java.util.Iterator;
+import java.util.logging.Level;
 
 
 public class EssentialsServerListener implements Listener {
@@ -27,6 +28,11 @@ public class EssentialsServerListener implements Listener {
                     iterator.remove();
                 }
             }
-        } catch (UnsupportedOperationException e) { }
+        } catch (UnsupportedOperationException e) {
+            if (ess.getServer().getName().equalsIgnoreCase("Cauldron")) {
+                Bukkit.getLogger().log(Level.SEVERE, e.getMessage(), e);
+                Bukkit.getLogger().log(Level.SEVERE, "Please update your server or report this to the developers of your server implementation!");
+            }
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
@@ -1,0 +1,30 @@
+package com.earth2me.essentials;
+
+import net.ess3.api.IEssentials;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.ServerListPingEvent;
+
+import java.util.Iterator;
+
+
+public class EssentialsServerListener implements Listener {
+    private final transient IEssentials ess;
+
+    public EssentialsServerListener(final IEssentials ess) {
+        this.ess = ess;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onServerListPing(final ServerListPingEvent event) {
+        Iterator<Player> iterator = event.iterator();
+        while (iterator.hasNext()) {
+            Player player = iterator.next();
+            if (ess.getUser(player).isVanished()) {
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
@@ -19,12 +19,14 @@ public class EssentialsServerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onServerListPing(final ServerListPingEvent event) {
-        Iterator<Player> iterator = event.iterator();
-        while (iterator.hasNext()) {
-            Player player = iterator.next();
-            if (ess.getUser(player).isVanished()) {
-                iterator.remove();
+        try {
+            Iterator<Player> iterator = event.iterator();
+            while (iterator.hasNext()) {
+                Player player = iterator.next();
+                if (ess.getUser(player).isVanished()) {
+                    iterator.remove();
+                }
             }
-        }
+        } catch (UnsupportedOperationException e) { }
     }
 }


### PR DESCRIPTION
Catch the UnsupportedOperationException on a server list ping, in case the server software doesn't correctly implement ServerListPingEvent#iterator(). This should fix #857.
