### PR TITLE
Allow updating the compass target to be optional

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -350,7 +350,10 @@ public class EssentialsPlayerListener implements Listener {
     }
 
     // Makes the compass item ingame always point to the first essentials home.  #EasterEgg
+    // EssentialsX: This can now optionally require a permission to enable, if set in the config.
     private void updateCompass(final User user) {
+        if (ess.getSettings().isCompassTowardsHomePerm() && !user.isAuthorized("essentials.home.compass")) return;
+
         Location loc = user.getHome(user.getLocation());
         if (loc == null) {
             loc = user.getBase().getBedSpawnLocation();

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -306,4 +306,6 @@ public interface ISettings extends IConf {
     List<String> getDefaultEnabledConfirmCommands();
 
     boolean isConfirmCommandEnabledByDefault(String commandName);
+
+    boolean isCompassTowardsHomePerm();
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -533,6 +533,7 @@ public class Settings implements net.ess3.api.ISettings {
         currencyFormat = _getCurrencyFormat();
         unprotectedSigns = _getUnprotectedSign();
         defaultEnabledConfirmCommands = _getDefaultEnabledConfirmCommands();
+        isCompassTowardsHomePerm = _isCompassTowardsHomePerm();
     }
 
     private List<Integer> itemSpawnBl = new ArrayList<Integer>();
@@ -1438,5 +1439,16 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean isConfirmCommandEnabledByDefault(String commandName) {
         return getDefaultEnabledConfirmCommands().contains(commandName.toLowerCase());
+    }
+
+    private boolean isCompassTowardsHomePerm;
+
+    private boolean _isCompassTowardsHomePerm() {
+        return config.getBoolean("compass-towards-home-perm", false);
+    }
+
+    @Override
+    public boolean isCompassTowardsHomePerm() {
+        return isCompassTowardsHomePerm;
     }
 }

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -522,6 +522,13 @@ default-enabled-confirm-commands:
 #- pay
 #- clearinventory
 
+# Set the timeout, in seconds for players to accept a tpa before the request is cancelled.
+# Set to 0 for no timeout.
+tpa-accept-cancellation: 120
+
+# Allow players to set hats by clicking on their helmet slot.
+allow-direct-hat: true
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                   EssentialsHome                     | #
@@ -551,12 +558,12 @@ sethome-multiple:
 # In this example someone with 'essentials.sethome.multiple' and 'essentials.sethome.multiple.vip' will have 5 homes.
 # Remember, they MUST have both permission nodes in order to be able to set multiple homes.
 
-# Set the timeout, in seconds for players to accept a tpa before the request is cancelled.
-# Set to 0 for no timeout.
-tpa-accept-cancellation: 120
-
-# Allow players to set hats by clicking on their helmet slot.
-allow-direct-hat: true
+# Controls whether players need the permission "essentials.home.compass" in order to point
+# the player's compass at their first home.
+#
+# Leaving this as false will retain Essentials' original behaviour, which is to always
+# change the compass' direction to point towards their first home.
+compass-towards-home-perm: false
 
 ############################################################
 # +------------------------------------------------------+ #


### PR DESCRIPTION
If `compass-towards-home-perm` is enabled in the EssentialsX config, then the permission `essentials.home.compass` is checked before changing the player's compass target.

Closes #1918.