### PR TITLE
Fixes #2403 - Ability to execute /back for another player

### DIFF
--- a/Essentials/src/com/earth2me/essentials/api/ITeleport.java
+++ b/Essentials/src/com/earth2me/essentials/api/ITeleport.java
@@ -111,6 +111,19 @@ public interface ITeleport {
     void back(Trade chargeFor) throws Exception;
 
     /**
+     * Teleport wrapper used to handle /back teleports that
+     * are executed by a different player with this
+     * instance of teleport as a target.
+     *
+     * @param teleporter - The user performing the /back command.
+     *                   This value may be {@code null} to indicate console.
+     * @param chargeFor - What the {@code teleporter} will be charged if teleportPlayer is successful
+     *
+     * @throws Exception
+     */
+    void back(IUser teleporter, Trade chargeFor) throws Exception;
+
+    /**
      * Teleport wrapper used to handle throwing user home after a jail sentence
      *
      * @throws Exception

--- a/Essentials/src/com/earth2me/essentials/commands/Commandback.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandback.java
@@ -1,8 +1,15 @@
 package com.earth2me.essentials.commands;
 
+import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -13,24 +20,82 @@ public class Commandback extends EssentialsCommand {
     }
 
     @Override
-    protected void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
+    protected void run(Server server, User user, String commandLabel, String[] args) throws Exception {
+        CommandSource sender = user.getSource();
+        if (args.length > 0 && user.isAuthorized("essentials.back.others")) {
+            this.parseCommand(server, sender, args, true);
+            return;
+        }
+
+        teleportBack(sender, user);
+    }
+
+    @Override
+    protected void run(Server server, CommandSource sender, String commandLabel, String[] args) throws Exception {
+        if (args.length < 1) {
+            throw new NotEnoughArgumentsException();
+        }
+
+        this.parseCommand(server, sender, args, true);
+    }
+
+    private void parseCommand(Server server, CommandSource sender, String[] args, boolean allowOthers) throws Exception {
+        Collection<Player> players = new ArrayList<>();
+
+        if (allowOthers && args.length > 0 && args[0].trim().length() > 2) {
+            players = server.matchPlayer(args[0].trim());
+        }
+
+        if (players.size() < 1) {
+            throw new PlayerNotFoundException();
+        }
+
+        for (Player player : players) {
+            sender.sendMessage(tl("backOther", player.getName()));
+            teleportBack(sender, ess.getUser(player));
+        }
+    }
+
+    private void teleportBack(CommandSource sender, User user) throws Exception {
         if (user.getLastLocation() == null) {
             throw new Exception(tl("noLocationFound"));
         }
 
         String lastWorldName = user.getLastLocation().getWorld().getName();
 
-        if (user.getWorld() != user.getLastLocation().getWorld() && ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + lastWorldName)) {
-            throw new Exception(tl("noPerm", "essentials.worlds." + lastWorldName));
+        User requester = null;
+        if (sender.isPlayer()) {
+            requester = ess.getUser(sender.getPlayer());
+
+            if (user.getWorld() != user.getLastLocation().getWorld() && this.ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + lastWorldName)) {
+                throw new Exception(tl("noPerm", "essentials.worlds." + lastWorldName));
+            }
+
+            if (!requester.isAuthorized("essentials.back.into." + lastWorldName)) {
+                throw new Exception(tl("noPerm", "essentials.back.into." + lastWorldName));
+            }
         }
 
-        if (!user.isAuthorized("essentials.back.into." + lastWorldName)) {
-            throw new Exception(tl("noPerm", "essentials.back.into." + lastWorldName));
+        if (requester == null) {
+            user.getTeleport().back(null, null);
+        } else if (!requester.equals(user)) {
+            Trade charge = new Trade(this.getName(), this.ess);
+            charge.isAffordableFor(requester);
+            user.getTeleport().back(requester, charge);
+        } else {
+            Trade charge = new Trade(this.getName(), this.ess);
+            charge.isAffordableFor(user);
+            user.getTeleport().back(charge);
         }
-
-        final Trade charge = new Trade(this.getName(), ess);
-        charge.isAffordableFor(user);
-        user.getTeleport().back(charge);
         throw new NoChargeException();
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        if (user.isAuthorized("essentials.back.others") && args.length == 1) {
+            return getPlayers(server, user);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -20,6 +20,7 @@ antiBuildPlace=\u00a74You are not permitted to place\u00a7c {0} \u00a74here.
 antiBuildUse=\u00a74You are not permitted to use\u00a7c {0}\u00a74.
 autoAfkKickReason=You have been kicked for idling more than {0} minutes.
 backAfterDeath=\u00a76Use the /back command to return to your death point.
+backOther=\u00a76Returned\u00a7c {0}\u00a76 to previous location.
 backupDisabled=\u00a74An external backup script has not been configured.
 backupFinished=\u00a76Backup finished.
 backupStarted=\u00a76Backup started.

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -24,6 +24,7 @@ autoTeleportDisabledFor=\u00a7c{0}\u00a76 is no longer automatically approving t
 autoTeleportEnabled=\u00a76You are now automatically approving teleport requests.
 autoTeleportEnabledFor=\u00a7c{0}\u00a76 is now automatically approving teleport requests.
 backAfterDeath=\u00a76Use the /back command to return to your death point.
+backOther=\u00a76Returned\u00a7c {0}\u00a76 to previous location.
 backupDisabled=\u00a74An external backup script has not been configured.
 backupFinished=\u00a76Backup finished.
 backupStarted=\u00a76Backup started.

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -19,7 +19,7 @@ commands:
     aliases: [eantioch,grenade,egrenade,tnt,etnt]
   back:
     description: Teleports you to your location prior to tp/spawn/warp.
-    usage: /<command>
+    usage: /<command> [player]
     aliases: [eback,return,ereturn]
   backup:
     description: Runs the backup if configured.


### PR DESCRIPTION
This PR fixes #2403.

Prior to this patch, players may only execute `/back` for themselves. By adding `/back [player]`, this command can be extended for use by a player to teleport someone else to their last location recorded by Essentials.

**Notes**

I ran into a few *difficulties* on some decisions for `Teleport.java` and `Commandback.java`. If any certain design decision I've made comes into question, I'd be happy to discuss and amend them.

**Demo**
```
[22:45:27 INFO]: CONSOLE issued server command: /ess version
[22:45:27 INFO]: Server version: 1.13.2-R0.1-SNAPSHOT git-Paper-"7d843554" (MC: 1.13.2)
[22:45:27 INFO]: EssentialsX version: 2.16.1.10
[22:45:27 INFO]: LuckPerms version: 4.3.73
[22:45:27 INFO]: Vault is not installed. Chat and permissions may not work.
```

https://streamable.com/ytlx4