### PR TITLE
Fix usage of deprecated getTargetBlock (fixes #1433)

### DIFF
--- a/Essentials/src/com/earth2me/essentials/signs/SignPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignPlayerListener.java
@@ -11,6 +11,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Level;
 
 
@@ -38,7 +39,7 @@ public class SignPlayerListener implements Listener {
         if (event.isCancelled() && event.getAction() == Action.RIGHT_CLICK_AIR) {
             Block targetBlock = null;
             try {
-                targetBlock = event.getPlayer().getTargetBlock((HashSet<Byte>) null, 5);
+                targetBlock = event.getPlayer().getTargetBlock((Set<Material>) null, 5);
             } catch (IllegalStateException ex) {
                 if (ess.getSettings().isDebug()) {
                     ess.getLogger().log(Level.WARNING, ex.getMessage(), ex);


### PR DESCRIPTION
Fixes use of the `LivingEntity#getTargetBlock(HashSet<Byte>, int)`, replacing it with `LivingEntity#getTargetBlock(HashSet<Material>, int)` which is still supported by Spigot 1.12.1. Fixes #1433.