### PR TITLE
Add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!---
+If needed, you can paste your config and logs on https://gist.github.com and
+include a link in your issue. Post separate problems in separate issues, as
+this makes it easier to keep track of them. These top lines won't appear when
+you create your issue, so make sure to put details at the bottom of the post.
+-->
+
+EssentialsX version (`/essentials`): 
+
+Server software (`/version`): 
+
+EssentialsX config (if applicable): 
+


### PR DESCRIPTION
Having an issue template should help to prompt users to give information that helps to solve issues, like versions etc. However, this shouldn't be too overwhelming and doesn't have to be strictly followed (for example, we usually don't need their EssX version for feature requests).