### PR TITLE
Fixes #1866: Adds color formatting to /mail sendall

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -81,7 +81,8 @@ public class Commandmail extends EssentialsCommand {
             if (!user.isAuthorized("essentials.mail.sendall")) {
                 throw new Exception(tl("noPerm", "essentials.mail.sendall"));
             }
-            ess.runTaskAsynchronously(new SendAll(tl("mailFormat", user.getName(), FormatUtil.stripFormat(getFinalArg(args, 1)))));
+            ess.runTaskAsynchronously(new SendAll(tl("mailFormat", user.getName(),
+                    FormatUtil.formatMessage(user, "essentials.mail", StringUtil.sanitizeString(FormatUtil.stripFormat(getFinalArg(args, 1)))))));
             user.sendMessage(tl("mailSent"));
             return;
         }


### PR DESCRIPTION
**Issue synopsis - #1866**
The `/mail sendall` command did not allow users to use ampersand (`&`) formatted color codes in their messages. This is contrary to the `/mail send` command which does allow users to input said color codes.

**Proposed changes**
The same convention for sending a colored message as from `/mail send` is used in `/mail sendall`.

**Demo**
![2018-02-23_15 23 40](https://user-images.githubusercontent.com/5037004/36621602-b068a6f4-18ad-11e8-8cae-70d09daadbeb.jpeg)