### PR TITLE
Set PORTAL as an Unsafe Destination

### DIFF
--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -306,12 +306,12 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
 
         if (ess.getSettings().addPrefixSuffix()) {
             //These two extra toggles are not documented, because they are mostly redundant #EasterEgg
-            if (withPrefix || !ess.getSettings().disablePrefix()) {
+            if (withPrefix && !ess.getSettings().disablePrefix()) {
                 final String ptext = ess.getPermissionsHandler().getPrefix(base).replace('&', '§');
                 prefix.insert(0, ptext);
                 suffix = "§r";
             }
-            if (withSuffix || !ess.getSettings().disableSuffix()) {
+            if (withSuffix && !ess.getSettings().disableSuffix()) {
                 final String stext = ess.getPermissionsHandler().getSuffix(base).replace('&', '§');
                 suffix = stext + "§r";
                 suffix = suffix.replace("§f§f", "§f").replace("§f§r", "§r").replace("§r§r", "§r");

--- a/Essentials/src/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/LocationUtil.java
@@ -252,6 +252,9 @@ public class LocationUtil {
         if (below.getType() == Material.BED_BLOCK) {
             return true;
         }
+        if (world.getBlockAt(x, y, z).getType() == Material.PORTAL) {
+            return true;
+        }
         return (!HOLLOW_MATERIALS.contains(world.getBlockAt(x, y, z).getType())) || (!HOLLOW_MATERIALS.contains(world.getBlockAt(x, y + 1, z).getType()));
     }
 


### PR DESCRIPTION
Regarding issue #1021 I added PORTAL as an Unsafe Destination to address a case where:

1. Friend2 starts a "/tpa Friend1"
2. Friend2 starts a "/tpahere Victim"
3. Friend2 moves into a Portal
4. Friend1 closes all exits of the Portal
5. Victim accepts the teleport
6. Friend1 accepts the teleport
7. Victim is now 100% trapped and can only exit with ALT+F4 and never joining back

This is especially useful when Nether is disabled, but can address troll teleports inside the Nether too.