### PR TITLE
Fixed did not send the message when you typed the command

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandantioch.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandantioch.java
@@ -14,7 +14,7 @@ public class Commandantioch extends EssentialsCommand {
 
     @Override
     public void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
-        if (args.length > 0) {
+        if (args.length < 0) {
             ess.broadcastMessage(user, "...lobbest thou thy Holy Hand Grenade of Antioch towards thy foe,");
             ess.broadcastMessage(user, "who being naughty in My sight, shall snuff it.");
         }


### PR DESCRIPTION
As it is in the title when the player entered the `/antioch` command, he did not send the message unless he had written anything in argument 1.