### PR TITLE
Replace nbsp with a space when formatting messages

### DIFF
--- a/Essentials/src/com/earth2me/essentials/I18n.java
+++ b/Essentials/src/com/earth2me/essentials/I18n.java
@@ -93,7 +93,7 @@ public class I18n implements net.ess3.api.II18n {
             }
             messageFormatCache.put(format, messageFormat);
         }
-        return messageFormat.format(objects);
+        return messageFormat.format(objects).replace(' ', ' '); // replace nbsp with a space
     }
 
     public void updateLocale(final String loc) {


### PR DESCRIPTION
When some commands are formatting numbers, there is nbsp character as a thousands separator, but Minecraft is not able to properly display it, so it's better to replace it with a normal space

gif shows output of /gc before and after the change:
![essentials_gc](https://user-images.githubusercontent.com/3875202/51753599-71659780-20ba-11e9-86e4-076b4cfabec7.gif)
