### PR TITLE
Fixes #1767: Adds ignore check for /me

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandme.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandme.java
@@ -53,6 +53,8 @@ public class Commandme extends EssentialsCommand {
                 final Location playerLoc = onlineUser.getLocation();
                 if (playerLoc.getWorld() != world) {
                     abort = true;
+                } else if (onlineUser.isIgnoredPlayer(user)) {
+                    abort = true;
                 } else {
                     final double delta = playerLoc.distanceSquared(loc);
                     if (delta > radius) {


### PR DESCRIPTION
Fixes #1767 

The above issue states that the `/me` command was not properly ignored by players who have `/ignore`d the executor of `/me`.

This PR introduces a change that checks to ensure that the player running `/me` is not ignored by target players before sending them the message.

Demo: git-Spigot-d20369f-7fc5cd8 (MC: 1.9) (Implementing API version 1.9-R0.1-SNAPSHOT)
https://streamable.com/zouy6