### PR TITLE
[Fix] Ensure payment has to be above zero

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
@@ -27,7 +27,7 @@ public class Commandpay extends EssentialsLoopCommand {
             throw new NotEnoughArgumentsException();
         }
         
-        if (args[1].contains("-")) {
+        if (args[1].contains("-") || amount.compareTo(BigDecimal.ZERO) == 0) {
             throw new Exception(tl("payMustBePositive"));
         }
 


### PR DESCRIPTION
As per title, you can send payments of zero dollars. This should be fixed as paying someone 0 makes no sense logically.