### PR TITLE
Improve spawn-on-join with ability to specify groups.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -250,6 +250,10 @@ public interface ISettings extends IConf {
 
     boolean isSpawnOnJoin();
 
+    List<String> getSpawnOnJoinGroups();
+    
+    boolean isUserInSpawnOnJoinGroup(IUser user);
+
     boolean isTeleportToCenterLocation();
 
     boolean isCommandCooldownsEnabled();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -546,6 +546,7 @@ public class Settings implements net.ess3.api.ISettings {
         customQuitMessage = _getCustomQuitMessage();
         isCustomQuitMessage = !customQuitMessage.equals("none");
         muteCommands = _getMuteCommands();
+        spawnOnJoinGroups = _getSpawnOnJoinGroups();
         commandCooldowns = _getCommandCooldowns();
         npcsInBalanceRanking = _isNpcsInBalanceRanking();
         currencyFormat = _getCurrencyFormat();
@@ -1184,7 +1185,41 @@ public class Settings implements net.ess3.api.ISettings {
 
     @Override
     public boolean isSpawnOnJoin() {
-        return config.getBoolean("spawn-on-join", false);
+        return !this.spawnOnJoinGroups.isEmpty();
+    }
+    
+    private List<String> spawnOnJoinGroups;
+
+    public List<String> _getSpawnOnJoinGroups() {
+        List<String> def = Collections.emptyList();
+        if (config.isSet("spawn-on-join")) {
+            if (config.isList("spawn-on-join")) {
+                return new ArrayList<>(config.getStringList("spawn-on-join"));
+            } else if (config.isBoolean("spawn-on-join")) { // List of [*] to make all groups go to spawn on join.
+                // This also maintains backwards compatibility with initial impl of single boolean value.
+                return config.getBoolean("spawn-on-join") ? Collections.singletonList("*") : def;
+            }
+            // Take whatever the value is, convert to string and add it to a list as a single value.
+            String val = config.get("spawn-on-join").toString();
+            return !val.isEmpty() ? Collections.singletonList(val) : def;
+        } else {
+            return def;
+        }
+    }
+
+    @Override
+    public List<String> getSpawnOnJoinGroups() {
+        return this.spawnOnJoinGroups;
+    }
+
+    @Override
+    public boolean isUserInSpawnOnJoinGroup(IUser user) {
+        for (String group : this.spawnOnJoinGroups) {
+            if (group.equals("*") || user.inGroup(group)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
+++ b/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
@@ -15,6 +15,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -71,10 +72,11 @@ public class EssentialsSpawnPlayerListener implements Listener {
     public void delayedJoin(final Player player) {
         if (player.hasPlayedBefore()) {
             LOGGER.log(Level.FINE, "Old player join");
-            
-            if (ess.getSettings().isSpawnOnJoin()) {
+            List<String> spawnOnJoinGroups = ess.getSettings().getSpawnOnJoinGroups();
+            if (!spawnOnJoinGroups.isEmpty()) {
                 final User user = ess.getUser(player);
-                if (!user.isAuthorized("essentials.spawn-on-join.exempt")) {
+                
+                if (ess.getSettings().isUserInSpawnOnJoinGroup(user) && !user.isAuthorized("essentials.spawn-on-join.exempt")) {
                     ess.scheduleSyncDelayedTask(new Runnable() {
                         @Override
                         public void run() {


### PR DESCRIPTION
This PR extends the `spawn-on-join` configuration option to allow certain groups to be specified instead of a _all or nothing_ type of dealio.

This PR was inspired by #919. Which although had a possible hacky fix with negating permissions, might sufficient for different cases.

`spawn-on-join` now accepts three different data types:
1. Boolean - if the value is `true`, all players will be teleported to spawn when joining. If false, this feature is simply disabled.
2. String - The value is interpreted as a group name and the user is checked for presence in said group when joining. If they belong to the group, then they will be teleported to spawn when joining.
3. List of Strings - The value is interpreted as a list of groups that are treated as stated above in String.

Note: a group name of "*" is interpreted as a wildcard and catches all players, causing them to teleport to spawn on join.

P.S. Exemption permission is still present.
# hacktoberfest
