### PR TITLE
Check Protect/AntiBuild config materials against Material enum

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.signs.EssentialsSign;
 import com.earth2me.essentials.signs.Signs;
 import com.earth2me.essentials.textreader.IText;
 import com.earth2me.essentials.textreader.SimpleTextInput;
+import com.earth2me.essentials.utils.EnumUtil;
 import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.NumberUtil;
 
@@ -691,12 +692,20 @@ public class Settings implements net.ess3.api.ISettings {
             if (itemName.isEmpty()) {
                 continue;
             }
-            ItemStack itemStack;
-            try {
-                itemStack = ess.getItemDb().get(itemName);
-                list.add(itemStack.getType());
-            } catch (Exception ex) {
+
+            Material mat = EnumUtil.getMaterial(itemName.toUpperCase());
+            
+            if (mat == null) {
+                try {
+                    ItemStack itemStack = ess.getItemDb().get(itemName);
+                    mat = itemStack.getType();
+                } catch (Exception ignored) {}
+            }
+
+            if (mat == null) {
                 logger.log(Level.SEVERE, tl("unknownItemInList", itemName, configName));
+            } else {
+                list.add(mat);
             }
         }
         return list;

--- a/Essentials/src/com/earth2me/essentials/utils/EnumUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/EnumUtil.java
@@ -12,7 +12,7 @@ public class EnumUtil {
 
     /**
      * Returns the field matching the first provided enum name that exists within the given
-     * enum class.
+     * enum class. If no field is found, this method returns null.
      *
      * @param enumClass The class to search through
      * @param names The names of the fields to search for


### PR DESCRIPTION
This should allow entries such as `LAVA` or `WATER` to still be recognised even though FlatItemDb refuses to spawn stacks of those in. Fixes #2360.