### PR TITLE
The Future of EssentialsX

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -166,6 +166,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             
             Console.setInstance(this);
 
+            LOGGER.warning("EssentialsX has been discontinued and will not support Minecraft 1.13.");
+            LOGGER.warning("Thanks for using EssentialsX!");
+
             final PluginManager pm = getServer().getPluginManager();
             for (Plugin plugin : pm.getPlugins()) {
                 if (plugin.getDescription().getName().startsWith("Essentials") && !plugin.getDescription().getVersion().equals(this.getDescription().getVersion()) && !plugin.getDescription().getName().equals("EssentialsAntiCheat")) {

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Note
 --------
 
-> EssentialsX has been discontinued.
-> 1.12 is the last version of Spigot supported by EssentialsX.
-> There are no plans to officially support 1.13 or above.
-> We suggest you switch to a maintained alternative.
+> EssentialsX has been discontinued.  
+> 1.12 is the last version of Spigot supported by EssentialsX.  
+> There are no plans to officially support 1.13 or above.  
+> We suggest you switch to a maintained alternative.  
 > Thanks for using EssentialsX!
 
 ![](https://i.imgur.com/CP4SZpB.png)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+Note
+--------
+
+> EssentialsX has been discontinued.
+> 1.12 is the last version of Spigot supported by EssentialsX.
+> There are no plans to officially support 1.13 or above.
+> We suggest you switch to a maintained alternative.
+> Thanks for using EssentialsX!
+
 ![](https://i.imgur.com/CP4SZpB.png)
 
 [![Downloads](https://i.imgur.com/MMc0PJY.png)](http://ci.ender.zone/job/EssentialsX/)


### PR DESCRIPTION
**Update from @drtshock - EssentialsX is not being discontinued, see [this reply](https://github.com/drtshock/Essentials/pull/1688#issuecomment-351192522) for details.**

---

The below statement is no longer relevant but is kept for reference.
<details>

> After some consideration, it has been decided to discontinue EssentialsX.  
> This was due to the effort needed to maintain Essentials' legacy code and support for Minecraft versions dating back to 2014 while attempting to support modern, evolving server platforms such as Paper, as well as due to the major overhauls that would be needed to support 1.13 when released, which would require much more spare time than we have available to work on EssentialsX.  
> For this reason, EssentialsX will no longer be updated to newer Minecraft releases.  
> Rest in peace, EssentialsX 2015-2017
</details>