### PR TITLE
Fixes #1928 - Auto-AFK issue: AFK timer not reset on disconnect

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -221,7 +221,7 @@ public class EssentialsPlayerListener implements Listener {
 
         final long currentTime = System.currentTimeMillis();
         dUser.checkMuteTimeout(currentTime);
-        dUser.updateActivityOnInteract(false);
+        dUser.updateActivity(false);
         dUser.stopTransaction();
 
         class DelayJoinTask implements Runnable {

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -183,7 +183,7 @@ public class EssentialsPlayerListener implements Listener {
             }
         }
 
-        user.updateActivityOnInteract(false);
+        user.updateActivity(false);
         if (!user.isHidden()) {
             user.setLastLogout(System.currentTimeMillis());
         }


### PR DESCRIPTION
Fixes #1928.

Prior to this patch, players may leave the server and rejoin with their AFK timer still running. This has been fixed by always resetting the player's AFK timer on disconnect, regardless of the setting of `cancel-afk-on-interact`.

This PR is similar to #1935. However, I feel justified in opening this PR as it has a much cleaner diff and rectifies the issue at hand without adding any extra features. @md678685 mentioned:

> Players' AFK timers shouldn't be stored when they log off - that's an oversight on our part.

and thus, I have directly addressed the problem without adding an extra config option to disable this. 

Finally, I feel that this PR would have a better chance of being pulled over #1935, and therefore fixing the issue more quickly.

**Demo**
```
[16:49:13 INFO]: CONSOLE issued server command: /ess version
[16:49:13 INFO]: Server version: 1.13.2-R0.1-SNAPSHOT git-Paper-"16db0e6a" (MC: 1.13.2)
[16:49:13 INFO]: EssentialsX version: 2.16.1.10
[16:49:13 INFO]: LuckPerms version: 4.3.73
[16:49:13 INFO]: Vault is not installed. Chat and permissions may not work.
```

https://streamable.com/t5wnc