### PR TITLE
[Feature] Add world specific /back dest. perms

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -60,6 +60,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.event.world.WorldUnloadEvent;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.InvalidDescriptionException;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
@@ -245,6 +247,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
             Economy.setEss(this);
             execTimer.mark("RegHandler");
+
+            for (World w : Bukkit.getWorlds())
+                addDefaultBackPermissionsToWorld(w);
 
             metrics = new Metrics(this);
             if (!metrics.isOptOut()) {
@@ -867,6 +872,18 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
         return potionMetaProvider;
     }
 
+    private static void addDefaultBackPermissionsToWorld(World w) {
+        String permName = "essentials.back.into." + w.getName();
+
+        Permission p = Bukkit.getPluginManager().getPermission(permName);
+        if (p == null) {
+            p = new Permission(permName,
+                    "Allows access to /back when the destination location is within world " + w.getName(),
+                    PermissionDefault.TRUE);
+            Bukkit.getPluginManager().addPermission(p);
+        }
+    }
+
     private static class EssentialsWorldListener implements Listener, Runnable {
         private transient final IEssentials ess;
 
@@ -876,6 +893,8 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
         @EventHandler(priority = EventPriority.LOW)
         public void onWorldLoad(final WorldLoadEvent event) {
+            addDefaultBackPermissionsToWorld(event.getWorld());
+
             ess.getJails().onReload();
             ess.getWarps().reloadConfig();
             for (IConf iConf : ((Essentials) ess).confList) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandback.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandback.java
@@ -17,9 +17,17 @@ public class Commandback extends EssentialsCommand {
         if (user.getLastLocation() == null) {
             throw new Exception(tl("noLocationFound"));
         }
-        if (user.getWorld() != user.getLastLocation().getWorld() && ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + user.getLastLocation().getWorld().getName())) {
-            throw new Exception(tl("noPerm", "essentials.worlds." + user.getLastLocation().getWorld().getName()));
+
+        String lastWorldName = user.getLastLocation().getWorld().getName();
+
+        if (user.getWorld() != user.getLastLocation().getWorld() && ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + lastWorldName)) {
+            throw new Exception(tl("noPerm", "essentials.worlds." + lastWorldName));
         }
+
+        if (!user.isAuthorized("essentials.back.into." + lastWorldName)) {
+            throw new Exception(tl("noPerm", "essentials.back.into." + lastWorldName));
+        }
+
         final Trade charge = new Trade(this.getName(), ess);
         charge.isAffordableFor(user);
         user.getTeleport().back(charge);


### PR DESCRIPTION
Adds world specific perms for whether a player may use /back to teleport
back to a given world. Adds logic to default
essentials.back.into.<world> permissions for loaded worlds to true to
maintain backwards compatibility.