### PR TITLE
Add LuckPerms to "specialCasePlugins" in SuperpermsHandler

### DIFF
--- a/Essentials/src/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
@@ -68,7 +68,7 @@ public class SuperpermsHandler implements IPermissionsHandler {
         String enabledPermsPlugin = null;
         List<String> specialCasePlugins = Arrays.asList("PermissionsEx", "GroupManager",
                 "SimplyPerms", "Privileges", "bPermissions", "zPermissions", "PermissionsBukkit",
-                "DroxPerms", "xPerms");
+                "DroxPerms", "xPerms", "LuckPerms");
         for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
             if (specialCasePlugins.contains(plugin.getName())) {
                 enabledPermsPlugin = plugin.getName();


### PR DESCRIPTION
Despite the changes made as a result of #1356, I'm still getting a lot of people come to me unable to negate permissions for Essentials commands, due to the previous default value of `use-bukkit-permissions`.

Naturally, once people install Essentials once, they don't tend to reset their configuration files. I'm getting slightly tired of people blaming me for this. 😢 

Thanks. :)