### PR TITLE
Removed null values from AbstractVaultHandler.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/perm/impl/AbstractVaultHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/impl/AbstractVaultHandler.java
@@ -48,7 +48,7 @@ public abstract class AbstractVaultHandler extends SuperpermsHandler {
         String playerPrefix = chat.getPlayerPrefix(base);
         if (playerPrefix == null) {
             String playerGroup = perms.getPrimaryGroup(base);
-            return chat.getGroupPrefix((String) null, playerGroup);
+            return chat.getGroupPrefix(base.getWorld().getName(), playerGroup);
         } else {
             return playerPrefix;
         }
@@ -59,7 +59,7 @@ public abstract class AbstractVaultHandler extends SuperpermsHandler {
         String playerSuffix = chat.getPlayerSuffix(base);
         if (playerSuffix == null) {
             String playerGroup = perms.getPrimaryGroup(base);
-            return chat.getGroupSuffix((String) null, playerGroup);
+            return chat.getGroupSuffix(base.getWorld().getName(), playerGroup);
         } else {
             return playerSuffix;
         }


### PR DESCRIPTION
I'm in the process of writing a permissions plugin, and every time I try to talk it threw an error. The error was caused by this null value that was existing. I removed it and changed it to get the Player's world name. This should fix my error.