### PR TITLE
Clean imports

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandgc.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandgc.java
@@ -3,7 +3,11 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.NumberUtil;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Chunk;
+import org.bukkit.Server;
+import org.bukkit.World;
 
 import java.lang.management.ManagementFactory;
 import java.util.List;
@@ -13,6 +17,7 @@ import static com.earth2me.essentials.I18n.tl;
 
 
 public class Commandgc extends EssentialsCommand {
+
     public Commandgc() {
         super("gc");
     }


### PR DESCRIPTION
This pull request gets rid of a `org.bukkit.*` import in the Commandgc.java class so I don't have to look at it anymore.