### PR TITLE
cancel-afk-on-interact and cancel-afk-on-move are now separate settings

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
@@ -47,7 +47,7 @@ public class EssentialsEntityListener implements Listener {
                     event.setCancelled(true);
                 }
             }
-            attacker.updateActivity(true);
+            attacker.updateActivityOnInteract(true);
         } else if (eAttack instanceof Projectile && eDefend instanceof Player) {
             final Projectile projectile = (Projectile) event.getDamager();
             //This should return a ProjectileSource on 1.7.3 beta +
@@ -55,7 +55,7 @@ public class EssentialsEntityListener implements Listener {
             if (shooter instanceof Player) {
                 final User attacker = ess.getUser((Player) shooter);
                 onPlayerVsPlayerDamage(event, (Player) eDefend, attacker);
-                attacker.updateActivity(true);
+                attacker.updateActivityOnInteract(true);
             }
         }
     }
@@ -194,7 +194,7 @@ public class EssentialsEntityListener implements Listener {
         if (event.getEntity() instanceof Player) {
             final User user = ess.getUser((Player) event.getEntity());
             if (user.isAfk()) {
-                user.updateActivity(true);
+                user.updateActivityOnInteract(true);
             }
         }
     }

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -99,7 +99,7 @@ public class EssentialsPlayerListener implements Listener {
             }
         }
 
-        user.updateActivity(true);
+        user.updateActivityOnInteract(true);
         user.setDisplayNick();
     }
 
@@ -124,8 +124,8 @@ public class EssentialsPlayerListener implements Listener {
             final Location from = event.getFrom();
             final Location origTo = event.getTo();
             final Location to = origTo.clone();
-            if (ess.getSettings().cancelAfkOnMove() && origTo.getY() >= from.getBlockY() + 1) {
-                user.updateActivity(true);
+            if (origTo.getY() >= from.getBlockY() + 1) {
+                user.updateActivityOnMove(true);
                 return;
             }
             to.setX(from.getX());
@@ -138,12 +138,10 @@ public class EssentialsPlayerListener implements Listener {
             }
             return;
         }
-        if(ess.getSettings().cancelAfkOnMove()) {
             final Location afk = user.getAfkPosition();
             if (afk == null || !event.getTo().getWorld().equals(afk.getWorld()) || afk.distanceSquared(event.getTo()) > 9) {
-                user.updateActivity(true);
+                user.updateActivityOnMove(true);
             }
-        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
@@ -178,7 +176,7 @@ public class EssentialsPlayerListener implements Listener {
             }
         }
 
-        user.updateActivity(false);
+        user.updateActivityOnInteract(false);
         if (!user.isHidden()) {
             user.setLastLogout(System.currentTimeMillis());
         }
@@ -216,7 +214,7 @@ public class EssentialsPlayerListener implements Listener {
 
         final long currentTime = System.currentTimeMillis();
         dUser.checkMuteTimeout(currentTime);
-        dUser.updateActivity(false);
+        dUser.updateActivityOnInteract(false);
         dUser.stopTransaction();
 
         class DelayJoinTask implements Runnable {
@@ -487,7 +485,7 @@ public class EssentialsPlayerListener implements Listener {
         }
         final User user = ess.getUser(player);
         if (update) {
-            user.updateActivity(broadcast);
+            user.updateActivityOnInteract(broadcast);
         }
 
         if (ess.getSettings().isCommandCooldownsEnabled() && pluginCommand != null
@@ -610,9 +608,7 @@ public class EssentialsPlayerListener implements Listener {
                 }
                 break;
         }
-        if(ess.getSettings().cancelAfkOnInteract()) {
-            ess.getUser(event.getPlayer()).updateActivity(true);
-        }
+            ess.getUser(event.getPlayer()).updateActivityOnInteract(true);
     }
 
     // This method allows the /jump lock feature to work, allows teleporting while flying #EasterEgg
@@ -778,9 +774,7 @@ public class EssentialsPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerFishEvent(final PlayerFishEvent event) {
         final User user = ess.getUser(event.getPlayer());
-        if(ess.getSettings().cancelAfkOnInteract()) {
-            user.updateActivity(true);
-        }
+            user.updateActivityOnInteract(true);
     }
     
     private final class PlayerListenerPre1_12 implements Listener {

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -138,9 +138,11 @@ public class EssentialsPlayerListener implements Listener {
             }
             return;
         }
-        final Location afk = user.getAfkPosition();
-        if (afk == null || !event.getTo().getWorld().equals(afk.getWorld()) || afk.distanceSquared(event.getTo()) > 9) {
-            user.updateActivity(true);
+        if(ess.getSettings().cancelAfkOnMove()) {
+            final Location afk = user.getAfkPosition();
+            if (afk == null || !event.getTo().getWorld().equals(afk.getWorld()) || afk.distanceSquared(event.getTo()) > 9) {
+                user.updateActivity(true);
+            }
         }
     }
 
@@ -608,7 +610,9 @@ public class EssentialsPlayerListener implements Listener {
                 }
                 break;
         }
-        ess.getUser(event.getPlayer()).updateActivity(true);
+        if(ess.getSettings().cancelAfkOnInteract()) {
+            ess.getUser(event.getPlayer()).updateActivity(true);
+        }
     }
 
     // This method allows the /jump lock feature to work, allows teleporting while flying #EasterEgg
@@ -774,7 +778,9 @@ public class EssentialsPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerFishEvent(final PlayerFishEvent event) {
         final User user = ess.getUser(event.getPlayer());
-        user.updateActivity(true);
+        if(ess.getSettings().cancelAfkOnInteract()) {
+            user.updateActivity(true);
+        }
     }
     
     private final class PlayerListenerPre1_12 implements Listener {

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -489,7 +489,7 @@ public class Settings implements net.ess3.api.ISettings {
         disableItemPickupWhileAfk = _getDisableItemPickupWhileAfk();
         registerBackInListener = _registerBackInListener();
         cancelAfkOnInteract = _cancelAfkOnInteract();
-        cancelAfkOnMove = _cancelAfkOnMove() && cancelAfkOnInteract;
+        cancelAfkOnMove = _cancelAfkOnMove();
         getFreezeAfkPlayers = _getFreezeAfkPlayers();
         afkListName = _getAfkListName();
         isAfkListName = !afkListName.equalsIgnoreCase("none");

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -558,6 +558,18 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
         lastActivity = System.currentTimeMillis();
     }
 
+    public void updateActivityOnMove(final boolean broadcast) {
+        if(ess.getSettings().cancelAfkOnMove()) {
+            updateActivity(broadcast);
+        }
+    }
+
+    public void updateActivityOnInteract(final boolean broadcast) {
+        if(ess.getSettings().cancelAfkOnInteract()) {
+            updateActivity(broadcast);
+        }
+    }
+
     public void checkActivity() {
         // Graceful time before the first afk check call. 
         if (System.currentTimeMillis() - lastActivity <= 10000) {

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -545,7 +545,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
     }
 
     public void updateActivity(final boolean broadcast) {
-        if (isAfk() && ess.getSettings().cancelAfkOnInteract()) {
+        if (isAfk()) {
             setAfk(false);
             if (broadcast && !isHidden()) {
                 setDisplayNick();


### PR DESCRIPTION
I have updated how the configs `cancel-afk-on-interact` and `cancel-afk-on-move` work.

The settings check is now done on the code that will execute the method `updateActivity` instead if being in the method itself, this is to avoid creating a new method just for move updates or adding a new parameter to it.

This should help to fix the issue #1050 if you disable the `cancel-afk-on-interact` setting in the config.yml file.