### PR TITLE
Implement config option for sleep ignoring AFK players

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -181,7 +181,7 @@ public interface ISettings extends IConf {
 
     boolean cancelAfkOnInteract();
 
-    boolean bypassSleepWhenAfk();
+    boolean sleepIgnoresAfkPlayers();
 
     boolean isAfkListName();
 

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -181,6 +181,8 @@ public interface ISettings extends IConf {
 
     boolean cancelAfkOnInteract();
 
+    boolean bypassSleepWhenAfk();
+
     boolean isAfkListName();
 
     String getAfkListName();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -494,7 +494,7 @@ public class Settings implements net.ess3.api.ISettings {
         cancelAfkOnInteract = _cancelAfkOnInteract();
         cancelAfkOnMove = _cancelAfkOnMove();
         getFreezeAfkPlayers = _getFreezeAfkPlayers();
-        bypassSleepWhenAfk = _bypassSleepWhenAfk();
+        sleepIgnoresAfkPlayers = _sleepIgnoresAfkPlayers();
         afkListName = _getAfkListName();
         isAfkListName = !afkListName.equalsIgnoreCase("none");
         itemSpawnBl = _getItemSpawnBlacklist();
@@ -871,15 +871,15 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getBoolean("cancel-afk-on-interact", true);
     }
 
-    private boolean bypassSleepWhenAfk;
+    private boolean sleepIgnoresAfkPlayers;
 
     @Override
-    public boolean bypassSleepWhenAfk() {
-        return bypassSleepWhenAfk;
+    public boolean sleepIgnoresAfkPlayers() {
+        return sleepIgnoresAfkPlayers;
     }
 
-    private boolean _bypassSleepWhenAfk() {
-        return config.getBoolean("bypass-sleep-when-afk", true);
+    private boolean _sleepIgnoresAfkPlayers() {
+        return config.getBoolean("sleep-ignores-afk-players", true);
     }
 
     private String afkListName;

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -494,6 +494,7 @@ public class Settings implements net.ess3.api.ISettings {
         cancelAfkOnInteract = _cancelAfkOnInteract();
         cancelAfkOnMove = _cancelAfkOnMove();
         getFreezeAfkPlayers = _getFreezeAfkPlayers();
+        bypassSleepWhenAfk = _bypassSleepWhenAfk();
         afkListName = _getAfkListName();
         isAfkListName = !afkListName.equalsIgnoreCase("none");
         itemSpawnBl = _getItemSpawnBlacklist();
@@ -868,6 +869,17 @@ public class Settings implements net.ess3.api.ISettings {
 
     private boolean _cancelAfkOnInteract() {
         return config.getBoolean("cancel-afk-on-interact", true);
+    }
+
+    private boolean bypassSleepWhenAfk;
+
+    @Override
+    public boolean bypassSleepWhenAfk() {
+        return bypassSleepWhenAfk;
+    }
+
+    private boolean _bypassSleepWhenAfk() {
+        return config.getBoolean("bypass-sleep-when-afk", true);
     }
 
     private String afkListName;

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -457,7 +457,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             return;
         }
 
-        this.getBase().setSleepingIgnored(this.isAuthorized("essentials.sleepingignored") || set && ess.getSettings().bypassSleepWhenAfk());
+        this.getBase().setSleepingIgnored(this.isAuthorized("essentials.sleepingignored") || set && ess.getSettings().sleepIgnoresAfkPlayers());
         if (set && !isAfk()) {
             afkPosition = this.getLocation();
             this.afkSince = System.currentTimeMillis();

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -457,7 +457,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             return;
         }
 
-        this.getBase().setSleepingIgnored(this.isAuthorized("essentials.sleepingignored") ? true : set);
+        this.getBase().setSleepingIgnored(this.isAuthorized("essentials.sleepingignored") || set && ess.getSettings().bypassSleepWhenAfk());
         if (set && !isAfk()) {
             afkPosition = this.getLocation();
             this.afkSince = System.currentTimeMillis();

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -399,7 +399,7 @@ cancel-afk-on-move: true
 # Should AFK players be ignored when other players are trying to sleep?
 # When this setting is false, players won't be able to skip the night if some players are AFK.
 # Users with the permission node essentials.sleepingignored will always be ignored.
-bypass-sleep-when-afk: true
+sleep-ignores-afk-players: true
 
 # Set the player's list name when they are AFK. This is none by default which specifies that Essentials 
 # should not interfere with the AFK player's list name.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -396,9 +396,10 @@ cancel-afk-on-interact: true
 # Disable this to reduce server lag.
 cancel-afk-on-move: true
 
-# When a player is AFK, should they be taken into account when other players are trying to sleep?
-# Set this to true when you want AFK players to be ignored when sleeping attempts to skip the night.
-bypass-sleep-when-afk: false
+# Should AFK players be ignored when other players are trying to sleep?
+# When this setting is false, players won't be able to skip the night if some players are AFK.
+# Users with the permission node essentials.sleepingignored will always be ignored.
+bypass-sleep-when-afk: true
 
 # Set the player's list name when they are AFK. This is none by default which specifies that Essentials 
 # should not interfere with the AFK player's list name.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -396,6 +396,10 @@ cancel-afk-on-interact: true
 # Disable this to reduce server lag.
 cancel-afk-on-move: true
 
+# When a player is AFK, should they be taken into account when other players are trying to sleep?
+# Set this to true when you want AFK players to be ignored when sleeping attempts to skip the night.
+bypass-sleep-when-afk: false
+
 # Set the player's list name when they are AFK. This is none by default which specifies that Essentials 
 # should not interfere with the AFK player's list name.
 # You may use color codes, use {USERNAME} the player's name or {PLAYER} for the player's displayname.


### PR DESCRIPTION
This pull request contributes to #2311.

I had a go at implementing a small config toggle for whether or not AFK players should be ignored when other players are trying to sleep. I tried my best with the config comments but I think it could use some help.

I also simplified the ternary operator at line 460 in User.java, but it can be changed back if you'd rather keep it the way it was.