### PR TITLE
Add default toggle for confirm commands in config.yml

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -302,4 +302,8 @@ public interface ISettings extends IConf {
     int getMotdDelay();
 
     boolean isDirectHatAllowed();
+
+    List<String> getDefaultDisabledConfirmCommands();
+
+    boolean isConfirmCommandEnabledByDefault(String commandName);
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -532,6 +532,7 @@ public class Settings implements net.ess3.api.ISettings {
         npcsInBalanceRanking = _isNpcsInBalanceRanking();
         currencyFormat = _getCurrencyFormat();
         unprotectedSigns = _getUnprotectedSign();
+        defaultDisabledConfirmCommands = _getDefaultDisabledConfirmCommands();
     }
 
     private List<Integer> itemSpawnBl = new ArrayList<Integer>();
@@ -1417,5 +1418,25 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean isDirectHatAllowed() {
         return config.getBoolean("allow-direct-hat", true);
+    }
+
+    private List<String> defaultDisabledConfirmCommands;
+
+    private List<String> _getDefaultDisabledConfirmCommands() {
+        List<String> commands = config.getStringList("default-disabled-confirm-commands");
+        for (int i = 0; i < commands.size(); i++) {
+            commands.set(i, commands.get(i).toLowerCase());
+        }
+        return commands;
+    }
+
+    @Override
+    public List<String> getDefaultDisabledConfirmCommands() {
+        return defaultDisabledConfirmCommands;
+    }
+    
+    @Override
+    public boolean isConfirmCommandEnabledByDefault(String commandName) {
+        return !getDefaultDisabledConfirmCommands().contains(commandName.toLowerCase());
     }
 }

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -898,14 +898,14 @@ public abstract class UserData extends PlayerExtension implements IConf {
         save();
     }
 
-    private boolean confirmPay = false; // players deny pay confirmation by default
+    private Boolean confirmPay;
 
-    public boolean _getConfirmPay() {
-        return config.getBoolean("confirm-pay", false);
+    private Boolean _getConfirmPay() {
+        return (Boolean) config.get("confirm-pay");
     }
 
     public boolean isPromptingPayConfirm() {
-        return confirmPay;
+        return confirmPay != null ? confirmPay : ess.getSettings().isConfirmCommandEnabledByDefault("pay");
     }
 
     public void setPromptingPayConfirm(boolean prompt) {
@@ -914,14 +914,14 @@ public abstract class UserData extends PlayerExtension implements IConf {
         save();
     }
 
-    private boolean confirmClear = false; // players deny clear confirmation by default
+    private Boolean confirmClear;
 
-    public boolean _getConfirmClear() {
-        return config.getBoolean("confirm-clear", false);
+    private Boolean _getConfirmClear() {
+        return (Boolean) config.get("confirm-clear");
     }
 
     public boolean isPromptingClearConfirm() {
-        return confirmClear;
+        return confirmClear != null ? confirmClear : ess.getSettings().isConfirmCommandEnabledByDefault("clearinventory");
     }
 
     public void setPromptingClearConfirm(boolean prompt) {

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -516,6 +516,12 @@ allow-bulk-buy-sell: true
 # This has no effect if the MOTD command or permission are disabled.
 delay-motd: 0
 
+# A list of commands that should have their complementary confirm commands disabled by default.
+# This is empty by default, for the latest list of valid commands see the latest source config.yml.
+default-disabled-confirm-commands:
+#- pay
+#- clearinventory
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                   EssentialsHome                     | #


### PR DESCRIPTION
This PR introduces a config property that controls the default prompting state for commands that require confirmation.

`default-disabled-confirm-commands` is a list of command names that when present, the command will not ask for confirmation by default. Since this list is empty by default, it means all confirming commands will be on by default. In the case that a command is present in the list, a player may manually use the appropriate confirm command to enable the feature for themselves.

Aims to fix issues including: #1667 and #1801