### PR TITLE
Prevent users being duplicated in the ignore list

### DIFF
--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -467,10 +467,11 @@ public abstract class UserData extends PlayerExtension implements IConf {
     }
 
     public void setIgnoredPlayer(IUser user, boolean set) {
+        final String entry = user.getName().toLowerCase(Locale.ENGLISH);
         if (set) {
-            ignoredPlayers.add(user.getName().toLowerCase(Locale.ENGLISH));
+            if (!ignoredPlayers.contains(entry)) ignoredPlayers.add(entry);
         } else {
-            ignoredPlayers.remove(user.getName().toLowerCase(Locale.ENGLISH));
+            ignoredPlayers.remove(entry);
         }
         setIgnoredPlayers(ignoredPlayers);
     }


### PR DESCRIPTION
Fixes #2064, as well as alleviating the issue encountered in kangarko/ChatControl-Pro#627 for EssentialsX users.