### PR TITLE
Round down balance when converting to double (Fixes #2101)

### DIFF
--- a/Essentials/src/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/com/earth2me/essentials/api/Economy.java
@@ -78,7 +78,14 @@ public class Economy {
      */
     @Deprecated
     public static double getMoney(String name) throws UserDoesNotExistException {
-        return getMoneyExact(name).doubleValue();
+        BigDecimal exactAmount = getMoneyExact(name);
+        double amount = exactAmount.doubleValue();
+        if (new BigDecimal(amount).compareTo(exactAmount) > 0) {
+            // closest double is bigger than the exact amount
+            // -> get the previous double value to not return more money than the user has
+            amount = Math.nextAfter(amount, Double.NEGATIVE_INFINITY);
+        }
+        return amount;
     }
 
     public static BigDecimal getMoneyExact(String name) throws UserDoesNotExistException {


### PR DESCRIPTION
Previously the Economy#getMoney method just used BigDecimal#doubleValue to return a less exact balance values for plugins that don't support BigDecimal yet. (e.g. Vault) This leads to rounding errors due to how doubleValue works (it uses the closest double value to the BigDecimal's value) which could make the method return more money than a user actually has.

This change makes sure that we always return a balance below the actual one by getting the closest double below the one BigDecimal#doubleValue returns if that was above the exact balance.