### PR TITLE
Fixes #94 - Player with same first letters conflict

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -104,7 +104,11 @@ public abstract class EssentialsCommand implements IEssentialsCommand {
         try {
             exPlayer = server.getPlayer(UUID.fromString(searchTerm));
         } catch (IllegalArgumentException ex) {
-            exPlayer = server.getPlayer(searchTerm);
+            if (getOffline) {
+                exPlayer = server.getPlayerExact(searchTerm);
+            } else {
+                exPlayer = server.getPlayer(searchTerm);
+            }
         }
 
         if (exPlayer != null) {


### PR DESCRIPTION
Fixes #94.

Prior to this patch, attempting to perform some action on a player with certain commands (such as `unban`) whose name starts with the same letters as another online player will cause the method to select the online player over the offline player. After this patch, all calls that allow offline players to be returned as a result will only look for exact matches before using `matchPlayer` to look for partial matches.

**Demo**
```
[18:54:11 INFO]: CONSOLE issued server command: /ess version
[18:54:11 INFO]: Server version: 1.13.2-R0.1-SNAPSHOT git-Paper-"7d843554" (MC: 1.13.2)
[18:54:11 INFO]: EssentialsX version: 2.16.1.9
[18:54:11 INFO]: LuckPerms version: 4.3.73
[18:54:11 INFO]: Vault is not installed. Chat and permissions may not work.
```

https://streamable.com/aguu3