### PR TITLE
Update to java 8

### DIFF
--- a/Essentials/pom.xml
+++ b/Essentials/pom.xml
@@ -26,6 +26,8 @@
                 <version>2.3.2</version>
                 <configuration>
                     <showDeprecation>false</showDeprecation>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This needs to be done at some point. Was hoping it could be now. Considering that Java 7 is EOL and Mojang themselves don't support Java 7 anymore, I think this is a change that should be merged.