### PR TITLE
2nd fix for Tablist prefix/suffix always showing

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1402,11 +1402,11 @@ public class Settings implements net.ess3.api.ISettings {
 
     @Override
     public boolean isAddingPrefixInPlayerlist() {
-        return config.getBoolean("add-prefix-in-playerlist", false);
+        return config.getBoolean("add-prefix-in-playerlist", true);
     }
 
     @Override
     public boolean isAddingSuffixInPlayerlist() {
-        return config.getBoolean("add-suffix-in-playerlist", false);
+        return config.getBoolean("add-suffix-in-playerlist", true);
     }
 }

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -306,12 +306,12 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
 
         if (ess.getSettings().addPrefixSuffix()) {
             //These two extra toggles are not documented, because they are mostly redundant #EasterEgg
-            if (withPrefix || !ess.getSettings().disablePrefix()) {
+            if (withPrefix && !ess.getSettings().disablePrefix()) {
                 final String ptext = ess.getPermissionsHandler().getPrefix(base).replace('&', '§');
                 prefix.insert(0, ptext);
                 suffix = "§r";
             }
-            if (withSuffix || !ess.getSettings().disableSuffix()) {
+            if (withSuffix && !ess.getSettings().disableSuffix()) {
                 final String stext = ess.getPermissionsHandler().getSuffix(base).replace('&', '§');
                 suffix = stext + "§r";
                 suffix = suffix.replace("§f§f", "§f").replace("§f§r", "§r").replace("§r§r", "§r");

--- a/Essentials/src/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/LocationUtil.java
@@ -252,6 +252,9 @@ public class LocationUtil {
         if (below.getType() == Material.BED_BLOCK) {
             return true;
         }
+        if (world.getBlockAt(x, y, z).getType() == Material.PORTAL) {
+            return true;
+        }
         return (!HOLLOW_MATERIALS.contains(world.getBlockAt(x, y, z).getType())) || (!HOLLOW_MATERIALS.contains(world.getBlockAt(x, y + 1, z).getType()));
     }
 


### PR DESCRIPTION
Latest PR was reverted due to people with old Essentials config that had not the value "add-prefix-in-tablist", which was defaulting to "false", causing the prefix to never show without them knowing why (unless they regenerated the config).

Now we are defaulting "add-prefix-in-tablist" and "add-suffix-in-tablist" to true, so they shouldn't have any problem and the behaviour is as expected.