### PR TITLE
Switch Vault dependency to VaultAPI

### DIFF
--- a/Essentials/pom.xml
+++ b/Essentials/pom.xml
@@ -44,8 +44,8 @@
     <dependencies>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
-            <artifactId>Vault</artifactId>
-            <version>1.5.6</version>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.7</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/Essentials/src/com/earth2me/essentials/register/payment/methods/VaultEco.java
+++ b/Essentials/src/com/earth2me/essentials/register/payment/methods/VaultEco.java
@@ -1,18 +1,17 @@
 package com.earth2me.essentials.register.payment.methods;
 
 import com.earth2me.essentials.register.payment.Method;
-import net.milkbowl.vault.Vault;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 
 
 public class VaultEco implements Method {
-    private Vault vault;
+    private Plugin vault;
     private Economy economy;
 
     @Override
-    public Vault getPlugin() {
+    public Plugin getPlugin() {
         return this.vault;
     }
 
@@ -108,7 +107,7 @@ public class VaultEco implements Method {
     public boolean isCompatible(Plugin plugin) {
         try {
             RegisteredServiceProvider<Economy> ecoPlugin = plugin.getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
-            return plugin instanceof Vault && ecoPlugin != null && !ecoPlugin.getProvider().getName().equals("Essentials Economy");
+            return plugin.getName().equals("Vault") && ecoPlugin != null && !ecoPlugin.getProvider().getName().equals("Essentials Economy");
         } catch (LinkageError | Exception e) {
             return false;
         }
@@ -116,7 +115,7 @@ public class VaultEco implements Method {
 
     @Override
     public void setPlugin(Plugin plugin) {
-        this.vault = (Vault) plugin;
+        this.vault = plugin;
         RegisteredServiceProvider<Economy> economyProvider = this.vault.getServer().getServicesManager().getRegistration(net.milkbowl.vault.economy.Economy.class);
         if (economyProvider != null) {
             this.economy = economyProvider.getProvider();


### PR DESCRIPTION
This PR removes the dependency on the Vault plugin itself, instead depending on VaultAPI directly (which is the recommended way to use Vault).

To do:
- [x] Change dependency in POM
- [x] Refactor Vault economy method to use VaultAPI not Vault