### PR TITLE
Add disable-eco boolean to configuration

### DIFF
--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -566,6 +566,10 @@ allow-direct-hat: true
 
 # For more information, visit http://wiki.ess3.net/wiki/Essentials_Economy
 
+# Setting to true will completely disable eco operations for Essentials.
+# This might have weird effects and we recommend leaving this to false.
+#disable-eco: false
+
 # Defines the balance with which new players begin. Defaults to 0.
 starting-balance: 0
 


### PR DESCRIPTION
Very old:
https://github.com/EssentialsX/Essentials/commit/dd65a1e76c6cc07aead41ebefe90b156e7163234

**Why do not these old features be entered into the configuration? You may just need a user.**

https://github.com/EssentialsX/Essentials/blob/cf9c9f707324826b0d1468a24ca42362ab2959bf/Essentials/src/com/earth2me/essentials/Settings.java#L644