### PR TITLE
[Fix] Prevent /me from bypassing a players /ignore filter

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandme.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandme.java
@@ -58,6 +58,9 @@ public class Commandme extends EssentialsCommand {
                         abort = true;
                     }
                 }
+                if (onlineUser.isIgnoredPlayer(user)) {
+                    abort = true;
+                }
                 if (abort) {
                     if (onlineUser.isAuthorized("essentials.chat.spy")) {
                         outList.add(player); // Just use the same list unless we wanted to format spyying for this.


### PR DESCRIPTION
Simple fix to the /me command.  Still allows for the spy feature to work (not sure why a spy would ignore someone).