### PR TITLE
Allow console to use essentials color codes when sending mail

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -105,11 +105,11 @@ public class Commandmail extends EssentialsCommand {
             if (u == null) {
                 throw new Exception(tl("playerNeverOnServer", args[1]));
             }
-            u.addMail(tl("mailFormat", "Server", getFinalArg(args, 2)));
+            u.addMail(tl("mailFormat", "Server", FormatUtil.replaceFormat(getFinalArg(args, 2))));
             sender.sendMessage(tl("mailSent"));
             return;
         } else if (args.length >= 2 && "sendall".equalsIgnoreCase(args[0])) {
-            ess.runTaskAsynchronously(new SendAll(tl("mailFormat", "Server", getFinalArg(args, 1))));
+            ess.runTaskAsynchronously(new SendAll(tl("mailFormat", "Server", FormatUtil.replaceFormat(getFinalArg(args, 1)))));
             sender.sendMessage(tl("mailSent"));
             return;
         } else if (args.length >= 2) {
@@ -118,7 +118,7 @@ public class Commandmail extends EssentialsCommand {
             if (u == null) {
                 throw new Exception(tl("playerNeverOnServer", args[0]));
             }
-            u.addMail(tl("mailFormat", "Server", getFinalArg(args, 1)));
+            u.addMail(tl("mailFormat", "Server", FormatUtil.replaceFormat(getFinalArg(args, 1))));
             sender.sendMessage(tl("mailSent"));
             return;
         }


### PR DESCRIPTION
Closes #2429 

Small change to allow mail sent from console to be formatted with essentials color codes.