### PR TITLE
Implement tab completion for all commands.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Enchantments.java
+++ b/Essentials/src/com/earth2me/essentials/Enchantments.java
@@ -218,4 +218,8 @@ public class Enchantments {
     public static Set<Entry<String, Enchantment>> entrySet() {
         return ENCHANTMENTS.entrySet();
     }
+
+    public static Set<String> keySet() {
+        return ENCHANTMENTS.keySet();
+    }
 }

--- a/Essentials/src/com/earth2me/essentials/ItemDb.java
+++ b/Essentials/src/com/earth2me/essentials/ItemDb.java
@@ -371,6 +371,10 @@ public class ItemDb implements IConf, net.ess3.api.IItemDb {
         return sb.toString().trim().replaceAll("§", "&");
     }
 
+    @Override
+    public Collection<String> listNames() {
+        return primaryName.values();
+    }
 
     static class ItemData {
         final private int itemNo;

--- a/Essentials/src/com/earth2me/essentials/api/IItemDb.java
+++ b/Essentials/src/com/earth2me/essentials/api/IItemDb.java
@@ -3,6 +3,7 @@ package com.earth2me.essentials.api;
 import com.earth2me.essentials.User;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collection;
 import java.util.List;
 
 
@@ -18,4 +19,6 @@ public interface IItemDb {
     List<ItemStack> getMatching(User user, String[] args) throws Exception;
 
     String serialize(ItemStack is);
+
+    Collection<String> listNames();
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandafk.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandafk.java
@@ -4,6 +4,9 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -75,6 +78,24 @@ public class Commandafk extends EssentialsCommand {
         }
         if (!msg.isEmpty()) {
             ess.broadcastMessage(user, msg);
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1 && user.isAuthorized("essentials.afk.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbalance.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbalance.java
@@ -6,6 +6,8 @@ import com.earth2me.essentials.utils.NumberUtil;
 import org.bukkit.Server;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -36,6 +38,24 @@ public class Commandbalance extends EssentialsCommand {
             user.sendMessage(tl("balance", NumberUtil.displayCurrency(bal, ess)));
         } else {
             throw new NotEnoughArgumentsException();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1 && user.isAuthorized("essentials.balance.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbalancetop.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbalancetop.java
@@ -5,6 +5,7 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.textreader.SimpleTextInput;
 import com.earth2me.essentials.textreader.TextPager;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 
 import java.math.BigDecimal;
@@ -159,6 +160,19 @@ public class Commandbalancetop extends EssentialsCommand {
                 lock.readLock().unlock();
             }
             ess.runTaskAsynchronously(new Calculator(new Viewer(sender, commandLabel, page, false), force));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList("1");
+            if (!sender.isPlayer() || ess.getUser(sender.getPlayer()).isAuthorized("essentials.balancetop.force")) {
+                options.add("force");
+            }
+            return options;
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandban.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandban.java
@@ -8,6 +8,8 @@ import com.earth2me.essentials.utils.FormatUtil;
 import org.bukkit.BanList;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Level;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -61,5 +63,14 @@ public class Commandban extends EssentialsCommand {
         }
 
         ess.broadcastMessage("essentials.ban.notify", tl("playerBanned", senderName, user.getName(), banReason));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbanip.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbanip.java
@@ -7,6 +7,8 @@ import com.earth2me.essentials.utils.FormatUtil;
 import org.bukkit.BanList;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Level;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -53,5 +55,15 @@ public class Commandbanip extends EssentialsCommand {
         server.getLogger().log(Level.INFO, tl("playerBanIpAddress", senderName, ipAddress, banReason));
 
         ess.broadcastMessage("essentials.banip.notify", tl("playerBanIpAddress", senderName, ipAddress, banReason));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            // TODO: Also list IP addresses?
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbigtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbigtree.java
@@ -2,9 +2,13 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.LocationUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.TreeType;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -34,6 +38,15 @@ public class Commandbigtree extends EssentialsCommand {
             user.sendMessage(tl("bigTreeSuccess"));
         } else {
             throw new Exception(tl("bigTreeFailure"));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return Lists.newArrayList("redwood", "tree", "jungle");
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbook.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbook.java
@@ -2,10 +2,14 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
+import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -66,5 +70,26 @@ public class Commandbook extends EssentialsCommand {
     private boolean isAuthor(BookMeta bmeta, String player) {
         String author = bmeta.getAuthor();
         return author != null && author.equalsIgnoreCase(player);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        // Right now, we aren't testing what's held in the player's hand - we could, but it's not necessarily worth it
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList("sign", "unsign");  // sign and unsign aren't real, but work
+            if (user.isAuthorized("essentials.book.author")) {
+                options.add("author");
+            }
+            if (user.isAuthorized("essentials.book.title")) {
+                options.add("title");
+            }
+            return options;
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("author") && user.isAuthorized("essentials.book.author")) {
+            List<String> options = getPlayers(server, user);
+            options.add("Herobrine"); // #EasterEgg
+            return options;
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbroadcastworld.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbroadcastworld.java
@@ -8,12 +8,15 @@ import com.earth2me.essentials.textreader.IText;
 import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.textreader.SimpleTextInput;
 import com.earth2me.essentials.utils.FormatUtil;
+import com.google.common.collect.Lists;
 
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 
 public class Commandbroadcastworld extends EssentialsCommand {
@@ -55,6 +58,24 @@ public class Commandbroadcastworld extends EssentialsCommand {
                     user.sendMessage(messageText);
                 }
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        return Collections.emptyList(); // The argument is only for non-players
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> worlds = Lists.newArrayList();
+            for (World world : server.getWorlds()) {
+                worlds.add(world.getName());
+            }
+            return worlds;
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandburn.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandburn.java
@@ -4,6 +4,9 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -25,5 +28,16 @@ public class Commandburn extends EssentialsCommand {
         User user = getPlayer(server, sender, args, 0);
         user.getBase().setFireTicks(Integer.parseInt(args[1]) * 20);
         sender.sendMessage(tl("burnMsg", user.getDisplayName(), Integer.parseInt(args[1])));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else if (args.length == 2) {
+            return COMMON_DURATIONS;
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
@@ -10,6 +10,8 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -125,6 +127,52 @@ public class Commandclearinventory extends EssentialsCommand {
                     }
                 }
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (user.isAuthorized("essentials.clearinventory.others")) {
+            if (args.length == 1) {
+                List<String> options = getPlayers(server, user);
+                if (user.isAuthorized("essentials.clearinventory.all") || user.isAuthorized("essentials.clearinventory.multiple")) {
+                    // Assume that nobody will have the 'all' permission without the 'others' permission
+                    options.add("*");
+                }
+                return options;
+            } else if (args.length == 2) {
+                List<String> items = new ArrayList<>(getItems());
+                items.add("*");
+                items.add("**");
+                return items;
+            } else {
+                return Collections.emptyList();
+            }
+        } else {
+            if (args.length == 1) {
+                List<String> items = new ArrayList<>(getItems());
+                items.add("*");
+                items.add("**");
+                return items;
+            } else {
+                return Collections.emptyList();
+            }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> options = getPlayers(server, sender);
+            options.add("*");
+            return options;
+        } else if (args.length == 2) {
+            List<String> items = new ArrayList<>(getItems());
+            items.add("*");
+            items.add("**");
+            return items;
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandcondense.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandcondense.java
@@ -178,4 +178,13 @@ public class Commandcondense extends EssentialsCommand {
             return input.clone();
         }
     }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getMatchingItems(args[0]);
+        } else {
+            return Collections.emptyList();
+        }
+    }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commanddelhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddelhome.java
@@ -4,6 +4,9 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -47,5 +50,29 @@ public class Commanddelhome extends EssentialsCommand {
 
         user.delHome(name.toLowerCase(Locale.ENGLISH));
         sender.sendMessage(tl("deleteHome", name));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        User user = ess.getUser(sender.getPlayer());
+        boolean canDelOthers = (user == null || user.isAuthorized("essentials.delhome.others"));
+
+        if (args.length == 1) {
+            if (canDelOthers) {
+                return getPlayers(server, sender);
+            } else {
+                return user.getHomes();
+            }
+        } else if (args.length == 2 && canDelOthers) {
+            try {
+                user = getPlayer(server, args, 0, true, true);
+                return user.getHomes();
+            } catch (Exception ex) {
+                // No such user
+                return Collections.emptyList();
+            }
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commanddeljail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddeljail.java
@@ -2,7 +2,9 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
 import org.bukkit.Server;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -19,5 +21,18 @@ public class Commanddeljail extends EssentialsCommand {
 
         ess.getJails().removeJail(args[0]);
         sender.sendMessage(tl("deleteJail", args[0]));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            try {
+                return new ArrayList<>(ess.getJails().getList());
+            } catch (Exception e) {
+                return Collections.emptyList();
+            }
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commanddelwarp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddelwarp.java
@@ -3,6 +3,10 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.CommandSource;
 import org.bukkit.Server;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -19,5 +23,14 @@ public class Commanddelwarp extends EssentialsCommand {
 
         ess.getWarps().removeWarp(args[0]);
         sender.sendMessage(tl("deleteWarp", args[0]));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return new ArrayList<>(ess.getWarps().getList());
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandeco.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandeco.java
@@ -4,10 +4,13 @@ import com.earth2me.essentials.ChargeException;
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.google.common.collect.Lists;
 import net.ess3.api.MaxMoneyException;
 import org.bukkit.Server;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -97,5 +100,26 @@ public class Commandeco extends EssentialsLoopCommand {
 
     private enum EcoCommands {
         GIVE, TAKE, SET, RESET
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, final CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList();
+            for (EcoCommands command : EcoCommands.values()) {
+                options.add(command.name().toLowerCase(Locale.ENGLISH));
+            }
+            return options;
+        } else if (args.length == 2) {
+            return getPlayers(server, sender);
+        } else if (args.length == 3 && !args[0].equalsIgnoreCase(EcoCommands.RESET.name())) {
+            if (args[0].equalsIgnoreCase(EcoCommands.SET.name())) {
+                return Lists.newArrayList("0", ess.getSettings().getStartingBalance().toString());
+            } else {
+                return Lists.newArrayList("1", "10", "100", "1000");
+            }
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandenchant.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandenchant.java
@@ -5,11 +5,15 @@ import com.earth2me.essentials.MetaItemStack;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
 import com.earth2me.essentials.utils.StringUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -64,6 +68,27 @@ public class Commandenchant extends EssentialsCommand {
             user.sendMessage(tl("enchantmentRemoved", enchantmentName.replace('_', ' ')));
         } else {
             user.sendMessage(tl("enchantmentApplied", enchantmentName.replace('_', ' ')));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return new ArrayList<>(Enchantments.keySet());
+        } else if (args.length == 2) {
+            Enchantment enchantment = Enchantments.getByName(args[0]);
+            if (enchantment == null) {
+                return Collections.emptyList();
+            }
+            int min = enchantment.getStartLevel();
+            int max = enchantment.getMaxLevel();
+            List<String> options = Lists.newArrayList();
+            for (int i = min; i <= max; i++) {
+                options.add(Integer.toString(i));
+            }
+            return options;
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandenderchest.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandenderchest.java
@@ -3,6 +3,8 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
 
 public class Commandenderchest extends EssentialsCommand {
     public Commandenderchest() {
@@ -22,5 +24,14 @@ public class Commandenderchest extends EssentialsCommand {
             user.setEnderSee(false);
         }
 
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1 && user.isAuthorized("essentials.enderchest.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandessentials.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandessentials.java
@@ -9,6 +9,7 @@ import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.FloatUtil;
 import com.earth2me.essentials.utils.NumberUtil;
 import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.Sound;
@@ -16,7 +17,9 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
@@ -302,5 +305,53 @@ public class Commandessentials extends EssentialsCommand {
 
         UUID offlineuuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(Charsets.UTF_8));
         sender.sendMessage("Offline Mode UUID: " + offlineuuid.toString());
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList();
+            options.add("reload");
+            options.add("debug");
+            //options.add("nya");
+            //options.add("moo");
+            options.add("reset");
+            options.add("opt-out");
+            options.add("cleanup");
+            //options.add("uuidconvert");
+            //options.add("uuidtest");
+            return options;
+        } else if (args[0].equalsIgnoreCase("debug")) {
+            // No args
+        } else if (args[0].equalsIgnoreCase("nya")) {
+            // No args
+        } else if (args[0].equalsIgnoreCase("moo")) {
+            if (args.length == 2) {
+                return Lists.newArrayList("moo");
+            }
+        } else if (args[0].equalsIgnoreCase("reset")) {
+            if (args.length == 2) {
+                return getPlayers(server, sender);
+            }
+        } else if (args[0].equalsIgnoreCase("opt-out")) {
+            // No args
+        } else if (args[0].equalsIgnoreCase("cleanup")) {
+            if (args.length == 2) {
+                return COMMON_DURATIONS;
+            } else if (args.length == 3 || args.length == 4) {
+                return Lists.newArrayList("-1", "0");
+            }
+        } else if (args[0].equalsIgnoreCase("uuidconvert")) {
+            if (args.length == 2) {
+                return Lists.newArrayList("ignoreUFCache");
+            }
+        } else if (args[0].equalsIgnoreCase("uuidtest")) {
+            if (args.length == 2) {
+                return getPlayers(server, sender);
+            }
+        } else {
+            // No args
+        }
+        return Collections.emptyList();
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandexp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandexp.java
@@ -4,9 +4,11 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.SetExpFix;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -145,5 +147,59 @@ public class Commandexp extends EssentialsCommand {
         }
         SetExpFix.setTotalExperience(target.getBase(), (int) amount);
         sender.sendMessage(tl("expSet", target.getDisplayName(), amount));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList("show");
+            if (user.isAuthorized("essentials.exp.set")) {
+                options.add("set");
+            }
+            if (user.isAuthorized("essentials.exp.give")) {
+                options.add("give");
+            }
+            return options;
+        } else if (args.length == 2) {
+            if ((args[0].equalsIgnoreCase("set") && user.isAuthorized("essentials.exp.set")) || (args[0].equalsIgnoreCase("give") && user.isAuthorized("essentials.exp.give"))) {
+                String levellessArg = args[1].toLowerCase(Locale.ENGLISH).replace("l", "");
+                if (NumberUtil.isInt(levellessArg)) {
+                    return Lists.newArrayList(levellessArg, args[1] + "l");
+                } else {
+                    return Collections.emptyList();
+                }
+            } else if (args[0].equalsIgnoreCase("show") && user.isAuthorized("essentials.exp.others")) {
+                return getPlayers(server, user);
+            } else {
+                return Collections.emptyList();
+            }
+        } else if (args.length == 3 && (args[0].equalsIgnoreCase("set") && user.isAuthorized("essentials.exp.set.others")) || (args[0].equalsIgnoreCase("give") && user.isAuthorized("essentials.exp.give.others"))) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            // TODO: This seems somewhat buggy, both setting and showing - right now, ignoring that
+            return Lists.newArrayList("set", "give", "show");
+        } else if (args.length == 2) {
+            if (args[0].equalsIgnoreCase("set") || args[0].equalsIgnoreCase("give")) {
+                String levellessArg = args[1].toLowerCase(Locale.ENGLISH).replace("l", "");
+                if (NumberUtil.isInt(levellessArg)) {
+                    return Lists.newArrayList(levellessArg, args[1] + "l");
+                } else {
+                    return Collections.emptyList();
+                }
+            } else { // even without 'show'
+                return getPlayers(server, sender);
+            }
+        } else if (args.length == 3 && (args[0].equalsIgnoreCase("set") || args[0].equalsIgnoreCase("give"))) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandext.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandext.java
@@ -5,6 +5,9 @@ import com.earth2me.essentials.User;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -41,5 +44,14 @@ public class Commandext extends EssentialsLoopCommand {
 
     private void extPlayer(final Player player) {
         player.setFireTicks(0);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandfeed.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandfeed.java
@@ -6,6 +6,9 @@ import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -60,5 +63,23 @@ public class Commandfeed extends EssentialsLoopCommand {
         player.setFoodLevel(flce.getFoodLevel() > 20 ? 20 : flce.getFoodLevel());
         player.setSaturation(10);
         player.setExhaustion(0F);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1 && user.isAuthorized("essentials.feed.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
@@ -1,10 +1,13 @@
 package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
 
+import java.util.Collections;
+import java.util.List;
 
 public class Commandfireball extends EssentialsCommand {
     public Commandfireball() {
@@ -37,5 +40,14 @@ public class Commandfireball extends EssentialsCommand {
         projectile = (Projectile) user.getWorld().spawn(user.getBase().getEyeLocation().add(direction.getX(), direction.getY(), direction.getZ()), type);
         projectile.setShooter(user.getBase());
         projectile.setVelocity(direction);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return Lists.newArrayList("small", "arrow", "skull", "egg", "snowball", "expbottle", "large");
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandfirework.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandfirework.java
@@ -3,6 +3,8 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.MetaItemStack;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.google.common.collect.Lists;
+import org.bukkit.DyeColor;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Material;
 import org.bukkit.Server;
@@ -11,6 +13,9 @@ import org.bukkit.entity.Firework;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.util.Vector;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -111,6 +116,62 @@ public class Commandfirework extends EssentialsCommand {
             }
         } else {
             throw new Exception(tl("holdFirework"));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        // Note: this enforces an order of color fade shape effect, which the actual command doesn't have.  But that's fine. 
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList();
+            if (args[0].startsWith("color:")) {
+                String prefix;
+                if (args[0].contains(",")) {
+                    prefix = args[0].substring(0, args[0].lastIndexOf(',') + 1);
+                } else {
+                    prefix = "color:";
+                }
+                for (DyeColor color : DyeColor.values()) {
+                    options.add(prefix + color.name().toLowerCase() + ",");
+                }
+                return options;
+            }
+            options.add("clear");
+            options.add("power");
+            options.add("color:");
+            if (user.isAuthorized("essentials.firework.fire")) {
+                options.add("fire");
+            }
+            return options;
+        } else if (args.length == 2) {
+            if (args[0].equals("power")) {
+                return Lists.newArrayList("1", "2", "3", "4");
+            } else if (args[0].equals("fire")) {
+                return Lists.newArrayList("1");
+            } else if (args[0].startsWith("color:")) {
+                List<String> options = Lists.newArrayList();
+                if (!args[1].startsWith("fade:")) {
+                    args[1] = "fade:";
+                }
+                String prefix;
+                if (args[1].contains(",")) {
+                    prefix = args[1].substring(0, args[1].lastIndexOf(',') + 1);
+                } else {
+                    prefix = "fade:";
+                }
+                for (DyeColor color : DyeColor.values()) {
+                    options.add(prefix + color.name().toLowerCase() + ",");
+                }
+                return options;
+            } else {
+                return Collections.emptyList();
+            }
+        } else if (args.length == 3 && args[0].startsWith("color:")) {
+            return Lists.newArrayList("shape:star", "shape:ball", "shape:large", "shape:creeper", "shape:burst");
+        } else if (args.length == 4 && args[0].startsWith("color:")) {
+            return Lists.newArrayList("effect:trail", "effect:twinkle", "effect:trail,twinkle", "effect:twinkle,trail");
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandgamemode.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandgamemode.java
@@ -2,10 +2,12 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
+import com.google.common.collect.ImmutableList;
 import org.bukkit.GameMode;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -115,5 +117,46 @@ public class Commandgamemode extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
         return mode;
+    }
+
+    private List<String> STANDARD_OPTIONS = ImmutableList.of("creative", "survival", "adventure", "spectator", "toggle");
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            try {
+                // Direct command?  Don't ask for the mode
+                matchGameMode(commandLabel);
+                return getPlayers(server, sender);
+            } catch (NotEnoughArgumentsException e) {
+                return STANDARD_OPTIONS;
+            }
+        } else if (args.length == 2) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        boolean isDirectGamemodeCommand;
+        try {
+            // Direct command?
+            matchGameMode(commandLabel);
+            isDirectGamemodeCommand = true;
+        } catch (NotEnoughArgumentsException ex) {
+            isDirectGamemodeCommand = false;
+        }
+        if (args.length == 1) {
+            if (user.isAuthorized("essentials.gamemode.others") && isDirectGamemodeCommand) {
+                return getPlayers(server, user);
+            } else {
+                return STANDARD_OPTIONS;
+            }
+        } else if (args.length == 2 && user.isAuthorized("essentials.gamemode.others") && !isDirectGamemodeCommand) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandgetpos.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandgetpos.java
@@ -5,6 +5,9 @@ import com.earth2me.essentials.User;
 import org.bukkit.Location;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -41,6 +44,24 @@ public class Commandgetpos extends EssentialsCommand {
         sender.sendMessage(tl("posPitch", coords.getPitch()));
         if (distance != null && coords.getWorld().equals(distance.getWorld())) {
             sender.sendMessage(tl("distance", coords.distance(distance)));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1 && user.isAuthorized("essentials.getpos.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandgive.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandgive.java
@@ -5,11 +5,14 @@ import com.earth2me.essentials.MetaItemStack;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -98,5 +101,20 @@ public class Commandgive extends EssentialsCommand {
         }
 
         giveTo.getBase().updateInventory();
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else if (args.length == 2) {
+            return getItems();
+        } else if (args.length == 3) {
+            return Lists.newArrayList("1", "64");  // TODO: get actual max size
+        } else if (args.length == 4) {
+            return Lists.newArrayList("0");
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandhat.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhat.java
@@ -2,10 +2,14 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
+import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -43,6 +47,15 @@ public class Commandhat extends EssentialsCommand {
             } else {
                 user.sendMessage(tl("hatFail"));
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return Lists.newArrayList("remove", "wear"); // "wear" isn't real
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandheal.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandheal.java
@@ -8,6 +8,9 @@ import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 import org.bukkit.potion.PotionEffect;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -74,6 +77,24 @@ public class Commandheal extends EssentialsLoopCommand {
         user.sendMessage(tl("heal"));
         for (PotionEffect effect : player.getActivePotionEffects()) {
             player.removePotionEffect(effect.getType());
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1 && user.isAuthorized("essentials.heal.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandhelp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhelp.java
@@ -6,6 +6,8 @@ import com.earth2me.essentials.textreader.*;
 import com.earth2me.essentials.utils.NumberUtil;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -47,5 +49,14 @@ public class Commandhelp extends EssentialsCommand {
     @Override
     protected void run(final Server server, final CommandSource sender, final String commandLabel, final String[] args) throws Exception {
         sender.sendMessage(tl("helpConsole"));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getCommands(server);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandhelpop.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhelpop.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
 import org.bukkit.Server;
 
+import java.util.List;
 import java.util.logging.Level;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -38,5 +39,10 @@ public class Commandhelpop extends EssentialsCommand {
         server.getLogger().log(Level.INFO, message);
         ess.broadcastMessage("essentials.helpop.receive", message);
         return message;
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        return null;  // Use vanilla handler for message
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
@@ -7,6 +7,8 @@ import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -93,5 +95,36 @@ public class Commandhome extends EssentialsCommand {
             throw new Exception(tl("noPerm", "essentials.worlds." + loc.getWorld().getName()));
         }
         user.getTeleport().teleport(loc, charge, TeleportCause.COMMAND);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        boolean canVisitOthers = user.isAuthorized("essentials.home.others");
+
+        if (args.length == 1) {
+            if (canVisitOthers) {
+                return getPlayers(server, user);
+            } else {
+                List<String> homes = user.getHomes();
+                if (user.isAuthorized("essentials.home.bed")) {
+                    homes.add("bed");
+                }
+                return homes;
+            }
+        } else if (args.length == 2 && canVisitOthers) {
+            try {
+                User otherUser = getPlayer(server, args, 0, true, true);
+                List<String> homes = otherUser.getHomes();
+                if (user.isAuthorized("essentials.home.bed")) {
+                    homes.add("bed");
+                }
+                return homes;
+            } catch (Exception ex) {
+                // No such user
+                return Collections.emptyList();
+            }
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandignore.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandignore.java
@@ -3,6 +3,9 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -39,6 +42,15 @@ public class Commandignore extends EssentialsCommand {
                 user.setIgnoredPlayer(player, true);
                 user.sendMessage(tl("ignorePlayer", player.getName()));
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandinvsee.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandinvsee.java
@@ -4,6 +4,8 @@ import com.earth2me.essentials.User;
 import org.bukkit.Server;
 import org.bukkit.inventory.Inventory;
 
+import java.util.Collections;
+import java.util.List;
 
 public class Commandinvsee extends EssentialsCommand {
     public Commandinvsee() {
@@ -29,5 +31,17 @@ public class Commandinvsee extends EssentialsCommand {
         user.getBase().closeInventory();
         user.getBase().openInventory(inv);
         user.setInvSee(true);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, user);
+        } else {
+            //if (args.length == 2) {
+            //    return Lists.newArrayList("equipped");
+            //}
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commanditem.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanditem.java
@@ -3,10 +3,13 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.MetaItemStack;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
+import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -66,5 +69,18 @@ public class Commanditem extends EssentialsCommand {
             InventoryWorkaround.addItems(user.getBase().getInventory(), stack);
         }
         user.getBase().updateInventory();
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return getItems();
+        } else if (args.length == 2) {
+            return Lists.newArrayList("1", "64");  // TODO: get actual max size
+        } else if (args.length == 3) {
+            return Lists.newArrayList("0");
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commanditemdb.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanditemdb.java
@@ -5,6 +5,9 @@ import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -40,6 +43,15 @@ public class Commanditemdb extends EssentialsCommand {
         final String itemNameList = ess.getItemDb().names(itemStack);
         if (itemNameList != null) {
             sender.sendMessage(tl("itemNames", ess.getItemDb().names(itemStack)));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getItems();
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandjump.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandjump.java
@@ -3,9 +3,13 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.LocationUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -44,5 +48,15 @@ public class Commandjump extends EssentialsCommand {
         charge.isAffordableFor(user);
         user.getTeleport().teleport(loc, charge, TeleportCause.COMMAND);
         throw new NoChargeException();
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1 && user.isAuthorized("essentials.jump.lock")) {
+            // XXX these actually do the same thing
+            return Lists.newArrayList("lock", "unlock");
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandkick.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkick.java
@@ -6,6 +6,8 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Level;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -42,5 +44,14 @@ public class Commandkick extends EssentialsCommand {
 
         server.getLogger().log(Level.INFO, tl("playerKicked", senderName, target.getName(), kickReason));
         ess.broadcastMessage("essentials.kick.notify", tl("playerKicked", senderName, target.getName(), kickReason));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandkill.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkill.java
@@ -6,6 +6,9 @@ import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageEvent;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -42,5 +45,14 @@ public class Commandkill extends EssentialsLoopCommand {
         }
 
         sender.sendMessage(tl("kill", matchPlayer.getDisplayName()));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkit.java
@@ -7,6 +7,7 @@ import com.earth2me.essentials.utils.StringUtil;
 import org.bukkit.Server;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
@@ -97,6 +98,36 @@ public class Commandkit extends EssentialsCommand {
             } catch (Exception ex) {
                 ess.showError(userFrom.getSource(), ex, "\\ kit: " + kit.getName());
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            List<String> options = new ArrayList<>();
+            // TODO: Move all of this to its own method
+            for (String kitName : ess.getSettings().getKits().getKeys(false)) {
+                if (!user.isAuthorized("essentials.kits." + kitName)) { // Only check perm, not time or money
+                    continue;
+                }
+                options.add(kitName);
+            }
+            return options;
+        } else if (args.length == 2 && user.isAuthorized("essentials.kit.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return new ArrayList<>(ess.getSettings().getKits().getKeys(false)); // TODO: Move this to its own method
+        } else if (args.length == 2) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandlightning.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandlightning.java
@@ -2,9 +2,12 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.entity.LightningStrike;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.HashSet;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -47,6 +50,26 @@ public class Commandlightning extends EssentialsLoopCommand {
         }
         if (ess.getSettings().warnOnSmite()) {
             matchUser.sendMessage(tl("lightningSmited"));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (!user.isAuthorized("essentials.lightning.others")) {
+            // Can't use any params, including power
+            return Collections.emptyList();
+        } else {
+            return super.getTabCompleteOptions(server, user, commandLabel, args);
+        }
+    }
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else if (args.length == 2) {
+            return Lists.newArrayList(Integer.toString(this.power));
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandlist.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandlist.java
@@ -116,4 +116,13 @@ public class Commandlist extends EssentialsCommand {
             sender.sendMessage(PlayerList.outputFormat(groupName, PlayerList.listUsers(ess, users, ", ")));
         }
     }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return getGroups();
+        } else {
+            return Collections.emptyList();
+        }
+    }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -7,8 +7,10 @@ import com.earth2me.essentials.textreader.SimpleTextInput;
 import com.earth2me.essentials.textreader.TextPager;
 import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.StringUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -138,6 +140,51 @@ public class Commandmail extends EssentialsCommand {
                     user.addMail(message);
                 }
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList("read", "clear");
+            if (user.isAuthorized("essentials.mail.send")) {
+                options.add("send");
+            }
+            if (user.isAuthorized("essentials.mail.sendall")) {
+                options.add("sendall");
+            }
+            return options;
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("send") && user.isAuthorized("essentials.mail.send")) {
+            return getPlayers(server, user);
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("read")) {
+            final List<String> mail = user.getMails();
+            int pages = mail.size() / 9 + (mail.size() % 9 > 0 ? 1 : 0);
+            if (pages == 0) {
+                return Lists.newArrayList("0");
+            } else {
+                List<String> options = Lists.newArrayList("1");
+                if (pages > 1) {
+                    options.add(String.valueOf(pages));
+                }
+                return options;
+            }
+        } else if ((args.length > 2 && args[0].equalsIgnoreCase("send") && user.isAuthorized("essentials.mail.send")) || (args.length > 1 && args[0].equalsIgnoreCase("sendall") && user.isAuthorized("essentials.mail.sendall"))) {
+            return null; // Use vanilla handler
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return Lists.newArrayList("send", "sendall");
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("send")) {
+            return getPlayers(server, sender);
+        } else if ((args.length > 2 && args[0].equalsIgnoreCase("send")) || (args.length > 1 && args[0].equalsIgnoreCase("sendall"))) {
+            return null; // Use vanilla handler
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandme.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandme.java
@@ -10,6 +10,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -89,5 +90,10 @@ public class Commandme extends EssentialsCommand {
         message = FormatUtil.replaceFormat(message);
 
         ess.getServer().broadcastMessage(tl("action", "@", message));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        return null;  // It's a chat message, use the default chat handler
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmsg.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmsg.java
@@ -10,6 +10,7 @@ import com.earth2me.essentials.utils.FormatUtil;
 
 import org.bukkit.Server;
 
+import java.util.List;
 
 public class Commandmsg extends EssentialsLoopCommand {
 
@@ -51,5 +52,14 @@ public class Commandmsg extends EssentialsLoopCommand {
     protected void updatePlayer(final Server server, final CommandSource sender, final User messageReceiver, final String[] args) {
         IMessageRecipient messageSender = sender.isPlayer() ? ess.getUser(sender.getPlayer()) : Console.getInstance();
         messageSender.sendMessage(messageReceiver, args[0]); // args[0] is the message.
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return null;  // It's a chat message, use the default chat handler
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmute.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmute.java
@@ -7,6 +7,7 @@ import com.earth2me.essentials.utils.DateUtil;
 import net.ess3.api.events.MuteStatusChangeEvent;
 import org.bukkit.Server;
 
+import java.util.List;
 import java.util.logging.Level;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -83,6 +84,15 @@ public class Commandmute extends EssentialsCommand {
                 sender.sendMessage(tl("unmutedPlayer", user.getDisplayName()));
                 user.sendMessage(tl("playerUnmuted"));
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return COMMON_DATE_DIFFS; // Date diff can span multiple words
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
@@ -2,9 +2,13 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
+import com.google.common.collect.Lists;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -96,5 +100,35 @@ public class Commandnear extends EssentialsCommand {
             }
         }
         return output.length() > 1 ? output.toString() : tl("none");
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (user.isAuthorized("essentials.near.others")) {
+            if (args.length == 1) {
+                return getPlayers(server, user);
+            } else if (args.length == 2) {
+                return Lists.newArrayList(Integer.toString(ess.getSettings().getNearRadius()));
+            } else {
+                return Collections.emptyList();
+            }
+        } else {
+            if (args.length == 1) {
+                return Lists.newArrayList(Integer.toString(ess.getSettings().getNearRadius()));
+            } else {
+                return Collections.emptyList();
+            }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else if (args.length == 2) {
+            return Lists.newArrayList(Integer.toString(ess.getSettings().getNearRadius()));
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
@@ -8,6 +8,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -110,6 +112,24 @@ public class Commandnick extends EssentialsLoopCommand {
         if (!nickEvent.isCancelled()) {
             target.setNickname(nickname);
             target.setDisplayNick();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1 && user.isAuthorized("essentials.nick.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandnuke.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnuke.java
@@ -9,6 +9,8 @@ import org.bukkit.entity.TNTPrimed;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -45,6 +47,15 @@ public class Commandnuke extends EssentialsCommand {
                     final TNTPrimed tnt = world.spawn(tntloc, TNTPrimed.class);
                 }
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
@@ -7,10 +7,13 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.NumberUtil;
 import com.earth2me.essentials.utils.StringUtil;
 
+import com.google.common.collect.Lists;
 import net.ess3.api.MaxMoneyException;
 import org.bukkit.Server;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -82,6 +85,17 @@ public class Commandpay extends EssentialsLoopCommand {
             }
         } catch (Exception e) {
             sender.sendMessage(e.getMessage());
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else if (args.length == 2) {
+            return Lists.newArrayList(ess.getSettings().getMinimumPayAmount().toString());
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandpotion.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpotion.java
@@ -1,5 +1,8 @@
 package com.earth2me.essentials.commands;
 
+import org.bukkit.DyeColor;
+
+import com.google.common.collect.Lists;
 import com.earth2me.essentials.MetaItemStack;
 import com.earth2me.essentials.Potions;
 import com.earth2me.essentials.User;
@@ -11,6 +14,8 @@ import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -68,6 +73,37 @@ public class Commandpotion extends EssentialsCommand {
 
         } else {
             throw new Exception(tl("holdPotion"));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        // Note: this enforces an order of effect power duration splash, which the actual command doesn't have.  But that's fine. 
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList();
+            options.add("clear");
+            if (user.isAuthorized("essentials.potion.apply")) {
+                options.add("apply");
+            }
+            for (Map.Entry<String, PotionEffectType> entry : Potions.entrySet()) {
+                final String potionName = entry.getValue().getName().toLowerCase(Locale.ENGLISH);
+                if (user.isAuthorized("essentials.potion." + potionName)) {
+                    options.add("effect:" + entry.getKey());
+                }
+            }
+            return options;
+        } else if (args.length == 2 && args[0].startsWith("effect:")) {
+            return Lists.newArrayList("power:1", "power:2", "power:3", "power:4");
+        } else if (args.length == 3 && args[0].startsWith("effect:")) {
+            List<String> options = Lists.newArrayList();
+            for (String duration : COMMON_DURATIONS) {
+                options.add("duration:" + duration);
+            }
+            return options;
+        } else if (args.length == 4 && args[0].startsWith("effect:")) {
+            return Lists.newArrayList("splash:true", "splash:false");
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandpowertool.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpowertool.java
@@ -3,11 +3,13 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.StringUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -101,5 +103,60 @@ public class Commandpowertool extends EssentialsCommand {
             user.sendMessage(tl("powerToolsEnabled"));
         }
         user.setPowertool(itemStack, powertools);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList("d:", "c:", "l:");
+
+            if (user.isAuthorized("essentials.powertool.append")) {
+                for (String command : getCommands(server)) {
+                    options.add("a:" + command);
+                }
+            }
+
+            try {
+                final ItemStack itemStack = user.getBase().getItemInHand();
+                List<String> powertools = user.getPowertool(itemStack);
+                for (String tool : powertools) {
+                    options.add("r:" + tool);
+                }
+            } catch (Exception e) {}
+            return options;
+        } else if (args[0].startsWith("a:")) {
+            return tabCompleteCommand(user.getSource(), server, args[0].substring(2), args, 1);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else if (args.length == 2) {
+            return getItems();
+        } else if (args.length == 3) {
+            List<String> options = Lists.newArrayList("d:", "c:", "l:");
+
+            for (String command : getCommands(server)) {
+                options.add("a:" + command);
+            }
+
+            try {
+                final User user = getPlayer(server, args, 0, true, true);
+                final ItemStack itemStack = ess.getItemDb().get(args[1]);
+                List<String> powertools = user.getPowertool(itemStack);
+                for (String tool : powertools) {
+                    options.add("r:" + tool);
+                }
+            } catch (Exception e) {}
+            return options;
+        } else if (args[2].startsWith("a:")) {
+            return tabCompleteCommand(sender, server, args[2].substring(2), args, 3);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandptime.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandptime.java
@@ -1,5 +1,7 @@
 package com.earth2me.essentials.commands;
 
+import com.google.common.collect.Lists;
+
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.DescParseTickFormat;
@@ -182,6 +184,19 @@ public class Commandptime extends EssentialsCommand {
         }
 
         return users;
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        final User user = ess.getUser(sender.getPlayer());
+
+        if (args.length == 1) {
+            return Lists.newArrayList("get", "reset", "sunrise", "day", "morning", "noon", "afternoon", "sunset", "night", "midnight");
+        } else if (args.length == 2 && (getAliases.contains(args[0]) || user == null || user.isAuthorized("essentials.ptime.others"))) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandpweather.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpweather.java
@@ -1,5 +1,7 @@
 package com.earth2me.essentials.commands;
 
+import com.google.common.collect.Lists;
+
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
@@ -149,5 +151,16 @@ public class Commandpweather extends EssentialsCommand {
         }
 
         return users;
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return Lists.newArrayList("get", "reset", "storm", "sun");
+        } else if (args.length == 2 && (getAliases.contains(args[0]) || user == null || user.isAuthorized("essentials.pweather.others"))) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandrecipe.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandrecipe.java
@@ -8,6 +8,7 @@ import org.bukkit.Server;
 import org.bukkit.inventory.*;
 
 import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -163,5 +164,14 @@ public class Commandrecipe extends EssentialsCommand {
             return tl("recipeNothing");
         }
         return type.toString().replace("_", " ").toLowerCase(Locale.ENGLISH);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return getItems();
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandremove.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandremove.java
@@ -1,5 +1,7 @@
 package com.earth2me.essentials.commands;
 
+import com.google.common.collect.Lists;
+
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Mob;
 import com.earth2me.essentials.User;
@@ -9,6 +11,7 @@ import org.bukkit.World;
 import org.bukkit.entity.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -242,6 +245,24 @@ public class Commandremove extends EssentialsCommand {
         sender.sendMessage(tl("removed", removed));
     }
 
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList();
+            for (ToRemove toRemove : ToRemove.values()) {
+                options.add(toRemove.name().toLowerCase(Locale.ENGLISH));
+            }
+            return options;
+        } else if (args.length == 2) {
+            List<String> worlds = Lists.newArrayList();
+            for (World world : server.getWorlds()) {
+                worlds.add(world.getName());
+            }
+            return worlds;
+        } else {
+            return Collections.emptyList();
+        }
+    }
 
     private enum ToRemove {
         DROPS,

--- a/Essentials/src/com/earth2me/essentials/commands/Commandrepair.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandrepair.java
@@ -4,12 +4,14 @@ import com.earth2me.essentials.ChargeException;
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.StringUtil;
+import com.google.common.collect.Lists;
 import net.ess3.api.IUser;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -114,6 +116,19 @@ public class Commandrepair extends EssentialsCommand {
                 user.sendMessage(ex.getMessage());
             }
             repaired.add(itemName.replace('_', ' '));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList("hand");
+            if (user.isAuthorized("essentials.repair.all")) {
+                options.add("all");
+            }
+            return options;
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandsell.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandsell.java
@@ -3,10 +3,12 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
@@ -96,5 +98,16 @@ public class Commandsell extends EssentialsCommand {
         user.sendMessage(tl("itemSold", NumberUtil.displayCurrency(result, ess), amount, is.getType().toString().toLowerCase(Locale.ENGLISH), NumberUtil.displayCurrency(worth, ess)));
         logger.log(Level.INFO, tl("itemSoldConsole", user.getDisplayName(), is.getType().toString().toLowerCase(Locale.ENGLISH), NumberUtil.displayCurrency(result, ess), amount, NumberUtil.displayCurrency(worth, ess)));
         return result;
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getMatchingItems(args[0]);
+        } else if (args.length == 2) {
+            return Lists.newArrayList("1", "64");
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
@@ -2,8 +2,12 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.Kit;
 import com.earth2me.essentials.User;
+import com.earth2me.essentials.Settings;
 import org.bukkit.Server;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -27,6 +31,15 @@ public class Commandshowkit extends EssentialsCommand {
             for (String s : kit.getItems()) {
                 user.sendMessage(tl("kitItem", s));
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return new ArrayList<>(ess.getSettings().getKits().getKeys(false)); // TODO: Move this to its own method
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandskull.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandskull.java
@@ -2,10 +2,14 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
+import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -55,6 +59,19 @@ public class Commandskull extends EssentialsCommand {
             user.sendMessage(tl("givenSkull", owner));
         } else {
             user.sendMessage(tl("skullChanged", owner));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            if (user.isAuthorized("essentials.skull.others")) {
+                return getPlayers(server, user);
+            } else {
+                return Lists.newArrayList(user.getName());
+            }
+        } else {
+            return Collections.emptyList();
         }
     }
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandspeed.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandspeed.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.utils.FloatUtil;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -132,6 +133,24 @@ public class Commandspeed extends EssentialsCommand {
         } else {
             float ratio = ((userSpeed - 1) / 9) * (maxSpeed - defaultSpeed);
             return ratio + defaultSpeed;
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 3 && user.isAuthorized("essentials.speed.others")) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 3) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtempban.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtempban.java
@@ -7,8 +7,10 @@ import com.earth2me.essentials.utils.DateUtil;
 import org.bukkit.BanList;
 import org.bukkit.Server;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.logging.Level;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -60,5 +62,15 @@ public class Commandtempban extends EssentialsCommand {
         final String message = tl("playerTempBanned", senderName, user.getName(), expiry, banReason);
         server.getLogger().log(Level.INFO, message);
         ess.broadcastMessage("essentials.ban.notify", message);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            // Note: following args are both date diffs _and_ messages; ideally we'd mix with the vanilla handler
+            return COMMON_DATE_DIFFS;
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandthunder.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandthunder.java
@@ -1,8 +1,12 @@
 package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.World;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -30,6 +34,16 @@ public class Commandthunder extends EssentialsCommand {
             world.setThundering(setThunder);
             user.sendMessage(tl("thunder", setThunder ? tl("enabled") : tl("disabled")));
         }
+    }
 
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return Lists.newArrayList("true", "false");
+        } else if (args.length == 2) {
+            return COMMON_DATE_DIFFS;
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtime.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtime.java
@@ -4,6 +4,7 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.DescParseTickFormat;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.World;
 
@@ -161,6 +162,35 @@ public class Commandtime extends EssentialsCommand {
 
     private String normalizeWorldName(World world) {
         return world.getName().toLowerCase().replaceAll("\\s+", "_");
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        final User user = ess.getUser(sender.getPlayer());
+
+        if (args.length == 1) {
+            if (user == null || user.isAuthorized("essentials.time.set")) {
+                return Lists.newArrayList("set", "add");
+            } else {
+                return Collections.emptyList();
+            }
+        } else if (args.length == 2 && args[0].equalsIgnoreCase("set")) {
+            return Lists.newArrayList("sunrise", "day", "morning", "noon", "afternoon", "sunset", "night", "midnight");
+            // TODO: handle tab completion for add
+        } else if (args.length == 3 && (args[0].equalsIgnoreCase("set") || args[0].equalsIgnoreCase("add"))) {
+            List<String> worlds = Lists.newArrayList();
+            for (World world : server.getWorlds()) {
+                if (user == null || user.isAuthorized("essentials.time.world." + normalizeWorldName(world))) {
+                    worlds.add(world.getName());
+                }
+            }
+            if (user == null || user.isAuthorized("essentials.time.world.all")) {
+                worlds.add("*");
+            }
+            return worlds;
+        } else {
+            return Collections.emptyList();
+        }
     }
 }
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtogglejail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtogglejail.java
@@ -6,6 +6,10 @@ import com.earth2me.essentials.utils.DateUtil;
 import net.ess3.api.events.JailStatusChangeEvent;
 import org.bukkit.Server;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -91,6 +95,21 @@ public class Commandtogglejail extends EssentialsCommand {
                 }
                 sender.sendMessage(tl("jailReleased", player.getName()));
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else if (args.length == 2) {
+            try {
+                return new ArrayList<>(ess.getJails().getList());
+            } catch (Exception e) {
+                return Collections.emptyList();
+            }
+        } else {
+            return COMMON_DATE_DIFFS;
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtp.java
@@ -8,6 +8,9 @@ import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -116,6 +119,26 @@ public class Commandtp extends EssentialsCommand {
             target.sendMessage(tl("teleporting", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
         } else {
             throw new NotEnoughArgumentsException();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        // Don't handle coords
+        if (args.length == 1 || (args.length == 2 && user.isAuthorized("essentials.tp.others"))) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        // Don't handle coords
+        if (args.length == 1 || args.length == 2) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpa.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpa.java
@@ -3,6 +3,9 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -44,5 +47,14 @@ public class Commandtpa extends EssentialsCommand {
         }
         user.sendMessage(tl("requestSent", player.getDisplayName()));
         user.sendMessage(tl("typeTpacancel"));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpaall.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpaall.java
@@ -4,6 +4,9 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -48,6 +51,15 @@ public class Commandtpaall extends EssentialsCommand {
             } catch (Exception ex) {
                 ess.showError(sender, ex, getName());
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpahere.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpahere.java
@@ -3,6 +3,9 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -43,5 +46,14 @@ public class Commandtpahere extends EssentialsCommand {
         }
         user.sendMessage(tl("requestSent", player.getDisplayName()));
         user.sendMessage(tl("typeTpacancel"));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpall.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpall.java
@@ -6,6 +6,9 @@ import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -43,6 +46,15 @@ public class Commandtpall extends EssentialsCommand {
             } catch (Exception ex) {
                 ess.showError(sender, ex, getName());
             }
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtphere.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtphere.java
@@ -5,6 +5,9 @@ import com.earth2me.essentials.User;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -24,5 +27,14 @@ public class Commandtphere extends EssentialsCommand {
         }
         user.getTeleport().teleportPlayer(player, user.getBase(), new Trade(this.getName(), ess), TeleportCause.COMMAND);
         throw new NoChargeException();
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpo.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpo.java
@@ -4,6 +4,9 @@ import com.earth2me.essentials.User;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -40,6 +43,16 @@ public class Commandtpo extends EssentialsCommand {
                 target.getTeleport().now(toPlayer.getBase(), false, TeleportCause.COMMAND);
                 target.sendMessage(tl("teleportAtoB", user.getDisplayName(), toPlayer.getDisplayName()));
                 break;
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        // Don't handle coords
+        if (args.length == 1 || (args.length == 2 && user.isAuthorized("essentials.tp.others"))) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpohere.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpohere.java
@@ -4,6 +4,9 @@ import com.earth2me.essentials.User;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -27,5 +30,14 @@ public class Commandtpohere extends EssentialsCommand {
 
         // Verify permission
         player.getTeleport().now(user.getBase(), false, TeleportCause.COMMAND);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
@@ -4,9 +4,14 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FloatUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Location;
 import org.bukkit.Server;
+import org.bukkit.World;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -74,5 +79,41 @@ public class Commandtppos extends EssentialsCommand {
         user.sendMessage(tl("teleporting", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
         user.getTeleport().teleport(loc, null, TeleportCause.COMMAND);
 
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1 || args.length == 2 || args.length == 3) {
+            return Lists.newArrayList("~0");
+        } else if (args.length == 4 || args.length == 5) {
+            return Lists.newArrayList("0");
+        } else if (args.length == 6) {
+            List<String> worlds = Lists.newArrayList();
+            for (World world : server.getWorlds()) {
+                worlds.add(world.getName());
+            }
+            return worlds;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getPlayers(server, sender);
+        } else if (args.length == 2 || args.length == 3 || args.length == 4) {
+            return Lists.newArrayList("~0");
+        } else if (args.length == 5 || args.length == 6) {
+            return Lists.newArrayList("0");
+        } else if (args.length == 7) {
+            List<String> worlds = Lists.newArrayList();
+            for (World world : server.getWorlds()) {
+                worlds.add(world.getName());
+            }
+            return worlds;
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
@@ -2,9 +2,14 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.LocationUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.TreeType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -40,6 +45,19 @@ public class Commandtree extends EssentialsCommand {
             user.sendMessage(tl("treeSpawned"));
         } else {
             user.sendMessage(tl("treeFailure"));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> options = Lists.newArrayList();
+            for (TreeType type : TreeType.values()) {
+                options.add(type.name().toLowerCase(Locale.ENGLISH).replace("_", ""));
+            }
+            return options;
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandwarp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandwarp.java
@@ -12,6 +12,7 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -109,5 +110,29 @@ public class Commandwarp extends EssentialsCommand {
             throw new Exception(tl("warpUsePermission"));
         }
         owner.getTeleport().warp(user, name, charge, TeleportCause.COMMAND);
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            // Should we be checking "essentials.warp.list" here?
+            return new ArrayList<>(ess.getWarps().getList());
+        } else if (args.length == 2 && (user.isAuthorized("essentials.warp.otherplayers") || user.isAuthorized("essentials.warp.others"))) {
+            //TODO: Remove 'otherplayers' permission.
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return new ArrayList<>(ess.getWarps().getList());
+        } else if (args.length == 2) {
+            return getPlayers(server, sender);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandweather.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandweather.java
@@ -2,8 +2,12 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.World;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -60,6 +64,34 @@ public class Commandweather extends EssentialsCommand {
         } else {
             world.setStorm(isStorm);
             sender.sendMessage(isStorm ? tl("weatherStorm", world.getName()) : tl("weatherSun", world.getName()));
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return Lists.newArrayList("storm", "sun");
+        } else if (args.length == 2) {
+            return COMMON_DURATIONS;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> worlds = Lists.newArrayList();
+            for (World world : server.getWorlds()) {
+                worlds.add(world.getName());
+            }
+            return worlds;
+        } else if (args.length == 2) {
+            return Lists.newArrayList("storm", "sun");
+        } else if (args.length == 3) {
+            return COMMON_DURATIONS;
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandworld.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandworld.java
@@ -2,11 +2,13 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
+import com.google.common.collect.Lists;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -66,5 +68,21 @@ public class Commandworld extends EssentialsCommand {
         charge.isAffordableFor(user);
         user.getTeleport().teleport(target, charge, TeleportCause.COMMAND);
         throw new NoChargeException();
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            List<String> worlds = Lists.newArrayList();
+            for (World world : server.getWorlds()) {
+                if (ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + world.getName())) {
+                    continue;
+                }
+                worlds.add(world.getName());
+            }
+            return worlds;
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandworth.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandworth.java
@@ -3,10 +3,12 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -97,5 +99,27 @@ public class Commandworth extends EssentialsCommand {
         sender.sendMessage(is.getDurability() != 0 ? tl("worthMeta", is.getType().toString().toLowerCase(Locale.ENGLISH).replace("_", ""), is.getDurability(), NumberUtil.displayCurrency(result, ess), amount, NumberUtil.displayCurrency(worth, ess)) : tl("worth", is.getType().toString().toLowerCase(Locale.ENGLISH).replace("_", ""), NumberUtil.displayCurrency(result, ess), amount, NumberUtil.displayCurrency(worth, ess)));
 
         return result;
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getMatchingItems(args[0]);
+        } else if (args.length == 2) {
+            return Lists.newArrayList("1", "64");
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, CommandSource sender, String commandLabel, String[] args) {
+        if (args.length == 1) {
+            return getItems();
+        } else if (args.length == 2) {
+            return Lists.newArrayList("1", "64");
+        } else {
+            return Collections.emptyList();
+        }
     }
 }


### PR DESCRIPTION
This PR makes use of PR #1203 (Tab completion framework), implementing tab completion for all Essentials commands. This was originally done by @Pokechu22 in #1203, but I've reformatted that and fixed a few errors.

EDIT: This PR does not implement for `/createkit` a commit will follow after with the full feature.