### PR TITLE
Go to "home" when /home is run with no arguments and mulitple homes exist.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
@@ -56,6 +56,8 @@ public class Commandhome extends EssentialsCommand {
                 throw new Exception(tl("noHomeSetPlayer"));
             } else if (homes.size() == 1 && player.equals(user)) {
                 goHome(user, player, homes.get(0), charge);
+            } else if (homes.contains("home") && player.equals(user) && args.length == 0) {
+                goHome(user, player, "home", charge);
             } else {
                 final int count = homes.size();
                 if (user.isAuthorized("essentials.home.bed")) {


### PR DESCRIPTION
One of the things that has bothered me for a long time is how `/home` works. If you have no homes and do `/sethome` and then do `/home` you are taken home. Later if you do `/sethome mine`, `/home` now gives `Homes: home, mine`. It always seemed to me that since `/sethome` was performed performed with no arguments, `/home` should take you right back there, regardless of whether or not you have more than one home. This commit does exactly that.

I understand that this might be a controversial change to a long-standing Essentials feature. No pressure to approve it, but from a UX point of view, I believe this is an improvement. I'm interested to know your thoughts.

Thanks!
