### PR TITLE
Ensures that confirm-clear is set to false once a player logs in

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -309,6 +309,8 @@ public class EssentialsPlayerListener implements Listener {
                     ess.getLogger().log(Level.INFO, "Set god mode to false for {0} because they had it enabled without permission.", user.getName());
                 }
 
+                user.setPromptingClearConfirm(false);
+
                 user.stopTransaction();
             }
 

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -309,7 +309,7 @@ public class EssentialsPlayerListener implements Listener {
                     ess.getLogger().log(Level.INFO, "Set god mode to false for {0} because they had it enabled without permission.", user.getName());
                 }
 
-                user.setPromptingClearConfirm(false);
+                user.setConfirmingClearCommand(null);
 
                 user.stopTransaction();
             }

--- a/Essentials/src/com/earth2me/essentials/commands/Commanddown.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddown.java
@@ -1,0 +1,34 @@
+package com.earth2me.essentials.commands;
+
+import com.earth2me.essentials.Trade;
+import com.earth2me.essentials.User;
+import com.earth2me.essentials.utils.LocationUtil;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+import static com.earth2me.essentials.I18n.tl;
+
+public class Commanddown extends EssentialsCommand {
+    public Commanddown() {
+        super("down");
+    }
+
+    @Override
+    public void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
+        final int topX = user.getLocation().getBlockX();
+        final int topZ = user.getLocation().getBlockZ();
+        final float pitch = user.getLocation().getPitch();
+        final float yaw = user.getLocation().getYaw();
+
+        for (int y = user.getLocation().getBlockY() - 3; y > 0; y--) {
+            if (!LocationUtil.isBlockUnsafe(user.getWorld(), topX, y, topZ)) {
+                Location loc = new Location(user.getWorld(), topX, y, topZ, yaw, pitch);
+                user.getTeleport().teleport(loc, new Trade(this.getName(), ess), PlayerTeleportEvent.TeleportCause.COMMAND);
+                user.sendMessage(tl("teleportDown", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
+                return;
+            }
+        }
+
+    }
+}

--- a/Essentials/src/com/earth2me/essentials/commands/Commanddown.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddown.java
@@ -21,14 +21,16 @@ public class Commanddown extends EssentialsCommand {
         final float pitch = user.getLocation().getPitch();
         final float yaw = user.getLocation().getYaw();
 
+        Location loc = user.getLocation();
         for (int y = user.getLocation().getBlockY() - 3; y > 0; y--) {
             if (!LocationUtil.isBlockUnsafe(user.getWorld(), topX, y, topZ)) {
-                Location loc = new Location(user.getWorld(), topX, y, topZ, yaw, pitch);
-                user.getTeleport().teleport(loc, new Trade(this.getName(), ess), PlayerTeleportEvent.TeleportCause.COMMAND);
-                user.sendMessage(tl("teleportDown", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
-                return;
+                loc = new Location(user.getWorld(), topX, y, topZ, yaw, pitch);
+                break;
             }
         }
+
+        user.getTeleport().teleport(loc, new Trade(this.getName(), ess), PlayerTeleportEvent.TeleportCause.COMMAND);
+        user.sendMessage(tl("teleportDown", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
 
     }
 }

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -497,6 +497,7 @@ teleportationEnabled=\u00a76Teleportation \u00a7cenabled\u00a76.
 teleportationEnabledFor=\u00a76Teleportation \u00a7cenabled \u00a76for \u00a7c{0}\u00a76.
 teleportAtoB=\u00a7c{0}\u00a76 teleported you to \u00a7c{1}\u00a76.
 teleportDisabled=\u00a7c{0} \u00a74has teleportation disabled.
+teleportDown=\u00a76Teleporting down.
 teleportHereRequest=\u00a7c{0}\u00a76 has requested that you teleport to them.
 teleporting=\u00a76Teleporting...
 teleportInvalidLocation=Value of coordinates cannot be over 30000000

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -497,6 +497,7 @@ teleportationEnabled=\u00a76Teleportation \u00a7cenabled\u00a76.
 teleportationEnabledFor=\u00a76Teleportation \u00a7cenabled \u00a76for \u00a7c{0}\u00a76.
 teleportAtoB=\u00a7c{0}\u00a76 teleported you to \u00a7c{1}\u00a76.
 teleportDisabled=\u00a7c{0} \u00a74has teleportation disabled.
+teleportDown=\u00a76Teleporting down.
 teleportHereRequest=\u00a7c{0}\u00a76 has requested that you teleport to them.
 teleporting=\u00a76Teleporting...
 teleportInvalidLocation=Value of coordinates cannot be over 30000000

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -420,9 +420,9 @@ commands:
     usage: /<command>
     aliases: [etop]
   down:
-      description: Teleport to the highest block at your current position.
-      usage: /<down>
-      aliases: [edown]
+    description: Teleport to the highest block at your current position.
+    usage: /<down>
+    aliases: [edown]
   tp:
     description: Teleport to a player.
     usage: /<command> <player> [otherplayer]

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -107,6 +107,10 @@ commands:
     description: Opens a portable disposal menu.
     usage: /<command>
     aliases: [edisposal,trash,etrash]
+  down:
+    description: Teleport to first available block below you at your current location.
+    usage: /<down>
+    aliases: [edown]
   eco:
     description: Manages the server economy.
     usage: /<command> <give|take|set|reset> <player> <amount>
@@ -419,10 +423,6 @@ commands:
     description: Teleport to the highest block at your current position.
     usage: /<command>
     aliases: [etop]
-  down:
-    description: Teleport to the highest block at your current position.
-    usage: /<down>
-    aliases: [edown]
   tp:
     description: Teleport to a player.
     usage: /<command> <player> [otherplayer]

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -419,6 +419,10 @@ commands:
     description: Teleport to the highest block at your current position.
     usage: /<command>
     aliases: [etop]
+  down:
+      description: Teleport to the highest block at your current position.
+      usage: /<down>
+      aliases: [edown]
   tp:
     description: Teleport to a player.
     usage: /<command> <player> [otherplayer]


### PR DESCRIPTION
As pointed out in issue [#2021](url), the confirmation prompt for /clearinventory persists across logins, meaning that if a player issues the /clearinventory command after logging in when having issued it before logging out of a previous session, they will not be prompted for confirmation. This sets the value of confirm-clear to false as the player signs in to fix this issue.