### PR TITLE
Add sign color format to the configuration

### DIFF
--- a/Essentials/src/com/earth2me/essentials/signs/SignEnchant.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignEnchant.java
@@ -24,24 +24,24 @@ public class SignEnchant extends EssentialsSign {
         try {
             stack = sign.getLine(1).equals("*") || sign.getLine(1).equalsIgnoreCase("any") ? null : getItemStack(sign.getLine(1), 1, ess);
         } catch (SignException e) {
-            sign.setLine(1, "§c<item|any>");
+            sign.setLine(1, ChatColor.translateAlternateColorCodes('&', ess.getSettings().getErrorSignColor("<item|any>")));
             throw e;
         }
         final String[] enchantLevel = sign.getLine(2).split(":");
         if (enchantLevel.length != 2) {
-            sign.setLine(2, "§c<enchant>");
+            sign.setLine(2, ChatColor.translateAlternateColorCodes('&', ess.getSettings().getErrorSignColor("<enchant>")));
             throw new SignException(tl("invalidSignLine", 3));
         }
         final Enchantment enchantment = Enchantments.getByName(enchantLevel[0]);
         if (enchantment == null) {
-            sign.setLine(2, "§c<enchant>");
+            sign.setLine(2, ChatColor.translateAlternateColorCodes('&', ess.getSettings().getErrorSignColor("<enchant>")));
             throw new SignException(tl("enchantmentNotFound"));
         }
         int level;
         try {
             level = Integer.parseInt(enchantLevel[1]);
         } catch (NumberFormatException ex) {
-            sign.setLine(2, "§c<enchant>");
+            sign.setLine(2, ChatColor.translateAlternateColorCodes('&', ess.getSettings().getErrorSignColor("<enchant>")));
             throw new SignException(ex.getMessage(), ex);
         }
         final boolean allowUnsafe = ess.getSettings().allowUnsafeEnchantments() && player.isAuthorized("essentials.enchantments.allowunsafe") && player.isAuthorized("essentials.signs.enchant.allowunsafe");


### PR DESCRIPTION
This does not know if it's right, but this may be useful because the server owner can edit the sign color to show it in color. And the rest of the sign jar needs to do this.

_(I could not add more commit because I'm still looking for how.)_