### PR TITLE
specify amount in /more

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandmore.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmore.java
@@ -24,7 +24,7 @@ public class Commandmore extends EssentialsCommand {
             throw new Exception(tl("fullStack"));
         }
         final String itemname = stack.getType().toString().toLowerCase(Locale.ENGLISH).replace("_", "");
-        if (ess.getSettings().permissionBasedItemSpawn() ? (!user.isAuthorized("essentials.itemspawn.item-all") && !user.isAuthorized("essentials.itemspawn.item-" + itemname) && !user.isAuthorized("essentials.itemspawn.item-" + stack.getTypeId())) : (!user.isAuthorized("essentials.itemspawn.exempt") && !user.canSpawnItem(stack.getTypeId()))) {
+        if (!user.canSpawnItem(stack.getType())) {
             throw new Exception(tl("cantSpawnItem", itemname));
         }
         if (args.length > 1) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmore.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmore.java
@@ -38,7 +38,7 @@ public class Commandmore extends EssentialsCommand {
                 newAmount = stack.getMaxStackSize();
             } else {
                 if (newAmount > ess.getSettings().getOversizedStackSize()) {
-                    newAmount = ess.getSettings.getOversizedStackSize();
+                    newAmount = ess.getSettings().getOversizedStackSize();
                 }
             }
             stack.setAmount(newAmount);

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmore.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmore.java
@@ -29,13 +29,11 @@ public class Commandmore extends EssentialsCommand {
         }
         if (args.length > 1) {
             int newAmount = stack.getAmount();
-
             try {
-                newAmount += Integer.parseInt(ChatColor.stripColor(args[1]));
-            } catch(Exception e) {
+                newAmount += Integer.parseInt(args[1]);
+            } catch(NumberFormatException e) {
                 throw new Exception(tl("numberRequired"));
             }
-
             if (!user.isAuthorized("essentials.oversizedstacks")) {
                 newAmount = stack.getMaxStackSize();
             } else {
@@ -43,7 +41,6 @@ public class Commandmore extends EssentialsCommand {
                     newAmount = ess.getSettings.getOversizedStackSize();
                 }
             }
-
             stack.setAmount(newAmount);
         } else {
             if (user.isAuthorized("essentials.oversizedstacks")) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandmore.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmore.java
@@ -27,10 +27,30 @@ public class Commandmore extends EssentialsCommand {
         if (ess.getSettings().permissionBasedItemSpawn() ? (!user.isAuthorized("essentials.itemspawn.item-all") && !user.isAuthorized("essentials.itemspawn.item-" + itemname) && !user.isAuthorized("essentials.itemspawn.item-" + stack.getTypeId())) : (!user.isAuthorized("essentials.itemspawn.exempt") && !user.canSpawnItem(stack.getTypeId()))) {
             throw new Exception(tl("cantSpawnItem", itemname));
         }
-        if (user.isAuthorized("essentials.oversizedstacks")) {
-            stack.setAmount(ess.getSettings().getOversizedStackSize());
+        if (args.length > 1) {
+            int newAmount = stack.getAmount();
+
+            try {
+                newAmount += Integer.parseInt(ChatColor.stripColor(args[1]));
+            } catch(Exception e) {
+                throw new Exception(tl("numberRequired"));
+            }
+
+            if (!user.isAuthorized("essentials.oversizedstacks")) {
+                newAmount = stack.getMaxStackSize();
+            } else {
+                if (newAmount > ess.getSettings().getOversizedStackSize()) {
+                    newAmount = ess.getSettings.getOversizedStackSize();
+                }
+            }
+
+            stack.setAmount(newAmount);
         } else {
-            stack.setAmount(stack.getMaxStackSize());
+            if (user.isAuthorized("essentials.oversizedstacks")) {
+                stack.setAmount(ess.getSettings().getOversizedStackSize());
+            } else {
+                stack.setAmount(stack.getMaxStackSize());
+            }
         }
         user.getBase().updateInventory();
     }


### PR DESCRIPTION
This pull request closes #2342.

This pull request allows users to specify an amount when using the /more command. The command still make sure to fulfill the following:
- if the user does not have essentials.oversizedstacks, the command will make sure not to give users stacks sized over the maximum limit for that item.
- the command will make sure not to give users stacks above Essentials:OversizedStackSize

This is a simple improvement for /more, not necessarily necessary. Do with it what you will.

edit: I have not tested and cannot test this, though I am confident it is functional.