### PR TITLE
Block ignite only for PvP, not for PvE

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
@@ -124,7 +124,7 @@ public class EssentialsEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onEntityCombustByEntity(final EntityCombustByEntityEvent event) {
-        if (event.getCombuster() instanceof Arrow) {
+        if (event.getCombuster() instanceof Arrow && event.getEntity() instanceof Player) {
             Arrow combuster = (Arrow) event.getCombuster();
             if (combuster.getShooter() instanceof Player) {
                 final User srcCombuster = ess.getUser(((Player) combuster.getShooter()).getUniqueId());


### PR DESCRIPTION
Players with god mode enabled could not ignite (non player) mobs with bows while only igniting other players should be blocked.