### PR TITLE
Doesn't kick all players if the player has permission

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandkickall.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkickall.java
@@ -20,7 +20,7 @@ public class Commandkickall extends EssentialsCommand {
 
         for (Player onlinePlayer : ess.getOnlinePlayers()) {
             if (!sender.isPlayer() || !onlinePlayer.getName().equalsIgnoreCase(sender.getPlayer().getName())) {
-                if (onlinePlayer.isAuthorized("essentials.kick.exempt")) {
+                if (onlinePlayer.isAuthorized("essentials.kickall.exempt")) {
                     throw new Exception();
                 }
                 onlinePlayer.kickPlayer(kickReason);

--- a/Essentials/src/com/earth2me/essentials/commands/Commandkickall.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkickall.java
@@ -20,10 +20,9 @@ public class Commandkickall extends EssentialsCommand {
 
         for (Player onlinePlayer : ess.getOnlinePlayers()) {
             if (!sender.isPlayer() || !onlinePlayer.getName().equalsIgnoreCase(sender.getPlayer().getName())) {
-                if (onlinePlayer.isAuthorized("essentials.kickall.exempt")) {
-                    throw new Exception();
+                if (!onlinePlayer.isAuthorized("essentials.kickall.exempt")) {
+                    onlinePlayer.kickPlayer(kickReason);
                 }
-                onlinePlayer.kickPlayer(kickReason);
             }
         }
         sender.sendMessage(tl("kickedAll"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandkickall.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkickall.java
@@ -20,6 +20,9 @@ public class Commandkickall extends EssentialsCommand {
 
         for (Player onlinePlayer : ess.getOnlinePlayers()) {
             if (!sender.isPlayer() || !onlinePlayer.getName().equalsIgnoreCase(sender.getPlayer().getName())) {
+                if (onlinePlayer.isAuthorized("essentials.kick.exempt")) {
+                    throw new Exception();
+                }
                 onlinePlayer.kickPlayer(kickReason);
             }
         }


### PR DESCRIPTION
So, if a player has permission (eg, an operator or more), they will not kick them out because of permission.