### PR TITLE
Use Paper's new ServerListPingEvent methods if present

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
@@ -18,7 +18,7 @@ import java.util.logging.Level;
 public class EssentialsServerListener implements Listener {
     private final transient IEssentials ess;
     private boolean errorLogged = false;
-    private Boolean isPaperSample;
+    private boolean isPaperSample;
     private Method setSampleText;
     private Method getSampleText;
 
@@ -38,7 +38,6 @@ public class EssentialsServerListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onServerListPing(final ServerListPingEvent event) {
         if (isPaperSample) {
-            // ess.getLogger().info("Paper sample");
             try {
                 List<String> playerNames = (List<String>) getSampleText.invoke(event, null);
                 Iterator<String> iterator = playerNames.iterator();
@@ -56,7 +55,6 @@ public class EssentialsServerListener implements Listener {
                 }
             }
         } else {
-            // ess.getLogger().info("Spigot iterator");
             try {
                 Iterator<Player> iterator = event.iterator();
                 while (iterator.hasNext()) {

--- a/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
@@ -1,38 +1,76 @@
 package com.earth2me.essentials;
 
 import net.ess3.api.IEssentials;
+import net.ess3.nms.refl.ReflUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.ServerListPingEvent;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
 
 
 public class EssentialsServerListener implements Listener {
     private final transient IEssentials ess;
     private boolean errorLogged = false;
+    private Boolean isPaperSample;
+    private Method setSampleText;
+    private Method getSampleText;
 
     public EssentialsServerListener(final IEssentials ess) {
         this.ess = ess;
+        setSampleText = ReflUtil.getMethodCached(ServerListPingEvent.class, "setSampleText", List.class);
+        getSampleText = ReflUtil.getMethodCached(ServerListPingEvent.class, "getSampleText");
+        if (setSampleText != null && getSampleText != null) {
+            ess.getLogger().info("Using Paper 1.12+ ServerListPingEvent methods");
+            isPaperSample = true;
+        } else {
+            ess.getLogger().info("Using Spigot 1.7.10+ ServerListPingEvent iterator");
+            isPaperSample = false;
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onServerListPing(final ServerListPingEvent event) {
-        try {
-            Iterator<Player> iterator = event.iterator();
-            while (iterator.hasNext()) {
-                Player player = iterator.next();
-                if (ess.getUser(player).isVanished()) {
-                    iterator.remove();
+        if (isPaperSample) {
+            // ess.getLogger().info("Paper sample");
+            try {
+                List<String> playerNames = (List<String>) getSampleText.invoke(event, null);
+                Iterator<String> iterator = playerNames.iterator();
+                while (iterator.hasNext()) {
+                    String player = iterator.next();
+                    if (ess.getUser(player).isVanished()) {
+                        iterator.remove();
+                    }
+                }
+                setSampleText.invoke(event, playerNames);
+            } catch (IllegalAccessException | InvocationTargetException | ClassCastException e) {
+                if (!errorLogged) {
+                    ess.getLogger().log(Level.WARNING, "Unable to hide players from server list ping using Paper 1.12+ method!", e);
+                    errorLogged = true;
                 }
             }
-        } catch (UnsupportedOperationException e) {
-            if (!errorLogged) {
-                ess.getLogger().warning("Current server implementation does not support "
-                    + "hiding players from server list ping. Update or contact the maintainers.");
-                errorLogged = true;
+        } else {
+            // ess.getLogger().info("Spigot iterator");
+            try {
+                Iterator<Player> iterator = event.iterator();
+                while (iterator.hasNext()) {
+                    Player player = iterator.next();
+                    if (ess.getUser(player).isVanished()) {
+                        iterator.remove();
+                    }
+                }
+            } catch (UnsupportedOperationException e) {
+                if (!errorLogged) {
+                    ess.getLogger().warning("Current server implementation does not support "
+                            + "hiding players from server list ping. Update or contact the maintainers.");
+                    errorLogged = true;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1419 - as of the Paper patch that added the new methods, there's now no way to change the server list player count on Paper 1.12+, but this PR fixes the names of vanished players showing up in the server list.

Tested against Spigot 1.12.1 and Paper 1.12.1, latest builds as of submitting PR.