### PR TITLE
Sort /near by nearest player.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
@@ -7,9 +7,7 @@ import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 
-import javafx.util.Pair;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -87,7 +85,7 @@ public class Commandnear extends EssentialsCommand {
         final long radiusSquared = radius * radius;
         boolean showHidden = user.canInteractVanished();
 
-        Queue<Pair<User, Long>> playerDistances = new PriorityQueue<>(Comparator.comparingLong(Pair::getValue));
+        Queue<User> nearbyPlayers = new PriorityQueue<>((o1, o2) -> (int) (o1.getLocation().distanceSquared(loc) - o2.getLocation().distanceSquared(loc)));
 
         for (User player : ess.getOnlineUsers()) {
             if (!player.equals(user) && (!player.isHidden(user.getBase()) || showHidden || user.getBase().canSee(player.getBase()))) {
@@ -98,17 +96,17 @@ public class Commandnear extends EssentialsCommand {
 
                 final long delta = (long) playerLoc.distanceSquared(loc);
                 if (delta < radiusSquared) {
-                    playerDistances.offer(new Pair<>(player, delta));
+                    nearbyPlayers.offer(player);
                 }
             }
         }
 
-        while (!playerDistances.isEmpty()) {
+        while (!nearbyPlayers.isEmpty()) {
             if (output.length() > 0) {
                 output.append(", ");
             }
-            Pair<User, Long> playerDistance = playerDistances.poll();
-            output.append(playerDistance.getKey().getDisplayName()).append("§f(§4").append((long) Math.sqrt(playerDistance.getValue())).append("m§f)");
+            User nearbyPlayer = nearbyPlayers.poll();
+            output.append(nearbyPlayer.getDisplayName()).append("§f(§4").append((long) Math.sqrt(nearbyPlayer.getLocation().distanceSquared(loc))).append("m§f)");
         }
 
         return output.length() > 1 ? output.toString() : tl("none");

--- a/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
@@ -106,7 +106,7 @@ public class Commandnear extends EssentialsCommand {
                 output.append(", ");
             }
             User nearbyPlayer = nearbyPlayers.poll();
-            output.append(nearbyPlayer.getDisplayName()).append("§f(§4").append((long) Math.sqrt(nearbyPlayer.getLocation().distanceSquared(loc))).append("m§f)");
+            output.append(nearbyPlayer.getDisplayName()).append("§f(§4").append((long) nearbyPlayer.getLocation().distance(loc)).append("m§f)");
         }
 
         return output.length() > 1 ? output.toString() : tl("none");

--- a/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
@@ -7,8 +7,12 @@ import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
 
+import javafx.util.Pair;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -83,6 +87,8 @@ public class Commandnear extends EssentialsCommand {
         final long radiusSquared = radius * radius;
         boolean showHidden = user.canInteractVanished();
 
+        Queue<Pair<User, Long>> playerDistances = new PriorityQueue<>(Comparator.comparingLong(Pair::getValue));
+
         for (User player : ess.getOnlineUsers()) {
             if (!player.equals(user) && (!player.isHidden(user.getBase()) || showHidden || user.getBase().canSee(player.getBase()))) {
                 final Location playerLoc = player.getLocation();
@@ -92,13 +98,19 @@ public class Commandnear extends EssentialsCommand {
 
                 final long delta = (long) playerLoc.distanceSquared(loc);
                 if (delta < radiusSquared) {
-                    if (output.length() > 0) {
-                        output.append(", ");
-                    }
-                    output.append(player.getDisplayName()).append("§f(§4").append((long) Math.sqrt(delta)).append("m§f)");
+                    playerDistances.offer(new Pair<>(player, delta));
                 }
             }
         }
+
+        while (!playerDistances.isEmpty()) {
+            if (output.length() > 0) {
+                output.append(", ");
+            }
+            Pair<User, Long> playerDistance = playerDistances.poll();
+            output.append(playerDistance.getKey().getDisplayName()).append("§f(§4").append((long) Math.sqrt(playerDistance.getValue())).append("m§f)");
+        }
+
         return output.length() > 1 ? output.toString() : tl("none");
     }
 


### PR DESCRIPTION
An improvement for the /near command to sort the output by the nearest player. Closes #1333.

I have personally tested this change on a server with about four players nearby, and I have to say that the output is definitely way more convenient to look at.

This pull request is a replacement for #2154 since I closed that one on accident. I have cut down on the number of dependencies, as requested.