### PR TITLE
Make permission plugin detection more generic in Superperms handler

### DIFF
--- a/Essentials/src/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
@@ -66,11 +66,13 @@ public class SuperpermsHandler implements IPermissionsHandler {
 
     public String getEnabledPermsPlugin() {
         String enabledPermsPlugin = null;
-        List<String> specialCasePlugins = Arrays.asList("PermissionsEx", "GroupManager",
-                "SimplyPerms", "Privileges", "bPermissions", "zPermissions", "PermissionsBukkit",
-                "DroxPerms", "xPerms");
         for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
-            if (specialCasePlugins.contains(plugin.getName())) {
+            final boolean match = plugin.getName().toLowerCase().contains("permissions") ||
+                    plugin.getName().toLowerCase().endsWith("perms") ||
+                    plugin.getName().equals("GroupManager") ||
+                    plugin.getName().equals("Privileges");
+            
+            if (match) {
                 enabledPermsPlugin = plugin.getName();
                 break;
             }


### PR DESCRIPTION
Previously there was just a hard coded list of permission plugins. There's a number of new permission plugins which have emerged recently, which are not in this list. Instead of adding them, I've changed the way they're detected.

Instead of checking for absolute matches, a plugin will be deemed a "permission provider" if its name:
* contains `permissions`
* ends with `perms`
* is `GroupManager` or `Privileges` (special cases)

This is necessary, as if Vault is not installed and the user is running an "unsupported" permissions plugin (one that's not in the list), Essentials will fallback to using config based permissions.

https://github.com/drtshock/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/perm/PermissionsHandler.java#L112-L117
(the config option "useSuperperms" is false by default)

This means that any permissions set by the user are ignored.

However, if a plugin is detected in the list above, Superperms will be selected, and config permissions will be ignored. (the correct behaviour)
https://github.com/drtshock/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/perm/PermissionsHandler.java#L100

Related to lucko/LuckPerms#348
