### PR TITLE
attempt to fix Essentials overriding Skulls

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -727,6 +727,7 @@ public class EssentialsPlayerListener implements Listener {
         } else if (clickedInventory != null && clickedInventory.getType() == InventoryType.PLAYER) {
             if (ess.getSettings().isDirectHatAllowed() && event.getClick() == ClickType.LEFT && event.getSlot() == 39
                 && event.getCursor().getType() != Material.AIR && event.getCursor().getType().getMaxDurability() == 0
+                && !MaterialUtil.isSkull(event.getCursor().getType())
                 && ess.getUser(event.getWhoClicked()).isAuthorized("essentials.hat")) {
                 event.setCancelled(true);
                 final PlayerInventory inv = (PlayerInventory) clickedInventory;


### PR DESCRIPTION
When a player puts on a Skull, Essentials thinks it's a regular block and tries to put it on their head for them. This causes some issues because the game itself puts the Skull on, so other plugins looking out for players putting Skulls on their heads get cancelled by Essentials.

This PR should fix the issue, though I am unable to test as I've only been using Java for about a month.