### PR TITLE
Fix teleportation to caves in 1.13

### DIFF
--- a/Essentials/src/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/LocationUtil.java
@@ -28,6 +28,8 @@ public class LocationUtil {
             }
         }
 
+        HOLLOW_MATERIALS.add(Material.CAVE_AIR);
+
         TRANSPARENT_MATERIALS.addAll(HOLLOW_MATERIALS);
         TRANSPARENT_MATERIALS.add(Material.WATER);
         try {


### PR DESCRIPTION
This pull request simply adds cave_air as a hollow material in the LocationUtil class.

Cave air and void air were both added to 1.13 as new blocks. While void air does not appear naturally in the world,  cave air now generates as part of caves in updated maps. This breaks many of the teleportation commands (such as /home or /back) when teleporting to caves. Since Material.isTransparent is deprecated ([source](https://www.spigotmc.org/threads/bukkit-craftbukkit-spigot-bungeecord-1-13-development-builds.328883/)) and is thus unlikely to be updated, it is the responsibility of essentials to account for this inconsistency. Normal air is considered a transparent material ([source](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/Material.java#3514)) and so it makes sense to add cave air to the list of hollow materials as well, since the list consists of materials from this category. This fixes the issue of not being able to teleport into caves.