### PR TITLE
Alter config options for EssentialsX Spawn listeners

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -192,6 +192,8 @@ public interface ISettings extends IConf {
 
     EventPriority getRespawnPriority();
 
+    EventPriority getSpawnJoinPriority();
+
     long getTpaAcceptCancellation();
 
     long getTeleportInvulnerability();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -962,6 +962,9 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     private EventPriority getPriority(String priority) {
+        if ("none".equals(priority)) {
+            return null;
+        }
         if ("lowest".equals(priority)) {
             return EventPriority.LOWEST;
         }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -961,9 +961,7 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getBoolean("disable-item-pickup-while-afk", false);
     }
 
-    @Override
-    public EventPriority getRespawnPriority() {
-        String priority = config.getString("respawn-listener-priority", "normal").toLowerCase(Locale.ENGLISH);
+    private EventPriority getPriority(String priority) {
         if ("lowest".equals(priority)) {
             return EventPriority.LOWEST;
         }
@@ -980,6 +978,18 @@ public class Settings implements net.ess3.api.ISettings {
             return EventPriority.HIGHEST;
         }
         return EventPriority.NORMAL;
+    }
+
+    @Override
+    public EventPriority getRespawnPriority() {
+        String priority = config.getString("respawn-listener-priority", "normal").toLowerCase(Locale.ENGLISH);
+        return getPriority(priority);
+    }
+
+    @Override
+    public EventPriority getSpawnJoinPriority() {
+        String priority = config.getString("spawn-join-listener-priority", "normal").toLowerCase(Locale.ENGLISH);
+        return getPriority(priority);
     }
 
     @Override

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -879,10 +879,16 @@ newbies:
   #kit: ''
   kit: tools
 
+# What priority should we use for handling respawns?
+# Set this to none, if you want vanilla respawning behaviour.
 # Set this to lowest, if you want Multiverse to handle the respawning.
 # Set this to high, if you want EssentialsSpawn to handle the respawning.
 # Set this to highest, if you want to force EssentialsSpawn to handle the respawning.
 respawn-listener-priority: high
+
+# What priority should we use for handling spawning on joining the server?
+# See respawn-listener-priority for possible values.
+spawn-join-listener-priority: high
 
 # When users die, should they respawn at their first home or bed, instead of the spawnpoint?
 respawn-at-home: false

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -888,6 +888,7 @@ respawn-listener-priority: high
 
 # What priority should we use for handling spawning on joining the server?
 # See respawn-listener-priority for possible values.
+# Note: changing this may impact or break spawn-on-join functionality.
 spawn-join-listener-priority: high
 
 # When users die, should they respawn at their first home or bed, instead of the spawnpoint?

--- a/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawn.java
+++ b/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawn.java
@@ -7,6 +7,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventException;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
@@ -41,18 +42,26 @@ public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn {
         ess.addReloadListener(spawns);
 
         final EssentialsSpawnPlayerListener playerListener = new EssentialsSpawnPlayerListener(ess, spawns);
-        pluginManager.registerEvent(PlayerRespawnEvent.class, playerListener, ess.getSettings().getRespawnPriority(), new EventExecutor() {
-            @Override
-            public void execute(final Listener ll, final Event event) throws EventException {
-                ((EssentialsSpawnPlayerListener) ll).onPlayerRespawn((PlayerRespawnEvent) event);
-            }
-        }, this);
-        pluginManager.registerEvent(PlayerJoinEvent.class, playerListener, ess.getSettings().getRespawnPriority(), new EventExecutor() {
-            @Override
-            public void execute(final Listener ll, final Event event) throws EventException {
-                ((EssentialsSpawnPlayerListener) ll).onPlayerJoin((PlayerJoinEvent) event);
-            }
-        }, this);
+
+        EventPriority respawnPriority = ess.getSettings().getRespawnPriority();
+        if (respawnPriority != null) {
+            pluginManager.registerEvent(PlayerRespawnEvent.class, playerListener, respawnPriority, new EventExecutor() {
+                @Override
+                public void execute(final Listener ll, final Event event) throws EventException {
+                    ((EssentialsSpawnPlayerListener) ll).onPlayerRespawn((PlayerRespawnEvent) event);
+                }
+            }, this);
+        }
+
+        EventPriority joinPriority = ess.getSettings().getSpawnJoinPriority();
+        if (joinPriority != null) {
+            pluginManager.registerEvent(PlayerJoinEvent.class, playerListener, joinPriority, new EventExecutor() {
+                @Override
+                public void execute(final Listener ll, final Event event) throws EventException {
+                    ((EssentialsSpawnPlayerListener) ll).onPlayerJoin((PlayerJoinEvent) event);
+                }
+            }, this);
+        }
     }
 
     @Override


### PR DESCRIPTION
Adds a separate config option for spawn-on-join listener, and accepts "none" as a valid option, which disables the listener.

Implements suggestion in #1472.