### PR TITLE
Implement new versioning as per #1873

### DIFF
--- a/Essentials/pom.xml
+++ b/Essentials/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ess3</groupId>
         <artifactId>EssentialsXParent</artifactId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
     </parent>
 
     <artifactId>EssentialsX</artifactId>
@@ -19,6 +19,7 @@
     </licenses>
 
     <build>
+        <finalName>EssentialsX-${full.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -13,7 +13,7 @@
 
 # If you have problems join the Essentials help support channel: http://tiny.cc/EssentialsChat
 
-# Version ${project.version}-b${build.number}
+# Version ${full.version}
 
 # KITS ARE NOW IN THE kits.yml FILE
 

--- a/Essentials/src/items.csv
+++ b/Essentials/src/items.csv
@@ -1,4 +1,4 @@
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 #If you change this file, it will not be automatically updated after the next release.
 #item,id,metadata
 stone,1,0

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_cs.properties
+++ b/Essentials/src/messages_cs.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_da.properties
+++ b/Essentials/src/messages_da.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_de.properties
+++ b/Essentials/src/messages_de.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_es.properties
+++ b/Essentials/src/messages_es.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_et.properties
+++ b/Essentials/src/messages_et.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_fi.properties
+++ b/Essentials/src/messages_fi.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_fr.properties
+++ b/Essentials/src/messages_fr.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.com
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Début des traductions
 # EssentialsX a été traduit par la communauté française.

--- a/Essentials/src/messages_hu.properties
+++ b/Essentials/src/messages_hu.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by: montlikadani

--- a/Essentials/src/messages_it.properties
+++ b/Essentials/src/messages_it.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_ko.properties
+++ b/Essentials/src/messages_ko.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_lt.properties
+++ b/Essentials/src/messages_lt.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_nl.properties
+++ b/Essentials/src/messages_nl.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_pl.properties
+++ b/Essentials/src/messages_pl.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # Updated by RikoDEV

--- a/Essentials/src/messages_pt.properties
+++ b/Essentials/src/messages_pt.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_pt_BR.properties
+++ b/Essentials/src/messages_pt_BR.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_ro.properties
+++ b/Essentials/src/messages_ro.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_ru.properties
+++ b/Essentials/src/messages_ru.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_sv.properties
+++ b/Essentials/src/messages_sv.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_tr.properties
+++ b/Essentials/src/messages_tr.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_zh_HK.properties
+++ b/Essentials/src/messages_zh_HK.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/messages_zh_TW.properties
+++ b/Essentials/src/messages_zh_TW.properties
@@ -1,5 +1,5 @@
 #X-Generator: crowdin.net
-#version: ${project.version}-b${build.number}
+#version: ${full.version}
 # Single quotes have to be doubled: ''
 # Translations start here
 # by:

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -2,7 +2,7 @@
 name: Essentials
 main: com.earth2me.essentials.Essentials
 # Note to developers: This next line cannot change, or the automatic versioning system will break.
-version: ${project.version}-b${build.number}
+version: ${full.version}
 website: http://tiny.cc/EssentialsCommands
 description: Provides an essential, core set of commands for Bukkit.
 softdepend: [Vault]

--- a/EssentialsAntiBuild/pom.xml
+++ b/EssentialsAntiBuild/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ess3</groupId>
         <artifactId>EssentialsXParent</artifactId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
     </parent>
 
     <artifactId>EssentialsXAntiBuild</artifactId>
@@ -17,6 +17,10 @@
             <url>http://www.gnu.org/copyleft/gpl.html</url>
         </license>
     </licenses>
+
+    <build>
+        <finalName>EssentialsXAntiBuild-${full.version}</finalName>
+    </build>
 
     <dependencies>
         <dependency>

--- a/EssentialsAntiBuild/src/plugin.yml
+++ b/EssentialsAntiBuild/src/plugin.yml
@@ -2,7 +2,7 @@
 name: EssentialsAntiBuild
 main: com.earth2me.essentials.antibuild.EssentialsAntiBuild
 # Note to developers: This next line cannot change, or the automatic versioning system will break.
-version: ${project.version}-b${build.number}
+version: ${full.version}
 website: http://tiny.cc/EssentialsCommands
 description: Provides build protection.
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits, Iaccidentally]

