### PR TITLE
Add PlaceholderAPI support

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -153,8 +153,8 @@ public class EssentialsPlayerListener implements Listener {
             event.setQuitMessage(null);
         } else if (ess.getSettings().isCustomQuitMessage() && event.getQuitMessage() != null) {
             final Player player = event.getPlayer();
-            String quitMessage = ess.getSettings().getCustomQuitMessage();
-            quitMessage.replace("{PLAYER}", player.getDisplayName())
+            String quitMessage = ess.getSettings().getCustomQuitMessage()
+                    .replace("{PLAYER}", player.getDisplayName())
                     .replace("{USERNAME}", player.getName());
             //Untested, should work tho
             quitMessage = FormatUtil.placeholderAPIFormat(user, quitMessage);

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -5,6 +5,7 @@ import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.textreader.TextInput;
 import com.earth2me.essentials.textreader.TextPager;
 import com.earth2me.essentials.utils.DateUtil;
+import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.LocationUtil;
 import net.ess3.api.IEssentials;
 import net.ess3.nms.refl.ReflUtil;
@@ -152,7 +153,11 @@ public class EssentialsPlayerListener implements Listener {
             event.setQuitMessage(null);
         } else if (ess.getSettings().isCustomQuitMessage() && event.getQuitMessage() != null) {
             final Player player = event.getPlayer();
-            event.setQuitMessage(ess.getSettings().getCustomQuitMessage().replace("{PLAYER}", player.getDisplayName()).replace("{USERNAME}", player.getName()));
+            String quitMessage = ess.getSettings().getCustomQuitMessage();
+            quitMessage.replace("{PLAYER}", player.getDisplayName())
+                    .replace("{USERNAME}", player.getName());
+            quitMessage = FormatUtil.placeholderAPIFormat(user, quitMessage);
+            event.setQuitMessage(quitMessage);
         }
 
         user.startTransaction();

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -264,6 +264,7 @@ public class EssentialsPlayerListener implements Listener {
                     String msg = ess.getSettings().getCustomJoinMessage()
                         .replace("{PLAYER}", player.getDisplayName()).replace("{USERNAME}", player.getName())
                         .replace("{UNIQUE}", NumberFormat.getInstance().format(ess.getUserMap().getUniqueUsers()));
+                    msg = FormatUtil.placeholderAPIFormat(player, msg);
                     ess.getServer().broadcastMessage(msg);
                 } else if (ess.getSettings().allowSilentJoinQuit()) {
                     ess.getServer().broadcastMessage(message);

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -156,6 +156,7 @@ public class EssentialsPlayerListener implements Listener {
             String quitMessage = ess.getSettings().getCustomQuitMessage();
             quitMessage.replace("{PLAYER}", player.getDisplayName())
                     .replace("{USERNAME}", player.getName());
+            //Untested, should work tho
             quitMessage = FormatUtil.placeholderAPIFormat(user, quitMessage);
             event.setQuitMessage(quitMessage);
         }
@@ -261,6 +262,7 @@ public class EssentialsPlayerListener implements Listener {
                 } else if (message == null) {
                     //NOOP
                 } else if (ess.getSettings().isCustomJoinMessage()) {
+                    //Untested, should work tho
                     String msg = ess.getSettings().getCustomJoinMessage()
                         .replace("{PLAYER}", player.getDisplayName()).replace("{USERNAME}", player.getName())
                         .replace("{UNIQUE}", NumberFormat.getInstance().format(ess.getUserMap().getUniqueUsers()));

--- a/Essentials/src/com/earth2me/essentials/EssentialsPluginListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPluginListener.java
@@ -1,7 +1,9 @@
 package com.earth2me.essentials;
 
 import com.earth2me.essentials.register.payment.Methods;
+import com.earth2me.essentials.utils.FormatUtil;
 import net.ess3.api.IEssentials;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -29,6 +31,10 @@ public class EssentialsPluginListener implements Listener, IConf {
         if (!Methods.hasMethod() && Methods.setMethod(ess.getServer().getPluginManager())) {
             ess.getLogger().log(Level.INFO, "Payment method found (" + Methods.getMethod().getLongName() + " version: " + ess.getPaymentMethod().getMethod().getVersion() + ")");
         }
+
+        if(!FormatUtil.papiEnabled && event.getPlugin().getName().equals("PlaceholderAPI")) {
+            FormatUtil.papiEnabled = true;
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -41,6 +47,10 @@ public class EssentialsPluginListener implements Listener, IConf {
         if (ess.getPaymentMethod() != null && Methods.hasMethod() && Methods.checkDisabled(event.getPlugin())) {
             Methods.reset();
             ess.getLogger().log(Level.INFO, "Payment method was disabled. No longer accepting payments.");
+        }
+
+        if(FormatUtil.papiEnabled && event.getPlugin().getName().equals("PlaceholderAPI")){
+            FormatUtil.papiEnabled = false;
         }
     }
 

--- a/Essentials/src/com/earth2me/essentials/EssentialsPluginListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPluginListener.java
@@ -32,7 +32,7 @@ public class EssentialsPluginListener implements Listener, IConf {
             ess.getLogger().log(Level.INFO, "Payment method found (" + Methods.getMethod().getLongName() + " version: " + ess.getPaymentMethod().getMethod().getVersion() + ")");
         }
 
-        if(!FormatUtil.papiEnabled && event.getPlugin().getName().equals("PlaceholderAPI")) {
+        if((FormatUtil.papiEnabled == null || !FormatUtil.papiEnabled) && event.getPlugin().getName().equals("PlaceholderAPI")) {
             FormatUtil.papiEnabled = true;
         }
     }
@@ -49,7 +49,7 @@ public class EssentialsPluginListener implements Listener, IConf {
             ess.getLogger().log(Level.INFO, "Payment method was disabled. No longer accepting payments.");
         }
 
-        if(FormatUtil.papiEnabled && event.getPlugin().getName().equals("PlaceholderAPI")){
+        if(FormatUtil.papiEnabled != null && FormatUtil.papiEnabled && event.getPlugin().getName().equals("PlaceholderAPI")){
             FormatUtil.papiEnabled = false;
         }
     }

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -784,6 +784,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
     @Override
     public void sendMessage(String message) {
         if (!message.isEmpty()) {
+            message = FormatUtil.placeholderAPIFormat(this, message);
             base.sendMessage(message);
         }
     }

--- a/Essentials/src/com/earth2me/essentials/textreader/KeywordReplacer.java
+++ b/Essentials/src/com/earth2me/essentials/textreader/KeywordReplacer.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.PlayerList;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.DescParseTickFormat;
+import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.NumberUtil;
 import net.ess3.api.IEssentials;
 import org.bukkit.Location;
@@ -74,6 +75,7 @@ public class KeywordReplacer implements IText {
 
         for (int i = 0; i < input.getLines().size(); i++) {
             String line = input.getLines().get(i);
+            line = FormatUtil.placeholderAPIFormat(user, line);
             final Matcher matcher = KEYWORD.matcher(line);
 
             while (matcher.find()) {

--- a/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
@@ -25,6 +25,8 @@ public class FormatUtil {
     static final transient Pattern URL_PATTERN = Pattern.compile("((?:(?:https?)://)?[\\w-_\\.]{2,})\\.([a-zA-Z]{2,3}(?:/\\S+)?)");
     public static final Pattern IPPATTERN = Pattern.compile("^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
 
+    static Boolean papiEnabled = null;
+
     //This method is used to simply strip the native minecraft colour codes
     public static String stripFormat(final String input) {
         if (input == null) {
@@ -44,13 +46,18 @@ public class FormatUtil {
     //Formatting PlaceholderAPI Placeholders, returns the original string if the plugin isn't enabled
     //Seperate this from #getChatFormat() in ISettings due to the requirement of Player as an argurment
     public static String placeholderAPIFormat(final IUser user, final String input){
-        if(input == null) {
+        if (input == null) {
             return null;
         }
 
         Player player = user.getBase();
+
+        if (papiEnabled == null) {
+            papiEnabled = Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI");
+        }
+
         //Checking here instead, please tell me if there is a better way
-        if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+        if (papiEnabled) {
             return PlaceholderAPI.setPlaceholders(player, input);
         }
         return input;

--- a/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
@@ -26,7 +26,7 @@ public class FormatUtil {
     public static final Pattern IPPATTERN = Pattern.compile("^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
 
     //If we are going to make this static, should we move it?
-    public static Boolean papiEnabled = false;
+    public static Boolean papiEnabled = null;
 
     //This method is used to simply strip the native minecraft colour codes
     public static String stripFormat(final String input) {

--- a/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
@@ -43,14 +43,16 @@ public class FormatUtil {
         return stripColor(input, REPLACE_ALL_PATTERN);
     }
 
+    public static String placeholderAPIFormat(final IUser user, final String input) {
+        return placeholderAPIFormat(user.getBase(), input);
+    }
+
     //Formatting PlaceholderAPI Placeholders, returns the original string if the plugin isn't enabled
-    //Seperate this from #getChatFormat() in ISettings due to the requirement of Player as an argurment
-    public static String placeholderAPIFormat(final IUser user, final String input){
+    //Seperate this from #getChatFormat() in ISettings due to the requirement of Player as an argument
+    public static String placeholderAPIFormat(final Player player, final String input) {
         if (input == null) {
             return null;
         }
-
-        Player player = user.getBase();
 
         if (papiEnabled == null) {
             papiEnabled = Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI");

--- a/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
@@ -25,7 +25,8 @@ public class FormatUtil {
     static final transient Pattern URL_PATTERN = Pattern.compile("((?:(?:https?)://)?[\\w-_\\.]{2,})\\.([a-zA-Z]{2,3}(?:/\\S+)?)");
     public static final Pattern IPPATTERN = Pattern.compile("^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
 
-    static Boolean papiEnabled = null;
+    //If we are going to make this static, should we move it?
+    public static Boolean papiEnabled = null;
 
     //This method is used to simply strip the native minecraft colour codes
     public static String stripFormat(final String input) {

--- a/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
@@ -26,7 +26,7 @@ public class FormatUtil {
     public static final Pattern IPPATTERN = Pattern.compile("^([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\.([01]?\\d\\d?|2[0-4]\\d|25[0-5])$");
 
     //If we are going to make this static, should we move it?
-    public static Boolean papiEnabled = null;
+    public static Boolean papiEnabled = false;
 
     //This method is used to simply strip the native minecraft colour codes
     public static String stripFormat(final String input) {

--- a/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/FormatUtil.java
@@ -1,7 +1,10 @@
 package com.earth2me.essentials.utils;
 
+import me.clip.placeholderapi.PlaceholderAPI;
 import net.ess3.api.IUser;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
 
 import java.util.regex.Pattern;
 
@@ -36,6 +39,21 @@ public class FormatUtil {
             return null;
         }
         return stripColor(input, REPLACE_ALL_PATTERN);
+    }
+
+    //Formatting PlaceholderAPI Placeholders, returns the original string if the plugin isn't enabled
+    //Seperate this from #getChatFormat() in ISettings due to the requirement of Player as an argurment
+    public static String placeholderAPIFormat(final IUser user, final String input){
+        if(input == null) {
+            return null;
+        }
+
+        Player player = user.getBase();
+        //Checking here instead, please tell me if there is a better way
+        if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            return PlaceholderAPI.setPlaceholders(player, input);
+        }
+        return input;
     }
 
     //This is the general permission sensitive message format function, checks for urls.

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -5,7 +5,7 @@ main: com.earth2me.essentials.Essentials
 version: ${full.version}
 website: http://tiny.cc/EssentialsCommands
 description: Provides an essential, core set of commands for Bukkit.
-softdepend: [Vault]
+softdepend: [Vault, PlaceholderAPI]
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits, md_5, Iaccidentally, drtshock, vemacs, SupaHam, md678685]
 commands:
   afk:

--- a/Essentials/test/com/earth2me/essentials/FakeServer.java
+++ b/Essentials/test/com/earth2me/essentials/FakeServer.java
@@ -989,7 +989,7 @@ public class FakeServer implements Server {
 
         @Override
         public boolean isPluginEnabled(String name) {
-            throw new UnsupportedOperationException("Not supported yet.");
+            return name.equals("Essentials");
         }
 
         @Override

--- a/EssentialsChat/pom.xml
+++ b/EssentialsChat/pom.xml
@@ -21,24 +21,12 @@
     <build>
         <finalName>EssentialsXChat-${full.version}</finalName>
     </build>
-    <repositories>
-        <repository>
-            <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
-        </repository>
-    </repositories>
 
     <dependencies>
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>EssentialsX</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.clip</groupId>
-            <artifactId>placeholderapi</artifactId>
-            <version>LATEST</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/EssentialsChat/pom.xml
+++ b/EssentialsChat/pom.xml
@@ -21,12 +21,24 @@
     <build>
         <finalName>EssentialsXChat-${full.version}</finalName>
     </build>
+    <repositories>
+        <repository>
+            <id>placeholderapi</id>
+            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
             <groupId>net.ess3</groupId>
             <artifactId>EssentialsX</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>LATEST</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
+++ b/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
@@ -2,7 +2,9 @@ package com.earth2me.essentials.chat;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
+import me.clip.placeholderapi.PlaceholderAPI;
 import net.ess3.api.IEssentials;
+import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -57,6 +59,9 @@ public class EssentialsChatPlayerListenerLowest extends EssentialsChatPlayer {
         format = format.replace("{5}", team == null ? "" : team.getDisplayName());
         format = format.replace("{6}", prefix);
         format = format.replace("{7}", suffix);
+        if(Bukkit.getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")){
+            format = PlaceholderAPI.setPlaceholders(event.getPlayer(), format);
+        }
         synchronized (format) {
             event.setFormat(format);
         }

--- a/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
+++ b/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
@@ -2,7 +2,6 @@ package com.earth2me.essentials.chat;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
-import me.clip.placeholderapi.PlaceholderAPI;
 import net.ess3.api.IEssentials;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
@@ -59,9 +58,8 @@ public class EssentialsChatPlayerListenerLowest extends EssentialsChatPlayer {
         format = format.replace("{5}", team == null ? "" : team.getDisplayName());
         format = format.replace("{6}", prefix);
         format = format.replace("{7}", suffix);
-        if(Bukkit.getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")){
-            format = PlaceholderAPI.setPlaceholders(event.getPlayer(), format);
-        }
+        format = FormatUtil.placeholderAPIFormat(user, format);
+
         synchronized (format) {
             event.setFormat(format);
         }

--- a/EssentialsChat/src/plugin.yml
+++ b/EssentialsChat/src/plugin.yml
@@ -7,4 +7,4 @@ website: http://tiny.cc/EssentialsCommands
 description: Provides chat control features for Essentials.  Requires Permissions.
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits, md_5, Okamosy, Iaccidentally]
 depend: [Essentials]
-#softdepend: [Factions]
+softdepend: [PlaceholderAPI]

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
             <id>bukkit-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <modules>
@@ -66,6 +70,12 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.12.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>LATEST</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR cherry-picks commits from #1944. The differences between this PR and #1944 are:
* Performs placeholder replacement in `User.sendMessage` rather than in a new `FormatUtil.tlp` method
  * Avoids changes all over the plugin, as implemented in #1959
* Does not include #1921, which is an unrelated change.
* Doesn't include replacing `{...}` with `%...%`, as that would be confusing for users when old Essentials placeholders break

To do:
- [ ] Format placeholders in translated messages sent to the log
- [ ] Escape placeholders in mail/AFK messages
- [ ] Replace placeholders in mail/AFK *formats*
- [ ] Consider supporting "recipient placeholders" in formats, which are left unescaped and only parsed when received by a user?
- [ ] Escape unformatted `%`s in chat format
- [ ] Any other broadcast messages

Credits go to @Banbeucmas for the original PR.

Closes #1945, closes #1944, closes #1959, yada yada
