### PR TITLE
When sending tpa message, display the player name.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpa.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpa.java
@@ -38,7 +38,7 @@ public class Commandtpa extends EssentialsCommand {
 
         if (!player.isIgnoredPlayer(user)) {
             player.requestTeleport(user, false);
-            player.sendMessage(tl("teleportRequest", user.getDisplayName()));
+            player.sendMessage(tl("teleportRequest", user.getName()));
             player.sendMessage(tl("typeTpaccept"));
             player.sendMessage(tl("typeTpdeny"));
             if (ess.getSettings().getTpaAcceptCancellation() != 0) {


### PR DESCRIPTION
When sending tpa message, display the actual player name--not the display name.