### PR TITLE
Don't add duplicate usernames to vanished player list

### DIFF
--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -715,7 +715,10 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 }
             }
             setHidden(true);
-            ess.getVanishedPlayers().add(getName());
+            List<String> vanishedPlayers = ess.getVanishedPlayers();
+            if (!vanishedPlayers.contains(getName())) {
+                vanishedPlayers.add(getName());
+            }
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, false));
             }


### PR DESCRIPTION
This should fix the long standing bug with vanish not working properly, by not adding players to the vanished player list more than once.

However, an **alternative** approach was outlined in #1764 ([here](https://github.com/EssentialsX/Essentials/issues/1764#issuecomment-357887279)):
> ...we could replace the list with a `Set` and deprecate the existing `getVanishedPlayers`, especially considering since there's no reason for plugins to directly mutate the `ess.vanishedPlayers` list instead of using the appropriate `User` method.

@drtshock @SupaHam Thoughts on this PR's approach versus the alternative approach described above?