### PR TITLE
Ensure LOGGER is not equal to plugin logger before setting parent

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -155,7 +155,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     @Override
     public void onEnable() {
         try {
-            LOGGER.setParent(this.getLogger());
+            if (LOGGER != this.getLogger()) {
+                LOGGER.setParent(this.getLogger());
+            }
             execTimer = new ExecuteTimer();
             execTimer.start();
             i18n = new I18n(this);


### PR DESCRIPTION
PaperMC/Paper#890 introduced minor changes to the plugin logger to make plugin prefixes independent from the logging framework. As a result, the plugin logger now uses the plugin name as name.

Essentials uses the same logger name and redirects messages to the plugin logger by setting it as a parent. However, in newer Paper builds both loggers are now equal, resulting in infinite loops when logging messages because the logger has itself as parent.

Make sure the two loggers are not equal before setting the parent to avoid the following warning on newer Paper builds:

    [Essentials] Ignoring attempt to change parent of plugin logger

(On Spigot and older Paper builds this will not be true so the parent is still set correctly.)