### PR TITLE
Wrap constructScalar for SnakeYAML 1.21

### DIFF
--- a/Essentials/src/com/earth2me/essentials/storage/BukkitConstructor.java
+++ b/Essentials/src/com/earth2me/essentials/storage/BukkitConstructor.java
@@ -13,6 +13,8 @@ import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.*;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Locale;
 
 
@@ -32,10 +34,30 @@ public class BukkitConstructor extends CustomClassLoaderConstructor {
 
 
     private class ConstructBukkitScalar extends ConstructScalar {
+
+        private Method constructScalarMethod = null;
+        
+        protected String constructScalarRefl(ScalarNode scalarNode) {
+            try {
+                if (constructScalarMethod == null) {
+                    constructScalarMethod = ConstructScalar.class.getMethod("constructScalar", ScalarNode.class);
+                }
+                return (String) constructScalarMethod.invoke(this, scalarNode);
+            } catch (NoSuchMethodException 
+                    | SecurityException 
+                    | IllegalAccessException 
+                    | IllegalArgumentException 
+                    | InvocationTargetException e) {
+                e.printStackTrace();
+			}
+            
+            return null;
+        }
+
         @Override
         public Object construct(final Node node) {
             if (node.getType().equals(Material.class)) {
-                final String val = (String) constructScalar((ScalarNode) node);
+                final String val = constructScalarRefl((ScalarNode) node);
                 Material mat;
                 if (NumberUtil.isInt(val)) {
                     final int typeId = Integer.parseInt(val);
@@ -46,7 +68,7 @@ public class BukkitConstructor extends CustomClassLoaderConstructor {
                 return mat;
             }
             if (node.getType().equals(MaterialData.class)) {
-                final String val = (String) constructScalar((ScalarNode) node);
+                final String val = constructScalarRefl((ScalarNode) node);
                 if (val.isEmpty()) {
                     return null;
                 }
@@ -71,7 +93,7 @@ public class BukkitConstructor extends CustomClassLoaderConstructor {
                 return new MaterialData(mat, data);
             }
             if (node.getType().equals(ItemStack.class)) {
-                final String val = (String) constructScalar((ScalarNode) node);
+                final String val = constructScalarRefl((ScalarNode) node);
                 if (val.isEmpty()) {
                     return null;
                 }
@@ -134,7 +156,7 @@ public class BukkitConstructor extends CustomClassLoaderConstructor {
                 return stack;
             }
             if (node.getType().equals(EnchantmentLevel.class)) {
-                final String val = (String) constructScalar((ScalarNode) node);
+                final String val = constructScalarRefl((ScalarNode) node);
                 if (val.isEmpty()) {
                     return null;
                 }


### PR DESCRIPTION
In theory, fixes #1974, fixes #1975 and fixes #1976. Primarily this means that Spigot should be free to upgrade SnakeYAML to 1.21 again when ready.