### PR TITLE
Avoid using ServerListPingEvent workaround on fixed Paper builds

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsServerListener.java
@@ -25,15 +25,20 @@ public class EssentialsServerListener implements Listener {
 
     public EssentialsServerListener(final IEssentials ess) {
         this.ess = ess;
-        setSampleText = ReflUtil.getMethodCached(ServerListPingEvent.class, "setSampleText", List.class);
-        getSampleText = ReflUtil.getMethodCached(ServerListPingEvent.class, "getSampleText");
-        if (setSampleText != null && getSampleText != null) {
-            ess.getLogger().info("Using Paper 1.12+ ServerListPingEvent methods");
-            isPaperSample = true;
-        } else {
-            ess.getLogger().info("Using Spigot 1.7.10+ ServerListPingEvent iterator");
-            isPaperSample = false;
+
+        if (ReflUtil.getClassCached("com.destroystokyo.paper.event.server.PaperServerListPingEvent") == null) {
+            // This workaround is only necessary for older Paper builds
+            setSampleText = ReflUtil.getMethodCached(ServerListPingEvent.class, "setSampleText", List.class);
+            getSampleText = ReflUtil.getMethodCached(ServerListPingEvent.class, "getSampleText");
+            if (setSampleText != null && getSampleText != null) {
+                ess.getLogger().info("Using Paper 1.12+ ServerListPingEvent methods");
+                isPaperSample = true;
+                return;
+            }
         }
+
+        ess.getLogger().info("Using Spigot 1.7.10+ ServerListPingEvent iterator");
+        isPaperSample = false;
     }
 
     @EventHandler(priority = EventPriority.LOWEST)


### PR DESCRIPTION
Fixes #1924

PaperMC/Paper#884 has been fixed in recent Paper builds (1368+), which means the workaround is no longer necessary. Disable it when running a fixed build.