--- a/EssentialsChat/pom.xml
+++ b/EssentialsChat/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ess3</groupId>
         <artifactId>EssentialsXParent</artifactId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
     </parent>
 
     <artifactId>EssentialsXChat</artifactId>
@@ -17,6 +17,10 @@
             <url>http://www.gnu.org/copyleft/gpl.html</url>
         </license>
     </licenses>
+
+    <build>
+        <finalName>EssentialsXChat-${full.version}</finalName>
+    </build>
 
     <dependencies>
         <dependency>

--- a/EssentialsChat/src/plugin.yml
+++ b/EssentialsChat/src/plugin.yml
@@ -2,7 +2,7 @@
 name: EssentialsChat
 main: com.earth2me.essentials.chat.EssentialsChat
 # Note to developers: This next line cannot change, or the automatic versioning system will break.
-version: ${project.version}-b${build.number}
+version: ${full.version}
 website: http://tiny.cc/EssentialsCommands
 description: Provides chat control features for Essentials.  Requires Permissions.
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits, md_5, Okamosy, Iaccidentally]

--- a/EssentialsGeoIP/pom.xml
+++ b/EssentialsGeoIP/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ess3</groupId>
         <artifactId>EssentialsXParent</artifactId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
     </parent>
 
     <artifactId>EssentialsXGeoIP</artifactId>
@@ -43,6 +43,7 @@
     </dependencies>
 
     <build>
+        <finalName>EssentialsXGeoIP-${full.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/EssentialsGeoIP/src/plugin.yml
+++ b/EssentialsGeoIP/src/plugin.yml
@@ -2,7 +2,7 @@
 name: EssentialsGeoIP
 main: com.earth2me.essentials.geoip.EssentialsGeoIP
 # Note to developers: This next line cannot change, or the automatic versioning system will break.
-version: ${project.version}-b${build.number}
+version: ${full.version}
 website: http://tiny.cc/EssentialsCommands
 description: Shows the country or city of a user on login and /whois.
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, kjiang]

--- a/EssentialsProtect/pom.xml
+++ b/EssentialsProtect/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ess3</groupId>
         <artifactId>EssentialsXParent</artifactId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
     </parent>
 
     <artifactId>EssentialsXProtect</artifactId>
@@ -17,6 +17,10 @@
             <url>http://www.gnu.org/copyleft/gpl.html</url>
         </license>
     </licenses>
+
+    <build>
+        <finalName>EssentialsXProtect-${full.version}</finalName>
+    </build>
 
     <dependencies>
         <dependency>

--- a/EssentialsProtect/src/plugin.yml
+++ b/EssentialsProtect/src/plugin.yml
@@ -2,7 +2,7 @@
 name: EssentialsProtect
 main: com.earth2me.essentials.protect.EssentialsProtect
 # Note to developers: This next line cannot change, or the automatic versioning system will break.
-version: ${project.version}-b${build.number}
+version: ${full.version}
 website: http://tiny.cc/EssentialsCommands
 description: Provides protection for various parts of the world.
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits]

--- a/EssentialsSpawn/pom.xml
+++ b/EssentialsSpawn/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ess3</groupId>
         <artifactId>EssentialsXParent</artifactId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
     </parent>
 
     <artifactId>EssentialsXSpawn</artifactId>
@@ -17,6 +17,10 @@
             <url>http://www.gnu.org/copyleft/gpl.html</url>
         </license>
     </licenses>
+
+    <build>
+        <finalName>EssentialsXSpawn-${full.version}</finalName>
+    </build>
 
     <dependencies>
         <dependency>

