### PR TITLE
[Fix] Essentials signs validity

### DIFF
--- a/Essentials/src/com/earth2me/essentials/signs/EssentialsSign.java
+++ b/Essentials/src/com/earth2me/essentials/signs/EssentialsSign.java
@@ -7,7 +7,6 @@ import net.ess3.api.MaxMoneyException;
 import net.ess3.api.events.SignBreakEvent;
 import net.ess3.api.events.SignCreateEvent;
 import net.ess3.api.events.SignInteractEvent;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -211,9 +210,9 @@ public class EssentialsSign {
         return true;
     }
 
-    protected static boolean checkIfBlockBreaksSigns(final IEssentials ess, final Block block) {
+    protected static boolean checkIfBlockBreaksSigns(final Block block) {
         final Block sign = block.getRelative(BlockFace.UP);
-        if (sign.getType() == Material.SIGN_POST && isValidSign(ess, new BlockSign(sign))) {
+        if (sign.getType() == Material.SIGN_POST && isValidSign(new BlockSign(sign))) {
             return true;
         }
         final BlockFace[] directions = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
@@ -222,7 +221,7 @@ public class EssentialsSign {
             if (signblock.getType() == Material.WALL_SIGN) {
                 try {
                     final org.bukkit.material.Sign signMat = (org.bukkit.material.Sign) signblock.getState().getData();
-                    if (signMat != null && signMat.getFacing() == blockFace && isValidSign(ess, new BlockSign(signblock))) {
+                    if (signMat != null && signMat.getFacing() == blockFace && isValidSign(new BlockSign(signblock))) {
                         return true;
                     }
                 } catch (NullPointerException ex) {
@@ -233,18 +232,8 @@ public class EssentialsSign {
         return false;
     }
 
-    public static boolean isValidSign(final IEssentials ess, final ISign sign) {
-        if (!sign.getLine(0).matches("§1\\[.*\\]"))
-            return false;
-
-        // Validate that the sign is actually an essentials sign
-        String signName = ChatColor.stripColor(sign.getLine(0)).replaceAll("[^a-zA-Z]", "");
-        for (EssentialsSign essSign : ess.getSettings().enabledSigns()) {
-            if (essSign.getName().equalsIgnoreCase(signName))
-                return true;
-        }
-
-        return false;
+    public static boolean isValidSign(final ISign sign) {
+        return sign.getLine(0).matches("§1\\[.*\\]");
     }
 
     protected boolean onBlockPlace(final Block block, final User player, final String username, final IEssentials ess) throws SignException, ChargeException {

--- a/Essentials/src/com/earth2me/essentials/signs/EssentialsSign.java
+++ b/Essentials/src/com/earth2me/essentials/signs/EssentialsSign.java
@@ -7,6 +7,7 @@ import net.ess3.api.MaxMoneyException;
 import net.ess3.api.events.SignBreakEvent;
 import net.ess3.api.events.SignCreateEvent;
 import net.ess3.api.events.SignInteractEvent;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -232,8 +233,24 @@ public class EssentialsSign {
         return false;
     }
 
+    /** @deprecated, use {@link #isValidSign(IEssentials, ISign)} if possible */
+    @Deprecated
     public static boolean isValidSign(final ISign sign) {
         return sign.getLine(0).matches("§1\\[.*\\]");
+    }
+
+    public static boolean isValidSign(final IEssentials ess, final ISign sign) {
+        if (!sign.getLine(0).matches("§1\\[.*\\]"))
+            return false;
+
+        // Validate that the sign is actually an essentials sign
+        String signName = ChatColor.stripColor(sign.getLine(0)).replaceAll("[^a-zA-Z]", "");
+        for (EssentialsSign essSign : ess.getSettings().enabledSigns()) {
+            if (essSign.getName().equalsIgnoreCase(signName))
+                return true;
+        }
+
+        return false;
     }
 
     protected boolean onBlockPlace(final Block block, final User player, final String username, final IEssentials ess) throws SignException, ChargeException {

--- a/Essentials/src/com/earth2me/essentials/signs/EssentialsSign.java
+++ b/Essentials/src/com/earth2me/essentials/signs/EssentialsSign.java
@@ -7,6 +7,7 @@ import net.ess3.api.MaxMoneyException;
 import net.ess3.api.events.SignBreakEvent;
 import net.ess3.api.events.SignCreateEvent;
 import net.ess3.api.events.SignInteractEvent;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -210,9 +211,9 @@ public class EssentialsSign {
         return true;
     }
 
-    protected static boolean checkIfBlockBreaksSigns(final Block block) {
+    protected static boolean checkIfBlockBreaksSigns(final IEssentials ess, final Block block) {
         final Block sign = block.getRelative(BlockFace.UP);
-        if (sign.getType() == Material.SIGN_POST && isValidSign(new BlockSign(sign))) {
+        if (sign.getType() == Material.SIGN_POST && isValidSign(ess, new BlockSign(sign))) {
             return true;
         }
         final BlockFace[] directions = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
@@ -221,7 +222,7 @@ public class EssentialsSign {
             if (signblock.getType() == Material.WALL_SIGN) {
                 try {
                     final org.bukkit.material.Sign signMat = (org.bukkit.material.Sign) signblock.getState().getData();
-                    if (signMat != null && signMat.getFacing() == blockFace && isValidSign(new BlockSign(signblock))) {
+                    if (signMat != null && signMat.getFacing() == blockFace && isValidSign(ess, new BlockSign(signblock))) {
                         return true;
                     }
                 } catch (NullPointerException ex) {
@@ -232,8 +233,18 @@ public class EssentialsSign {
         return false;
     }
 
-    public static boolean isValidSign(final ISign sign) {
-        return sign.getLine(0).matches("§1\\[.*\\]");
+    public static boolean isValidSign(final IEssentials ess, final ISign sign) {
+        if (!sign.getLine(0).matches("§1\\[.*\\]"))
+            return false;
+
+        // Validate that the sign is actually an essentials sign
+        String signName = ChatColor.stripColor(sign.getLine(0)).replaceAll("[^a-zA-Z]", "");
+        for (EssentialsSign essSign : ess.getSettings().enabledSigns()) {
+            if (essSign.getName().equalsIgnoreCase(signName))
+                return true;
+        }
+
+        return false;
     }
 
     protected boolean onBlockPlace(final Block block, final User player, final String username, final IEssentials ess) throws SignException, ChargeException {

--- a/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
@@ -46,7 +46,7 @@ public class SignBlockListener implements Listener {
 
     public boolean protectSignsAndBlocks(final Block block, final Player player) throws MaxMoneyException {
         // prevent any signs be broken by destroying the block they are attached to
-        if (EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
+        if (EssentialsSign.checkIfBlockBreaksSigns(block)) {
             if (ess.getSettings().isDebug()) {
                 LOGGER.log(Level.INFO, "Prevented that a block was broken next to a sign.");
             }
@@ -142,7 +142,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block against = event.getBlockAgainst();
-        if ((against.getType() == WALL_SIGN || against.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(against))) {
+        if ((against.getType() == WALL_SIGN || against.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(against))) {
             event.setCancelled(true);
             return;
         }
@@ -166,7 +166,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
+        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
             event.setCancelled(true);
             return;
         }
@@ -186,7 +186,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
+        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
             event.setCancelled(true);
             return;
         }
@@ -206,7 +206,7 @@ public class SignBlockListener implements Listener {
         }
 
         for (Block block : event.getBlocks()) {
-            if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
+            if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
                 event.setCancelled(true);
                 return;
             }
@@ -231,7 +231,7 @@ public class SignBlockListener implements Listener {
             final Block[] affectedBlocks = new Block[]{pistonBaseBlock, pistonBaseBlock.getRelative(event.getDirection()), event.getRetractLocation().getBlock()};
 
             for (Block block : affectedBlocks) {
-                if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
+                if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
                     event.setCancelled(true);
                     return;
                 }

--- a/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
@@ -142,7 +142,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block against = event.getBlockAgainst();
-        if ((against.getType() == WALL_SIGN || against.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(against))) {
+        if ((against.getType() == WALL_SIGN || against.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(against))) {
             event.setCancelled(true);
             return;
         }
@@ -166,7 +166,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
             event.setCancelled(true);
             return;
         }
@@ -186,7 +186,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
             event.setCancelled(true);
             return;
         }
@@ -206,7 +206,7 @@ public class SignBlockListener implements Listener {
         }
 
         for (Block block : event.getBlocks()) {
-            if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+            if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
                 event.setCancelled(true);
                 return;
             }
@@ -231,7 +231,7 @@ public class SignBlockListener implements Listener {
             final Block[] affectedBlocks = new Block[]{pistonBaseBlock, pistonBaseBlock.getRelative(event.getDirection()), event.getRetractLocation().getBlock()};
 
             for (Block block : affectedBlocks) {
-                if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+                if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
                     event.setCancelled(true);
                     return;
                 }

--- a/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignBlockListener.java
@@ -46,7 +46,7 @@ public class SignBlockListener implements Listener {
 
     public boolean protectSignsAndBlocks(final Block block, final Player player) throws MaxMoneyException {
         // prevent any signs be broken by destroying the block they are attached to
-        if (EssentialsSign.checkIfBlockBreaksSigns(block)) {
+        if (EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
             if (ess.getSettings().isDebug()) {
                 LOGGER.log(Level.INFO, "Prevented that a block was broken next to a sign.");
             }
@@ -142,7 +142,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block against = event.getBlockAgainst();
-        if ((against.getType() == WALL_SIGN || against.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(against))) {
+        if ((against.getType() == WALL_SIGN || against.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(against))) {
             event.setCancelled(true);
             return;
         }
@@ -166,7 +166,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
             event.setCancelled(true);
             return;
         }
@@ -186,7 +186,7 @@ public class SignBlockListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+        if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
             event.setCancelled(true);
             return;
         }
@@ -206,7 +206,7 @@ public class SignBlockListener implements Listener {
         }
 
         for (Block block : event.getBlocks()) {
-            if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+            if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
                 event.setCancelled(true);
                 return;
             }
@@ -231,7 +231,7 @@ public class SignBlockListener implements Listener {
             final Block[] affectedBlocks = new Block[]{pistonBaseBlock, pistonBaseBlock.getRelative(event.getDirection()), event.getRetractLocation().getBlock()};
 
             for (Block block : affectedBlocks) {
-                if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+                if (((block.getType() == WALL_SIGN || block.getType() == SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
                     event.setCancelled(true);
                     return;
                 }

--- a/Essentials/src/com/earth2me/essentials/signs/SignEntityListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignEntityListener.java
@@ -25,7 +25,7 @@ public class SignEntityListener implements Listener {
         }
 
         for (Block block : event.blockList()) {
-            if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
+            if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
                 event.setCancelled(true);
                 return;
             }
@@ -46,7 +46,7 @@ public class SignEntityListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
+        if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
             event.setCancelled(true);
             return;
         }

--- a/Essentials/src/com/earth2me/essentials/signs/SignEntityListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignEntityListener.java
@@ -25,7 +25,7 @@ public class SignEntityListener implements Listener {
         }
 
         for (Block block : event.blockList()) {
-            if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+            if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
                 event.setCancelled(true);
                 return;
             }
@@ -46,7 +46,7 @@ public class SignEntityListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+        if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
             event.setCancelled(true);
             return;
         }

--- a/Essentials/src/com/earth2me/essentials/signs/SignEntityListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignEntityListener.java
@@ -25,7 +25,7 @@ public class SignEntityListener implements Listener {
         }
 
         for (Block block : event.blockList()) {
-            if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+            if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
                 event.setCancelled(true);
                 return;
             }
@@ -46,7 +46,7 @@ public class SignEntityListener implements Listener {
         }
 
         final Block block = event.getBlock();
-        if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(block)) {
+        if (((block.getType() == Material.WALL_SIGN || block.getType() == Material.SIGN_POST) && EssentialsSign.isValidSign(ess, new EssentialsSign.BlockSign(block))) || EssentialsSign.checkIfBlockBreaksSigns(ess, block)) {
             event.setCancelled(true);
             return;
         }


### PR DESCRIPTION
Any sign in the format of &1[...] was a valid sign according to essentials, but 3rd party plugins with the same sign format would be treated equally (cancelling nearby explosions, etc)

Valid signs after this fix are:
- In the format of &1[...] as before
- Are essentials signs and enabled in the essentials config

This is in reference to #1399