### PR TITLE
Hiding display names

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -239,6 +239,8 @@ public interface ISettings extends IConf {
 
     boolean ignoreColorsInMaxLength();
 
+    boolean hideDisplayNameInVanish();
+
     int getMaxUserCacheCount();
 
     boolean allowSilentJoinQuit();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1096,6 +1096,11 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getBoolean("ignore-colors-in-max-nick-length", false);
     }
 
+    @Override
+    public boolean hideDisplayNameInVanish() {
+        return config.getBoolean("hide-displayname-in-vanish", true);
+    }
+
     private boolean allowSilentJoin;
 
     public boolean _allowSilentJoinQuit() {

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1098,7 +1098,7 @@ public class Settings implements net.ess3.api.ISettings {
 
     @Override
     public boolean hideDisplayNameInVanish() {
-        return config.getBoolean("hide-displayname-in-vanish", true);
+        return config.getBoolean("hide-displayname-in-vanish", false);
     }
 
     private boolean allowSilentJoin;

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -359,7 +359,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
     }
 
     public String getDisplayName() {
-        return super.getBase().getDisplayName() == null ? super.getBase().getName() : super.getBase().getDisplayName();
+        return super.getBase().getDisplayName() == null || isHidden() ? super.getBase().getName() : super.getBase().getDisplayName();
     }
 
     @Override

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -359,7 +359,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
     }
 
     public String getDisplayName() {
-        return super.getBase().getDisplayName() == null || isHidden() ? super.getBase().getName() : super.getBase().getDisplayName();
+        return super.getBase().getDisplayName() == null || (ess.getSettings().hideDisplayNameInVanish() && isHidden()) ? super.getBase().getName() : super.getBase().getDisplayName();
     }
 
     @Override

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -36,6 +36,10 @@ max-nick-length: 15
 # ie: "&6Notch" has 7 characters (2 are part of a color code), a length of 5 is used when this option is set to true
 ignore-colors-in-max-nick-length: false
 
+# When this option is enabled, display names for hidden users will not be shown. This prevents players from being
+# able to see that they are online while vanished.
+hide-displayname-in-vanish: true
+
 # Disable this if you have any other plugin, that modifies the displayname of a user.
 change-displayname: true
 


### PR DESCRIPTION
Prevents a user's nickname from appearing if they are hidden. Closes issue #2221