### PR TITLE
Add Vault prefix/suffix support to EssXChat

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -449,8 +449,8 @@ public class Settings implements net.ess3.api.ISettings {
             mFormat = mFormat.replace("{TEAMPREFIX}", "{3}");
             mFormat = mFormat.replace("{TEAMSUFFIX}", "{4}");
             mFormat = mFormat.replace("{TEAMNAME}", "{5}");
-            mFormat = mFormat.replace("{VAULTPREFIX}", "{6}");
-            mFormat = mFormat.replace("{VAULTSUFFIX}", "{7}");
+            mFormat = mFormat.replace("{PREFIX}", "{6}");
+            mFormat = mFormat.replace("{SUFFIX}", "{7}");
             mFormat = "§r".concat(mFormat);
             chatFormats.put(group, mFormat);
         }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -449,6 +449,8 @@ public class Settings implements net.ess3.api.ISettings {
             mFormat = mFormat.replace("{TEAMPREFIX}", "{3}");
             mFormat = mFormat.replace("{TEAMSUFFIX}", "{4}");
             mFormat = mFormat.replace("{TEAMNAME}", "{5}");
+            mFormat = mFormat.replace("{VAULTPREFIX}", "{6}");
+            mFormat = mFormat.replace("{VAULTSUFFIX}", "{7}");
             mFormat = "§r".concat(mFormat);
             chatFormats.put(group, mFormat);
         }

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -686,6 +686,7 @@ chat:
 
   format: '<{DISPLAYNAME}> {MESSAGE}'
   #format: '&7[{GROUP}]&r {DISPLAYNAME}&7:&r {MESSAGE}'
+  #format: '&7{VAULTPREFIX}&r {DISPLAYNAME}&r &7{VAULTSUFFIX}&r: {MESSAGE}'
 
   group-formats:
   #  Default: '{WORLDNAME} {DISPLAYNAME}&7:&r {MESSAGE}'

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -683,10 +683,11 @@ chat:
   # Chat formatting can be done in two ways, you can either define a standard format for all chat.
   # Or you can give a group specific chat format, to give some extra variation.
   # For more information of chat formatting, check out the wiki: http://wiki.ess3.net/wiki/Chat_Formatting
+  # For EssentialsX changes, take a look at the EssentialsX wiki: https://github.com/EssentialsX/Essentials/wiki
 
   format: '<{DISPLAYNAME}> {MESSAGE}'
   #format: '&7[{GROUP}]&r {DISPLAYNAME}&7:&r {MESSAGE}'
-  #format: '&7{VAULTPREFIX}&r {DISPLAYNAME}&r &7{VAULTSUFFIX}&r: {MESSAGE}'
+  #format: '&7{PREFIX}&r {DISPLAYNAME}&r &7{SUFFIX}&r: {MESSAGE}'
 
   group-formats:
   #  Default: '{WORLDNAME} {DISPLAYNAME}&7:&r {MESSAGE}'

--- a/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
+++ b/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
@@ -46,7 +46,7 @@ public class EssentialsChatPlayerListenerLowest extends EssentialsChatPlayer {
         Player player = user.getBase();
         String prefix = ess.getPermissionsHandler().getPrefix(player);
         String suffix = ess.getPermissionsHandler().getSuffix(player);
-        Team team = player.getScoreboard().getPlayerTeam(user.getBase());
+        Team team = player.getScoreboard().getPlayerTeam(player);
 
         String format = ess.getSettings().getChatFormat(group);
         format = format.replace("{0}", group);

--- a/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
+++ b/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
@@ -4,6 +4,7 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
 import net.ess3.api.IEssentials;
 import org.bukkit.Server;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -41,7 +42,11 @@ public class EssentialsChatPlayerListenerLowest extends EssentialsChatPlayer {
         event.setMessage(FormatUtil.formatMessage(user, "essentials.chat", event.getMessage()));
         String group = user.getGroup();
         String world = user.getWorld().getName();
-        Team team = user.getBase().getScoreboard().getPlayerTeam(user.getBase());
+
+        Player player = user.getBase();
+        String prefix = ess.getPermissionsHandler().getPrefix(player);
+        String suffix = ess.getPermissionsHandler().getSuffix(player);
+        Team team = player.getScoreboard().getPlayerTeam(user.getBase());
 
         String format = ess.getSettings().getChatFormat(group);
         format = format.replace("{0}", group);
@@ -50,6 +55,8 @@ public class EssentialsChatPlayerListenerLowest extends EssentialsChatPlayer {
         format = format.replace("{3}", team == null ? "" : team.getPrefix());
         format = format.replace("{4}", team == null ? "" : team.getSuffix());
         format = format.replace("{5}", team == null ? "" : team.getDisplayName());
+        format = format.replace("{6}", prefix);
+        format = format.replace("{7}", suffix);
         synchronized (format) {
             event.setFormat(format);
         }


### PR DESCRIPTION
Add support for replacing Vault prefixes and suffixes in chat to EssentialsX Chat, using the variables `{VAULTPREFIX}` and `{VAULTSUFFIX}`.

Includes an example of how to use it in the config.