### PR TITLE
[Fix] Issue#1293 Muted Players can use /r

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandr.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandr.java
@@ -26,6 +26,11 @@ public class Commandr extends EssentialsCommand {
 
         if (sender.isPlayer()) {
             User user = ess.getUser(sender.getPlayer());
+
+            if (user.isMuted()) {
+                throw new Exception(tl("voiceSilenced"));
+            }
+
             message = FormatUtil.formatMessage(user, "essentials.msg", message);
             messageSender = user;
         } else {


### PR DESCRIPTION
[Fix] Fixed the issue where a player who is muted is able to do the command /r to someone who has /msg'd that user. I added in the suggestion that delbertina brought up in #1293. Just as a side note I would imagine that this kind of thing being /r while muted is unintended, but if it is supposed to be intended then maybe a config option would be a valid way to go with disabling that.