### PR TITLE
Fix versioning of NMS modules

### DIFF
--- a/Essentials/pom.xml
+++ b/Essentials/pom.xml
@@ -83,19 +83,19 @@
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>NMSProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>UpdatedMetaProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>1_8_R1Provider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>1_8_R2Provider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -119,13 +119,13 @@
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>LegacyProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>ReflectionProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/nms/1_8_R1Provider/pom.xml
+++ b/nms/1_8_R1Provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>EssentialsXParent</artifactId>
         <groupId>net.ess3</groupId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>NMSProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/nms/1_8_R2Provider/pom.xml
+++ b/nms/1_8_R2Provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>EssentialsXParent</artifactId>
         <groupId>net.ess3</groupId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>NMSProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/nms/LegacyProvider/pom.xml
+++ b/nms/LegacyProvider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>EssentialsXParent</artifactId>
         <groupId>net.ess3</groupId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>NMSProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/nms/NMSProvider/pom.xml
+++ b/nms/NMSProvider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>EssentialsXParent</artifactId>
         <groupId>net.ess3</groupId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/nms/ReflectionProvider/pom.xml
+++ b/nms/ReflectionProvider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>EssentialsXParent</artifactId>
         <groupId>net.ess3</groupId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -23,7 +23,7 @@
          <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>NMSProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/nms/UpdatedMetaProvider/pom.xml
+++ b/nms/UpdatedMetaProvider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>EssentialsXParent</artifactId>
         <groupId>net.ess3</groupId>
-        <version>2.0.1</version>
+        <version>2.15.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>NMSProvider</artifactId>
-            <version>2.0.1</version>
+            <version>2.15.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Resolves numerous build errors that emerged in 613e852ffd828b85b7e3fdbcb06be3c6cfdce3c5 and for some reason didn't cause a build error on ender.zone, but did everywhere else.

Fixes #1970.