### PR TITLE
[Fix] When the minimum pay amount is zero, users are unable to pay zero.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -147,10 +147,11 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
     }
 
     @Override
-    public void payUser(final User reciever, final BigDecimal value) throws ChargeException, MaxMoneyException {
-        if (value.signum() == 0) {
-            return;
+    public void payUser(final User reciever, final BigDecimal value) throws Exception {
+        if (value.compareTo(BigDecimal.ZERO) < 1) {
+            throw new Exception(tl("payMustBePositive", ess));
         }
+
         if (canAfford(value)) {
             setMoney(getMoney().subtract(value));
             reciever.setMoney(reciever.getMoney().add(value));


### PR DESCRIPTION
As per: #995

When the `minimum-pay-amount` is set to zero, the players cannot send Zero to each other and no chat message is returned. As the pay command is the only class to reference the payUser function, the check for zero dollars can be removed. 

Whilst this is a very much so edge case issue fix, it is important to allow this feature to be implemented correctly as intended. 