### PR TITLE
Fixes #1794: Hides error message if no MOTD present

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -334,7 +334,7 @@ public class EssentialsPlayerListener implements Listener {
 
                     final IText input = tempInput;
 
-                    if (input != null && user.isAuthorized("essentials.motd")) {
+                    if (input != null && !input.getLines().isEmpty() && user.isAuthorized("essentials.motd")) {
                         final IText output = new KeywordReplacer(input, user.getSource(), ess);
                         final TextPager pager = new TextPager(output, true);
                         pager.showPage("1", null, "motd", user.getSource());

--- a/Essentials/src/com/earth2me/essentials/textreader/TextPager.java
+++ b/Essentials/src/com/earth2me/essentials/textreader/TextPager.java
@@ -72,7 +72,6 @@ public class TextPager {
                 int pages = end / 9 + (end % 9 > 0 ? 1 : 0);
                 if (page > pages) {
                     sender.sendMessage(tl("infoUnknownChapter"));
-
                     return;
                 }
                 if (!onePage && commandName != null) {

--- a/Essentials/src/com/earth2me/essentials/textreader/TextPager.java
+++ b/Essentials/src/com/earth2me/essentials/textreader/TextPager.java
@@ -71,9 +71,7 @@ public class TextPager {
 
                 int pages = end / 9 + (end % 9 > 0 ? 1 : 0);
                 if (page > pages) {
-                    if (pages != 0) {
-                        sender.sendMessage(tl("infoUnknownChapter"));
-                    }
+                    sender.sendMessage(tl("infoUnknownChapter"));
 
                     return;
                 }

--- a/Essentials/src/com/earth2me/essentials/textreader/TextPager.java
+++ b/Essentials/src/com/earth2me/essentials/textreader/TextPager.java
@@ -71,7 +71,10 @@ public class TextPager {
 
                 int pages = end / 9 + (end % 9 > 0 ? 1 : 0);
                 if (page > pages) {
-                    sender.sendMessage(tl("infoUnknownChapter"));
+                    if (pages != 0) {
+                        sender.sendMessage(tl("infoUnknownChapter"));
+                    }
+
                     return;
                 }
                 if (!onePage && commandName != null) {


### PR DESCRIPTION
Fixes #1794

An empty MOTD file would cause the user to be displayed the unknown page error message upon joining.

This PR proposes a fix that will check to make sure there are pages in the first place before displaying an error message.

~One concern I still have is that the `/motd` command will not output anything after this change, which I suppose could possibly be desirable, but at the same time, I feel like there should be some response to at least the command even if the user does not receive a message on join.~