--- a/EssentialsSpawn/src/plugin.yml
+++ b/EssentialsSpawn/src/plugin.yml
@@ -2,7 +2,7 @@
 name: EssentialsSpawn
 main: com.earth2me.essentials.spawn.EssentialsSpawn
 # Note to developers: This next line cannot change, or the automatic versioning system will break.
-version: ${project.version}-b${build.number}
+version: ${full.version}
 website: http://tiny.cc/EssentialsCommands
 description: Provides spawn control commands, utilizing Essentials.
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits]

--- a/EssentialsXMPP/pom.xml
+++ b/EssentialsXMPP/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.ess3</groupId>
         <artifactId>EssentialsXParent</artifactId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
     </parent>
 
     <artifactId>EssentialsXXMPP</artifactId>
@@ -31,7 +31,10 @@
         </dependency>
     </dependencies>
 
+
+
     <build>
+        <finalName>EssentialsXXMPP-${full.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/EssentialsXMPP/src/plugin.yml
+++ b/EssentialsXMPP/src/plugin.yml
@@ -2,7 +2,7 @@
 name: EssentialsXMPP
 main: com.earth2me.essentials.xmpp.EssentialsXMPP
 # Note to developers: This next line cannot change, or the automatic versioning system will break.
-version: ${project.version}-b${build.number}
+version: ${full.version}
 website: http://ess.khhq.net/wiki/XMPP
 description: Provides xmpp communication.
 authors:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>net.ess3</groupId>
     <artifactId>EssentialsXParent</artifactId>
-    <version>2.0.1</version>
+    <version>2.15.0</version>
 
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -200,19 +200,11 @@
                     <replacements>
                         <replacement>
                             <token>TeamCity</token>
-                            <value>${build.number}</value>
-                        </replacement>
-                        <replacement>
-                            <token>GMBuildVer</token>
-                            <value>${GMVer}</value>
+                            <value>${full.version}</value>
                         </replacement>
                         <replacement>
                             <token>$${build.number}</token>
-                            <value>${build.number}</value>
-                        </replacement>
-                        <replacement>
-                            <token>$${GMVer}</token>
-                            <value>${GMVer}</value>
+                            <value>${full.version}</value>
                         </replacement>
                     </replacements>
                 </configuration>
@@ -250,6 +242,31 @@
                     <deployAtEnd>true</deployAtEnd>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <skipPoms>false</skipPoms>
+
+                    <runOnlyOnce>true</runOnlyOnce>
+                    <injectAllReactorProjects>true</injectAllReactorProjects>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+
+                    <gitDescribe>
+                        <tags>true</tags>
+                    </gitDescribe>
+                </configuration>
+
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -266,8 +283,14 @@
     </build>
 
     <properties>
-        <build.number>SNAPSHOT</build.number>
-        <GMVer>GMBuildVer</GMVer>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- The plugins' release version -->
+        <release.version>2.15.0</release.version>
+
+        <!-- The plugins' build number -->
+        <build.number>${git.closest.tag.commit.count}</build.number>
+
+        <full.version>${release.version}.${build.number}</full.version>
     </properties>
 </project>


### PR DESCRIPTION
Implements the new versioning as per @lucko's suggestions and the discussion on #1873, and bumps the EssentialsX version to 2.15.0. Also adds version-based naming to jar names.

The new versions are in the following format:
```
MAJOR.MINOR.PATCH.BUILD
```
...where `MAJOR` is always `2`, `MINOR` increments with feature releases as in semver (starting at 15 as to avoid conflicts with Essentials), `PATCH` is incremented as bugfix releases are pushed on Spigot and `BUILD` is the number of commits since the last tag. For example: `2.15.0.1` would be the first commit *after* the tag at `2.15.0`. This is independent of build servers, and still allows us to trace issues down to specific commits.

Note that this should only be merged when we're ready to jump to 2.15.0, as it also bumps the version, and it will not replace old jars in `target/` any more as they will have different jar names per commit.