### PR TITLE
Fix #1869

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
@@ -127,7 +127,7 @@ public class EssentialsEntityListener implements Listener {
         if (event.getCombuster() instanceof Arrow) {
             Arrow combuster = (Arrow) event.getCombuster();
             if (combuster.getShooter() instanceof Player) {
-                final User srcCombuster = ess.getUser(((Player) combuster.getShooter()).getUniqueId());
+                final User srcCombuster = ess.getUser(((Player) combuster.getShooter()).getName());
                 if (srcCombuster.isGodModeEnabled() && !srcCombuster.isAuthorized("essentials.god.pvp")) {
                     event.setCancelled(true);
                 }


### PR DESCRIPTION
Fix #1869 
```
 Caused by: java.lang.NullPointerException
         at com.earth2me.essentials.EssentialsEntityListener.onEntityCombustByEntity(EssentialsEntityListener.java:131) ~[?:?]
```