### PR TITLE
Fix spawning shields with enchantments (#2515) @Argetan

### DIFF
--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -208,8 +208,12 @@ public class MetaItemStack {
             stack.setItemMeta(meta);
         } else if (split.length > 1 && split[0].equalsIgnoreCase("itemflags") && hasMetaPermission(sender, "itemflags", false, true, ess)) {
             addItemFlags(string);
+        } else if (MaterialUtil.isFirework(stack.getType())) {
+            //WARNING - Meta for fireworks will be ignored after this point.
         } else if (MaterialUtil.isFirework(stack.getType())) {//WARNING - Meta for fireworks will be ignored after this point.
             addFireworkMeta(sender, false, string, ess);
+        } else if (MaterialUtil.isPotion(stack.getType())) {
+            //WARNING - Meta for potions will be ignored after this point.
         } else if (MaterialUtil.isPotion(stack.getType())) { //WARNING - Meta for potions will be ignored after this point.
             addPotionMeta(sender, false, string, ess);
         } else if (MaterialUtil.isBanner(stack.getType())) {

--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -210,11 +210,7 @@ public class MetaItemStack {
             addItemFlags(string);
         } else if (MaterialUtil.isFirework(stack.getType())) {
             //WARNING - Meta for fireworks will be ignored after this point.
-        } else if (MaterialUtil.isFirework(stack.getType())) {
-            //WARNING - Meta for fireworks will be ignored after this point.
             addFireworkMeta(sender, false, string, ess);
-        } else if (MaterialUtil.isPotion(stack.getType())) {
-            //WARNING - Meta for potions will be ignored after this point.
         } else if (MaterialUtil.isPotion(stack.getType())) {
             //WARNING - Meta for potions will be ignored after this point.
             addPotionMeta(sender, false, string, ess);

--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -210,11 +210,13 @@ public class MetaItemStack {
             addItemFlags(string);
         } else if (MaterialUtil.isFirework(stack.getType())) {
             //WARNING - Meta for fireworks will be ignored after this point.
-        } else if (MaterialUtil.isFirework(stack.getType())) {//WARNING - Meta for fireworks will be ignored after this point.
+        } else if (MaterialUtil.isFirework(stack.getType())) {
+            //WARNING - Meta for fireworks will be ignored after this point.
             addFireworkMeta(sender, false, string, ess);
         } else if (MaterialUtil.isPotion(stack.getType())) {
             //WARNING - Meta for potions will be ignored after this point.
-        } else if (MaterialUtil.isPotion(stack.getType())) { //WARNING - Meta for potions will be ignored after this point.
+        } else if (MaterialUtil.isPotion(stack.getType())) {
+            //WARNING - Meta for potions will be ignored after this point.
             addPotionMeta(sender, false, string, ess);
         } else if (MaterialUtil.isBanner(stack.getType())) {
             if (stack.getType().toString().equals("SHIELD") && Enchantments.getByName(split[0]) != null) {

--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -217,8 +217,12 @@ public class MetaItemStack {
         } else if (MaterialUtil.isPotion(stack.getType())) { //WARNING - Meta for potions will be ignored after this point.
             addPotionMeta(sender, false, string, ess);
         } else if (MaterialUtil.isBanner(stack.getType())) {
-            //WARNING - Meta for banners will be ignored after this point.
-            addBannerMeta(sender, false, string, ess);
+            if (stack.getType().toString().equals("SHIELD") && Enchantments.getByName(split[0]) != null) {
+                parseEnchantmentStrings(sender, allowUnsafe, split, ess);
+            } else {
+                //WARNING - Meta for banners will be ignored after this point.
+                addBannerMeta(sender, false, string, ess);
+            }
         } else if (split.length > 1 && (split[0].equalsIgnoreCase("color") || split[0].equalsIgnoreCase("colour")) && MaterialUtil.isLeatherArmor(stack.getType())) {
             final String[] color = split[1].split("(\\||,)");
             if (color.length == 1 && (NumberUtil.isInt(color[0]) || color[0].startsWith("#"))) {

--- a/scripts/buildtools.sh
+++ b/scripts/buildtools.sh
@@ -10,7 +10,11 @@ is_installed() {
 ensure_buildtools() {
     if [ ! -f "BuildTools.jar" ]; then
         echo "Downloading BuildTools..."
-        wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            curl https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar -o BuildTools.jar
+        else
+            wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+        fi
     fi
 }
 
@@ -53,5 +57,3 @@ if [ $is_183 -ne 0 ]; then
 else
     echo "CraftBukkit 1.8.3 installed; skipping BuildTools..."
 fi
-
-popd

--- a/scripts/buildtools.sh
+++ b/scripts/buildtools.sh
@@ -57,3 +57,5 @@ if [ $is_183 -ne 0 ]; then
 else
     echo "CraftBukkit 1.8.3 installed; skipping BuildTools..."
 fi
+
+popd


### PR DESCRIPTION
As the title suggests this PR will fix #2507. The issue was that enchantments would also be parsed by the `addBannerMeta()` function (which can't deal with enchantments), thus what I did was add a small if-statement that will check if a) the item is a shield and b) if an enchantment is being applied. If not, then just use the `addBannerMeta()` function.

The command I used to test my PR is the following:
`/give username shield 1 mending:1 unbreaking:5 name:Big_Round_Woodshield lore:A_large_shield_that_covers|most_of_the_body_at_any|given_time_during_combat.`
Which is the one mentioned in the issue (#2507).

_p.s. I made the small mistake of not branching before pushing/committing hence why there are 2 commits in this PR that have already been merged. But since they have already been merged they don't actually change anything._