### PR TITLE
Fixed jail not found

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commanddeljail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddeljail.java
@@ -19,6 +19,10 @@ public class Commanddeljail extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
 
+        if (ess.getJails().getJail(args[0]) == null) {
+            throw new Exception(tl("jailNotExist"));
+        }
+
         ess.getJails().removeJail(args[0]);
         sender.sendMessage(tl("deleteJail", args[0]));
     }


### PR DESCRIPTION
When the user entered a word to delete the jail, deleted it, but removed anything because no jail existed.