### PR TITLE
Update issue template to match actual command

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,9 +27,10 @@ Otherwise, if you are reporting a bug, read on:
 
 ### Information
 
-EssentialsX version (run `/ess version`): 
+Full output of `/ess version`:
 
-Server software (run `/version`): 
+
+
 
 Server log (upload `logs/latest.log` to [Gist](https://gist.github.com/)):
 


### PR DESCRIPTION
Update the issue template to accommodate for the actual `/ess version` command's output.

Edited with web editor, hence PR.