### PR TITLE
Economy API: Attempt to find users by UUID if username not present

### DIFF
--- a/Essentials/src/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/com/earth2me/essentials/api/Economy.java
@@ -8,6 +8,7 @@ import com.earth2me.essentials.utils.StringUtil;
 import com.google.common.base.Charsets;
 import net.ess3.api.IEssentials;
 import net.ess3.api.MaxMoneyException;
+import org.bukkit.entity.Player;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -68,7 +69,10 @@ public class Economy {
         User user = ess.getUser(name);
         if (user == null) {
             // Attempt lookup using UUID - this prevents issues using the economy during player join
-            user = ess.getUser(ess.getServer().getPlayerExact(name).getUniqueId());
+            Player player = ess.getServer().getPlayerExact(name);
+            if (player != null) {
+                user = ess.getUser(player.getUniqueId());
+            }
         }
 
         return user;

--- a/Essentials/src/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/com/earth2me/essentials/api/Economy.java
@@ -68,10 +68,17 @@ public class Economy {
 
         User user = ess.getUser(name);
         if (user == null) {
-            // Attempt lookup using UUID - this prevents issues using the economy during player join
+            /*
+                Attempt lookup using UUID - this prevents balance resets when accessing economy
+                via Vault during player join.
+                See: https://github.com/EssentialsX/Essentials/issues/2400
+            */
             Player player = ess.getServer().getPlayerExact(name);
             if (player != null) {
                 user = ess.getUser(player.getUniqueId());
+                if (user != null) {
+                    logger.info(String.format("[Economy] Found player %s by UUID %s but not by their actual name - they may have changed their username", name, player.getUniqueId().toString()));
+                }
             }
         }
 

--- a/Essentials/src/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/com/earth2me/essentials/api/Economy.java
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
 
 
 /**
- * Instead of using this api directly, we recommend to use the register plugin: http://bit.ly/RegisterMethod
+ * You should use Vault instead of directly using this class.
  */
 public class Economy {
     public Economy() {
@@ -64,7 +64,14 @@ public class Economy {
         if (name == null) {
             throw new RuntimeException("Economy username cannot be null");
         }
-        return ess.getUser(name);
+
+        User user = ess.getUser(name);
+        if (user == null) {
+            // Attempt lookup using UUID - this prevents issues using the economy during player join
+            user = ess.getUser(ess.getServer().getPlayerExact(name).getUniqueId());
+        }
+
+        return user;
     }
 
     /**

--- a/Essentials/test/com/earth2me/essentials/FakeServer.java
+++ b/Essentials/test/com/earth2me/essentials/FakeServer.java
@@ -500,7 +500,12 @@ public class FakeServer implements Server {
 
     @Override
     public Player getPlayerExact(String string) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        for (Player player : players) {
+            if (player.getName().equals(string)) {
+                return player;
+            }
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This is designed to address issue #2400, where players lose their balance when Vault tries to do economy operation during login. Instead of giving up immediately, the Economy API now tries to look up users by UUID if they can't be found by their name, which is the case when they change their usernames but EssentialsX hasn't updated its usermap yet. This should prevent Vault creating a new NPC file for the user, which leads to their balance being split between an NPC file and their correct UUID file.

See [this comment](https://github.com/EssentialsX/Essentials/issues/2400#issuecomment-466043896) for more information.