### PR TITLE
Remove Lombok

### DIFF
--- a/Essentials/src/com/earth2me/essentials/settings/Jails.java
+++ b/Essentials/src/com/earth2me/essentials/settings/Jails.java
@@ -2,15 +2,39 @@ package com.earth2me.essentials.settings;
 
 import com.earth2me.essentials.storage.MapValueType;
 import com.earth2me.essentials.storage.StorageObject;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import org.bukkit.Location;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 
-@Data @EqualsAndHashCode(callSuper = false) public class Jails implements StorageObject {
+public class Jails implements StorageObject {
     @MapValueType(Location.class)
     private Map<String, Location> jails = new HashMap<String, Location>();
+
+    public Map<String, Location> getJails() {
+        return jails;
+    }
+
+    public void setJails(Map<String, Location> jails) {
+        this.jails = jails;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Jails jails1 = (Jails) o;
+        return Objects.equals(jails, jails1.jails);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jails);
+    }
 }

--- a/Essentials/src/com/earth2me/essentials/settings/Jails.java
+++ b/Essentials/src/com/earth2me/essentials/settings/Jails.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 
 public class Jails implements StorageObject {
     @MapValueType(Location.class)
-    private Map<String, Location> jails = new HashMap<String, Location>();
+    private Map<String, Location> jails = new HashMap<>();
 
     public Map<String, Location> getJails() {
         return jails;

--- a/Essentials/src/com/earth2me/essentials/settings/Spawns.java
+++ b/Essentials/src/com/earth2me/essentials/settings/Spawns.java
@@ -2,14 +2,38 @@ package com.earth2me.essentials.settings;
 
 import com.earth2me.essentials.storage.MapValueType;
 import com.earth2me.essentials.storage.StorageObject;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
 import org.bukkit.Location;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
-@Data @EqualsAndHashCode(callSuper = false) public class Spawns implements StorageObject {
+public class Spawns implements StorageObject {
     @MapValueType(Location.class)
     private Map<String, Location> spawns = new HashMap<>();
+
+    public Map<String, Location> getSpawns() {
+        return spawns;
+    }
+
+    public void setSpawns(Map<String, Location> spawns) {
+        this.spawns = spawns;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Spawns spawns1 = (Spawns) o;
+        return Objects.equals(spawns, spawns1.spawns);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(spawns);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,12 +67,6 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Remove the (already minimal) usage of Lombok. This will ease development for people who don't already have their IDE set up for Lombok support.

It's also totally unnecessary - it took less than 60 seconds to generate the code needed to replace Lombok annotations in Jails and Spawns.