### PR TITLE
Improve Travis build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 /jars
 /out
 .idea/
+.buildtools/
 *.iml
 *.classpath
 *.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ cache:
   - $HOME/.m2
 
 before_install:
+  - chmod +x scripts/buildtools.sh
   - scripts/buildtools.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,9 @@
 language: java
 
-branches:
-  only:
-  - 2.x
-  - 1.13
-  
 cache:
   directories:
   - .buildtools
   - $HOME/.m2
 
 before_install:
-  - mkdir -p .buildtools
-  - cd .buildtools
-  - wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-  - rm -r work/
-  - java -jar BuildTools.jar --rev 1.8
-  - java -jar BuildTools.jar --rev 1.8.3
-  - cd ..
+  - scripts/buildtools.sh

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ EssentialsX is almost a completely drop-in replacement for Essentials. However, 
 
 * **If you have an unsupported permissions plugin but still wish to use wildcards, enable `use-bukkit-permissions` in the configuration.** Otherwise, the plugin will fall back to config-based permissions.
 
-* **EssentialsX requires Java 8 or higher.** On older versions, the plugin may not work properly. 
+* **EssentialsX requires Java 8 or higher.** On older versions, the plugin may not work properly.
 
 * **EssentialsX supports Minecraft versions 1.8.8, 1.9.4, 1.10.2, 1.11.2 and 1.12.2.** Support for 1.13.2 is coming soon.
 
@@ -41,7 +41,8 @@ Building
 --------
 
 EssentialsX builds against the Spigot/CraftBukkit server software for legacy support.
-To compile EssentialsX, you first need to run [BuildTools](https://www.spigotmc.org/wiki/buildtools) several times:
+To compile EssentialsX, you first need to run [BuildTools](https://www.spigotmc.org/wiki/buildtools).
+This can be done using the provided script at `scripts/buildtools.sh` which downloads and runs BuildTools automatically, or you can manually install the required versions with the following commands:
 
 ```
 java -jar BuildTools.jar --rev 1.8
@@ -53,7 +54,7 @@ Then, to build with Maven, run the following command:
 mvn clean install
 ```
 
-Each module's jar can be found in `target/` inside each module's directory. 
+Each module's jar can be found in `target/` inside each module's directory.
 
 
 Contributing
@@ -64,7 +65,7 @@ Want to help improve EssentialsX? There are numerous ways you can contribute to 
 If you'd like to make a financial contribution to the project, you can join our [Patreon](https://www.patreon.com/essentialsx/).
 If you can't make a donation, don't worry! There's lots of other ways to contribute:
 
-* Do you run a server? Take a look at our ["help wanted" issues](https://github.com/EssentialsX/Essentials/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22), 
+* Do you run a server? Take a look at our ["help wanted" issues](https://github.com/EssentialsX/Essentials/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22help+wanted%22),
   where you can find issues that need extra testing and investigation. You can also join the [MOSS Discord community](https://discord.gg/casfFyh)
   and provide support to others.
 * Do you speak multiple languages? If so, we always welcome pull requests to our [language files](https://essentialsx.github.io/#/Locale).

--- a/README.md
+++ b/README.md
@@ -41,15 +41,14 @@ Building
 --------
 
 EssentialsX builds against the Spigot/CraftBukkit server software for legacy support.
+
 To compile EssentialsX, you first need to run [BuildTools](https://www.spigotmc.org/wiki/buildtools).
-This can be done using the provided script at `scripts/buildtools.sh` which downloads and runs BuildTools automatically, or you can manually install the required versions with the following commands:
+This only needs to be done once. There are two ways to do this:
 
-```
-java -jar BuildTools.jar --rev 1.8
-java -jar BuildTools.jar --rev 1.8.3
-```
+* Use the provided script at `scripts/buildtools.sh` to automatically download and run BuildTools if needed.
+* Download and run BuildTools yourself for versions `1.8` and `1.8.3`.
 
-Then, to build with Maven, run the following command:
+Next, to build EssentialsX with Maven, run the following command:
 ```
 mvn clean install
 ```

--- a/scripts/buildtools.sh
+++ b/scripts/buildtools.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+mkdir -p .buildtools
+pushd .buildtools
+
+is_installed() {
+    mvn dependency:get -q -Dartifact=$1 -DremoteRepositories=file://$HOME/.m2/repository 1>/dev/null 2>&1
+    return $?
+}
+
+ensure_buildtools() {
+    if [ ! -f "BuildTools.jar" ]; then
+        echo "Downloading BuildTools..."
+        wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+    fi
+}
+
+run_buildtools() {
+    ensure_buildtools
+    java -jar BuildTools.jar --rev $1
+    if [ $? -ne 0 ]; then
+        echo "Running BuildTools for CB $1 failed! Aborting."
+        popd
+        exit 255
+    else
+        echo "Successfully built version $1"
+    fi
+}
+
+# Check CB 1.8
+is_installed org.bukkit:craftbukkit:1.8-R0.1-SNAPSHOT
+is_18=$? # 0 = present, 1 = not present
+
+# Check CB 1.8.3
+is_installed org.bukkit:craftbukkit:1.8.3-R0.1-SNAPSHOT
+is_183=$?
+
+if [ $is_18 -ne 0 ]; then
+    echo "Installing CraftBukkit 1.8..."
+    run_buildtools 1.8
+else
+    echo "CraftBukkit 1.8 installed; skipping BuildTools..."
+fi
+
+if [ $is_183 -ne 0 ]; then
+    echo "Installing CraftBukkit 1.8.3..."
+    run_buildtools 1.8.3
+else
+    echo "CraftBukkit 1.8.3 installed; skipping BuildTools..."
+fi
+
+popd


### PR DESCRIPTION
I've added a new script at `scripts/buildtools.sh` that is responsible for:
* Checking whether CraftBukkit 1.8 and 1.8.3 are already available in the local Maven repo
* Downloading BuildTools if not already present
* Running BuildTools if necessary

This improves Travis build times as it now doesn't run BuildTools twice for *every single build*, instead running it only if the Travis cache fails and CraftBukkit is missing for some other reason.