### PR TITLE
More 1.14 Progress

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Mob.java
+++ b/Essentials/src/com/earth2me/essentials/Mob.java
@@ -3,8 +3,7 @@ package com.earth2me.essentials;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
+import org.bukkit.entity.*;
 
 import java.util.*;
 import java.util.logging.Level;
@@ -83,6 +82,13 @@ public enum Mob {
     TROPICAL_FISH("TropicalFish", Enemies.NEUTRAL, "TROPICAL_FISH"),
     DROWNED("Drowned", Enemies.ENEMY, "DROWNED"),
     DOLPHIN("Dolphin", Enemies.NEUTRAL, "DOLPHIN"),
+    CAT("Cat", Enemies.FRIENDLY, EntityType.CAT),
+    FOX("Fox", Enemies.FRIENDLY, EntityType.FOX),
+    PANDA("Panda", Enemies.NEUTRAL, EntityType.PANDA),
+    PILLAGER("Pillager", Enemies.ENEMY, EntityType.PILLAGER),
+    RAVAGER("Ravager", Enemies.ENEMY, EntityType.RAVAGER),
+    TRADER_LLAMA("TraderLlama", Enemies.FRIENDLY, EntityType.TRADER_LLAMA),
+    WANDERING_TRADER("WanderingTrader", Enemies.FRIENDLY, EntityType.WANDERING_TRADER)
     ;
 
     public static final Logger logger = Logger.getLogger("Essentials");

--- a/Essentials/src/com/earth2me/essentials/MobData.java
+++ b/Essentials/src/com/earth2me/essentials/MobData.java
@@ -19,6 +19,7 @@ import static com.earth2me.essentials.I18n.tl;
 public enum MobData {
     BABY_AGEABLE("baby", Ageable.class, Data.BABY, true),
     ADULT_AGEABLE("adult", Ageable.class, Data.ADULT, true),
+    BABY_CAT("kitten", EntityType.CAT, Data.BABY, false),
     BABY_PIG("piglet", EntityType.PIG, Data.BABY, false),
     BABY_WOLF("puppy", EntityType.WOLF, Data.BABY, false),
     BABY_CHICKEN("chick", EntityType.CHICKEN, Data.BABY, false),
@@ -57,13 +58,19 @@ public enum MobData {
     GOLD_ARMOR_HORSE("goldarmor", EntityType.HORSE, EnumUtil.getMaterial("GOLDEN_HORSE_ARMOR", "GOLD_BARDING"), true),
     DIAMOND_ARMOR_HORSE("diamondarmor", EntityType.HORSE, EnumUtil.getMaterial("DIAMOND_HORSE_ARMOR", "DIAMOND_BARDING"), true),
     ARMOR_HORSE("armor", EntityType.HORSE, EnumUtil.getMaterial("IRON_HORSE_ARMOR", "IRON_BARDING"), true),
-    SIAMESE_CAT("siamese", EntityType.OCELOT, Ocelot.Type.SIAMESE_CAT, true),
-    WHITE_CAT("white", EntityType.OCELOT, Ocelot.Type.SIAMESE_CAT, false),
-    RED_CAT("red", EntityType.OCELOT, Ocelot.Type.RED_CAT, true),
-    ORANGE_CAT("orange", EntityType.OCELOT, Ocelot.Type.RED_CAT, false),
-    TABBY_CAT("tabby", EntityType.OCELOT, Ocelot.Type.RED_CAT, false),
-    BLACK_CAT("black", EntityType.OCELOT, Ocelot.Type.BLACK_CAT, true),
-    TUXEDO_CAT("tuxedo", EntityType.OCELOT, Ocelot.Type.BLACK_CAT, false),
+    SIAMESE_CAT("siamese", EntityType.CAT, Cat.Type.SIAMESE, true),
+    WHITE_CAT("white", EntityType.CAT, Cat.Type.WHITE, true),
+    RED_CAT("red", EntityType.CAT, Cat.Type.RED, true),
+    ORANGE_CAT("orange", EntityType.CAT, Cat.Type.RED, false),
+    TABBY_CAT("tabby", EntityType.CAT, Cat.Type.TABBY, false),
+    BLACK_CAT("black", EntityType.CAT, Cat.Type.BLACK, true),
+    BRITISH_SHORTHAIR_CAT("britishshorthair", EntityType.CAT, Cat.Type.BRITISH_SHORTHAIR, true),
+    CALICO_CAT("calico", EntityType.CAT, Cat.Type.CALICO, true),
+    PERSIAN_CAT("persian", EntityType.CAT, Cat.Type.PERSIAN, true),
+    RAGDOLL_CAT("ragdoll", EntityType.CAT, Cat.Type.RAGDOLL, true),
+    JELLIE_CAT("jellie", EntityType.CAT, Cat.Type.JELLIE, true),
+    ALL_BLACK_CAT("allblack", EntityType.CAT, Cat.Type.ALL_BLACK, true),
+    TUXEDO_CAT("tuxedo", EntityType.CAT, Cat.Type.BLACK, false),
     BABY_ZOMBIE("baby", EntityType.ZOMBIE.getEntityClass(), Data.BABYZOMBIE, true),
     ADULT_ZOMBIE("adult", EntityType.ZOMBIE.getEntityClass(), Data.ADULTZOMBIE, true),
     DIAMOND_SWORD_ZOMBIE("diamondsword", EntityType.ZOMBIE.getEntityClass(), Material.DIAMOND_SWORD, true),
@@ -83,12 +90,21 @@ public enum MobData {
     SADDLE_PIG("saddle", EntityType.PIG, Data.PIGSADDLE, true),
     ANGRY_WOLF("angry", EntityType.WOLF, Data.ANGRY, true),
     RABID_WOLF("rabid", EntityType.WOLF, Data.ANGRY, false),
-    FARMER_VILLAGER("farmer", EntityType.VILLAGER, Villager.Profession.FARMER, true),
-    LIBRARIAN_VILLAGER("librarian", EntityType.VILLAGER, Villager.Profession.LIBRARIAN, true),
-    PRIEST_VILLAGER("priest", EntityType.VILLAGER, Villager.Profession.PRIEST, true),
-    FATHER_VILLAGER("father", EntityType.VILLAGER, Villager.Profession.PRIEST, false),
-    SMITH_VILLAGER("smith", EntityType.VILLAGER, Villager.Profession.BLACKSMITH, true),
+    VILLAGER("villager", EntityType.VILLAGER, Villager.Profession.NONE, true),
+    ARMORER_VILLAGER("armorer", EntityType.VILLAGER, Villager.Profession.ARMORER, true),
     BUTCHER_VILLAGER("butcher", EntityType.VILLAGER, Villager.Profession.BUTCHER, true),
+    CARTOGRAPHER_VILLAGER("cartographer", EntityType.VILLAGER, Villager.Profession.CARTOGRAPHER, true),
+    CLERIC_VILLAGER("cleric", EntityType.VILLAGER, Villager.Profession.CLERIC, true),
+    FARMER_VILLAGER("farmer", EntityType.VILLAGER, Villager.Profession.FARMER, true),
+    FISHERMAN_VILLAGER("fisherman", EntityType.VILLAGER, Villager.Profession.FISHERMAN, true),
+    FLETCHER_VILLAGER("fletcher", EntityType.VILLAGER, Villager.Profession.FLETCHER, true),
+    LEATHERWORKER_VILLAGER("leatherworker", EntityType.VILLAGER, Villager.Profession.LEATHERWORKER, true),
+    LIBRARIAN_VILLAGER("librarian", EntityType.VILLAGER, Villager.Profession.LIBRARIAN, true),
+    MASON_VILLAGER("mason", EntityType.VILLAGER, Villager.Profession.MASON, true),
+    NITWIT_VILLAGER("nitwit", EntityType.VILLAGER, Villager.Profession.NITWIT, true),
+    SHEPHERD_VILLAGER("shepherd", EntityType.VILLAGER, Villager.Profession.SHEPHERD, true),
+    TOOLSMITH_VILLAGER("toolsmith", EntityType.VILLAGER, Villager.Profession.TOOLSMITH, true),
+    WEAPONSMITH("weaponsmith", EntityType.VILLAGER, Villager.Profession.WEAPONSMITH, true),
     SIZE_SLIME("", "<1-100>", EntityType.SLIME.getEntityClass(), Data.SIZE, true),
     NUM_EXPERIENCE_ORB("", "<1-2000000000>", EntityType.EXPERIENCE_ORB, Data.EXP, true),
     RED_PARROT("red", EntityType.PARROT, Parrot.Variant.RED, true),
@@ -107,7 +123,20 @@ public enum MobData {
     GLITTER_TROPICAL_FISH("glitter", EntityType.TROPICAL_FISH, TropicalFish.Pattern.GLITTER, true),
     BLOCKFISH_TROPICAL_FISH("blockfish", EntityType.TROPICAL_FISH, TropicalFish.Pattern.BLOCKFISH, true),
     BETTY_TROPICAL_FISH("betty", EntityType.TROPICAL_FISH, TropicalFish.Pattern.BETTY, true),
-    CLAYFISH_TROPICAL_FISH("clayfish", EntityType.TROPICAL_FISH, TropicalFish.Pattern.CLAYFISH, true);
+    CLAYFISH_TROPICAL_FISH("clayfish", EntityType.TROPICAL_FISH, TropicalFish.Pattern.CLAYFISH, true),
+    BABY_FOX("baby", EntityType.FOX, Data.BABY, false),
+    BROWN_MUSHROOM_COW("brown", EntityType.MUSHROOM_COW, MushroomCow.Variant.BROWN, true),
+    RED_MUSHROOM_COW("red", EntityType.MUSHROOM_COW, MushroomCow.Variant.RED, true),
+    AGGRESSIVE_PANDA("aggressive", EntityType.PANDA, Panda.Gene.AGGRESSIVE, true),
+    LAZY_PANDA("lazy", EntityType.PANDA, Panda.Gene.LAZY, true),
+    WORRIED_PANDA("worried", EntityType.PANDA, Panda.Gene.WORRIED, true),
+    PLAYFUL_PANDA("playful", EntityType.PANDA, Panda.Gene.PLAYFUL, true),
+    BROWN_PANDA("brown", EntityType.PANDA, Panda.Gene.BROWN, true),
+    WEAK_PANDA("weak", EntityType.PANDA, Panda.Gene.WEAK, true),
+    CREAMY_TRADER_LLAMA("creamy", EntityType.TRADER_LLAMA, TraderLlama.Color.CREAMY, true),
+    WHITE_TRADER_LLAMA("white", EntityType.TRADER_LLAMA, TraderLlama.Color.WHITE, true),
+    BROWN_TRADER_LLAMA("brown", EntityType.TRADER_LLAMA, TraderLlama.Color.BROWN, true),
+    GRAY_TRADER_LLAMA("gray", EntityType.TRADER_LLAMA, TraderLlama.Color.GRAY, true)
     ;
 
 
@@ -250,8 +279,8 @@ public enum MobData {
             ((Horse) spawned).setColor((Horse.Color) this.value);
         } else if (this.value instanceof Horse.Style) {
             ((Horse) spawned).setStyle((Horse.Style) this.value);
-        } else if (this.value instanceof Ocelot.Type) {
-            ((Ocelot) spawned).setCatType((Ocelot.Type) this.value);
+        } else if (this.value instanceof Cat.Type) {
+            ((Cat) spawned).setCatType((Cat.Type) this.value);
         } else if (this.value instanceof Villager.Profession) {
             ((Villager) spawned).setProfession((Villager.Profession) this.value);
         } else if (this.value instanceof Material) {
@@ -267,6 +296,12 @@ public enum MobData {
             ((Parrot) spawned).setVariant((Parrot.Variant) this.value);
         } else if (this.value instanceof TropicalFish.Pattern) {
             ((TropicalFish) spawned).setPattern((TropicalFish.Pattern) this.value);
+        } else if (this.value instanceof MushroomCow.Variant) {
+            ((MushroomCow) spawned).setVariant((MushroomCow.Variant) this.value);
+        } else if (this.value instanceof Panda.Gene) {
+            ((Panda) spawned).setMainGene((Panda.Gene) this.value);
+        } else if (this.value instanceof TraderLlama.Color) {
+            ((TraderLlama) spawned).setColor((TraderLlama.Color) this.value);
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/MobData.java
+++ b/Essentials/src/com/earth2me/essentials/MobData.java
@@ -58,19 +58,26 @@ public enum MobData {
     GOLD_ARMOR_HORSE("goldarmor", EntityType.HORSE, EnumUtil.getMaterial("GOLDEN_HORSE_ARMOR", "GOLD_BARDING"), true),
     DIAMOND_ARMOR_HORSE("diamondarmor", EntityType.HORSE, EnumUtil.getMaterial("DIAMOND_HORSE_ARMOR", "DIAMOND_BARDING"), true),
     ARMOR_HORSE("armor", EntityType.HORSE, EnumUtil.getMaterial("IRON_HORSE_ARMOR", "IRON_BARDING"), true),
-    SIAMESE_CAT("siamese", EntityType.CAT, Cat.Type.SIAMESE, true),
-    WHITE_CAT("white", EntityType.CAT, Cat.Type.WHITE, true),
-    RED_CAT("red", EntityType.CAT, Cat.Type.RED, true),
-    ORANGE_CAT("orange", EntityType.CAT, Cat.Type.RED, false),
-    TABBY_CAT("tabby", EntityType.CAT, Cat.Type.TABBY, false),
-    BLACK_CAT("black", EntityType.CAT, Cat.Type.BLACK, true),
+    SIAMESE_CAT("siamese", EntityType.OCELOT, Ocelot.Type.SIAMESE_CAT, true),
+    WHITE_CAT("white", EntityType.OCELOT, Ocelot.Type.SIAMESE_CAT, false),
+    RED_CAT("red", EntityType.OCELOT, Ocelot.Type.RED_CAT, true),
+    ORANGE_CAT("orange", EntityType.OCELOT, Ocelot.Type.RED_CAT, false),
+    TABBY_CAT("tabby", EntityType.OCELOT, Ocelot.Type.RED_CAT, false),
+    BLACK_CAT("black", EntityType.OCELOT, Ocelot.Type.BLACK_CAT, true),
+    TUXEDO_CAT("tuxedo", EntityType.OCELOT, Ocelot.Type.BLACK_CAT, false),
+    NEW_SIAMESE_CAT("siamese", EntityType.CAT, Cat.Type.SIAMESE, true),
+    NEW_WHITE_CAT("white", EntityType.CAT, Cat.Type.WHITE, true),
+    NEW_RED_CAT("red", EntityType.CAT, Cat.Type.RED, true),
+    NEW_ORANGE_CAT("orange", EntityType.CAT, Cat.Type.RED, false),
+    NEW_TABBY_CAT("tabby", EntityType.CAT, Cat.Type.TABBY, false),
+    NEW_BLACK_CAT("black", EntityType.CAT, Cat.Type.BLACK, true),
     BRITISH_SHORTHAIR_CAT("britishshorthair", EntityType.CAT, Cat.Type.BRITISH_SHORTHAIR, true),
     CALICO_CAT("calico", EntityType.CAT, Cat.Type.CALICO, true),
     PERSIAN_CAT("persian", EntityType.CAT, Cat.Type.PERSIAN, true),
     RAGDOLL_CAT("ragdoll", EntityType.CAT, Cat.Type.RAGDOLL, true),
     JELLIE_CAT("jellie", EntityType.CAT, Cat.Type.JELLIE, true),
     ALL_BLACK_CAT("allblack", EntityType.CAT, Cat.Type.ALL_BLACK, true),
-    TUXEDO_CAT("tuxedo", EntityType.CAT, Cat.Type.BLACK, false),
+    NEW_TUXEDO_CAT("tuxedo", EntityType.CAT, Cat.Type.BLACK, false),
     BABY_ZOMBIE("baby", EntityType.ZOMBIE.getEntityClass(), Data.BABYZOMBIE, true),
     ADULT_ZOMBIE("adult", EntityType.ZOMBIE.getEntityClass(), Data.ADULTZOMBIE, true),
     DIAMOND_SWORD_ZOMBIE("diamondsword", EntityType.ZOMBIE.getEntityClass(), Material.DIAMOND_SWORD, true),
@@ -281,6 +288,8 @@ public enum MobData {
             ((Horse) spawned).setStyle((Horse.Style) this.value);
         } else if (this.value instanceof Cat.Type) {
             ((Cat) spawned).setCatType((Cat.Type) this.value);
+        } else if (this.value instanceof Ocelot.Type) {
+            ((Ocelot) spawned).setCatType((Ocelot.Type) this.value);
         } else if (this.value instanceof Villager.Profession) {
             ((Villager) spawned).setProfession((Villager.Profession) this.value);
         } else if (this.value instanceof Material) {

--- a/Essentials/src/com/earth2me/essentials/MobData.java
+++ b/Essentials/src/com/earth2me/essentials/MobData.java
@@ -131,7 +131,6 @@ public enum MobData {
     BLOCKFISH_TROPICAL_FISH("blockfish", EntityType.TROPICAL_FISH, TropicalFish.Pattern.BLOCKFISH, true),
     BETTY_TROPICAL_FISH("betty", EntityType.TROPICAL_FISH, TropicalFish.Pattern.BETTY, true),
     CLAYFISH_TROPICAL_FISH("clayfish", EntityType.TROPICAL_FISH, TropicalFish.Pattern.CLAYFISH, true),
-    BABY_FOX("baby", EntityType.FOX, Data.BABY, false),
     BROWN_MUSHROOM_COW("brown", EntityType.MUSHROOM_COW, MushroomCow.Variant.BROWN, true),
     RED_MUSHROOM_COW("red", EntityType.MUSHROOM_COW, MushroomCow.Variant.RED, true),
     AGGRESSIVE_PANDA("aggressive", EntityType.PANDA, Panda.Gene.AGGRESSIVE, true),

--- a/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
+++ b/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
@@ -23,6 +23,7 @@ import org.bukkit.metadata.MetadataValue;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -159,6 +160,11 @@ public class OfflinePlayer implements Player {
     }
 
     public BlockFace getFacing() {
+        return null;
+    }
+
+    @Override
+    public Pose getPose() {
         return null;
     }
 
@@ -1614,4 +1620,9 @@ public class OfflinePlayer implements Player {
     @Override
 	public void updateCommands() {
 	}
+
+    @Override
+    public PersistentDataContainer getPersistentDataContainer() {
+        return null;
+    }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandkittycannon.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkittycannon.java
@@ -4,7 +4,7 @@ import com.earth2me.essentials.Mob;
 import com.earth2me.essentials.User;
 import org.bukkit.Location;
 import org.bukkit.Server;
-import org.bukkit.entity.Ocelot;
+import org.bukkit.entity.Cat;
 
 import java.util.Random;
 
@@ -18,13 +18,13 @@ public class Commandkittycannon extends EssentialsCommand {
 
     @Override
     protected void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
-        final Mob cat = Mob.OCELOT;
-        final Ocelot ocelot = (Ocelot) cat.spawn(user.getWorld(), server, user.getBase().getEyeLocation());
+        final Mob cat = Mob.CAT;
+        final Cat ocelot = (Cat) cat.spawn(user.getWorld(), server, user.getBase().getEyeLocation());
         if (ocelot == null) {
             return;
         }
-        final int i = random.nextInt(Ocelot.Type.values().length);
-        ocelot.setCatType(Ocelot.Type.values()[i]);
+        final int i = random.nextInt(Cat.Type.values().length);
+        ocelot.setCatType(Cat.Type.values()[i]);
         ocelot.setTamed(true);
         ocelot.setBaby();
         ocelot.setVelocity(user.getBase().getEyeLocation().getDirection().multiply(2));

--- a/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java
+++ b/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java
@@ -111,19 +111,8 @@ public class FakeWorld implements World {
     public boolean unloadChunk(int i, int i1, boolean bln) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
-
-    @Override
-    public boolean unloadChunk(int i, int i1, boolean bln, boolean bln1) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
     @Override
     public boolean unloadChunkRequest(int i, int i1) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-    @Override
-    public boolean unloadChunkRequest(int i, int i1, boolean bln) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
@@ -168,7 +157,7 @@ public class FakeWorld implements World {
     }
 
     @Override
-    public <T extends Arrow> T spawnArrow(Location location, Vector vector, float v, float v1, Class<T> aClass) {
+    public <T extends AbstractArrow> T spawnArrow(Location location, Vector vector, float v, float v1, Class<T> aClass) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 

--- a/Essentials/src/com/earth2me/essentials/utils/VersionUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/VersionUtil.java
@@ -20,10 +20,9 @@ public class VersionUtil {
     public static final BukkitVersion v1_12_2_R01 = BukkitVersion.fromString("1.12.2-R0.1-SNAPSHOT");
     public static final BukkitVersion v1_13_0_R01 = BukkitVersion.fromString("1.13.0-R0.1-SNAPSHOT");
     public static final BukkitVersion v1_13_2_R01 = BukkitVersion.fromString("1.13.2-R0.1-SNAPSHOT");
-    // TODO: update to 1.14 release
-    public static final BukkitVersion v1_14_PRE5 = BukkitVersion.fromString("1.14-pre5-SNAPSHOT");
+    public static final BukkitVersion v1_14_R01 = BukkitVersion.fromString("1.14-R0.1-SNAPSHOT");
 
-    private static final Set<BukkitVersion> supportedVersions = ImmutableSet.of(v1_8_8_R01, v1_9_4_R01, v1_10_2_R01, v1_11_2_R01, v1_12_2_R01, v1_13_2_R01);
+    private static final Set<BukkitVersion> supportedVersions = ImmutableSet.of(v1_8_8_R01, v1_9_4_R01, v1_10_2_R01, v1_11_2_R01, v1_12_2_R01, v1_13_2_R01,  v1_14_R01);
 
     private static BukkitVersion serverVersion = null;
 
@@ -43,7 +42,6 @@ public class VersionUtil {
 
         private final int major;
         private final int minor;
-        private final int prerelease;
         private final int patch;
         private final double revision;
 
@@ -54,30 +52,26 @@ public class VersionUtil {
                 if (!Bukkit.getName().equals("Essentials Fake Server")) {
                     throw new IllegalArgumentException(string + " is not in valid version format. e.g. 1.8.8-R0.1");
                 }
-                matcher = VERSION_PATTERN.matcher(v1_13_2_R01.toString());
+                matcher = VERSION_PATTERN.matcher(v1_14_R01.toString());
                 Preconditions.checkArgument(matcher.matches(), string + " is not in valid version format. e.g. 1.8.8-R0.1");
             }
 
-            return from(matcher.group(1), matcher.group(2), matcher.group(3), matcher.group(4), matcher.group(5));
+            return from(matcher.group(1), matcher.group(2), matcher.group(3), matcher.group(4));
         }
 
-        private static BukkitVersion from(String major, String minor, String patch, String revision, String prerelease) {
+        private static BukkitVersion from(String major, String minor, String patch, String revision) {
             if (patch.isEmpty()) patch = "0";
-            if (revision.isEmpty()) revision = "0";
-            if (prerelease.isEmpty()) prerelease = "-1";
             return new BukkitVersion(Integer.parseInt(major),
                 Integer.parseInt(minor),
                 Integer.parseInt(patch),
-                Double.parseDouble(revision),
-                Integer.parseInt(prerelease));
+                Double.parseDouble(revision));
         }
 
-        private BukkitVersion(int major, int minor, int patch, double revision, int prerelease) {
+        private BukkitVersion(int major, int minor, int patch, double revision) {
             this.major = major;
             this.minor = minor;
             this.patch = patch;
             this.revision = revision;
-            this.prerelease = prerelease;
         }
 
         public boolean isHigherThan(BukkitVersion o) {
@@ -112,10 +106,6 @@ public class VersionUtil {
             return revision;
         }
 
-        public int getPrerelease() {
-            return prerelease;
-        }
-
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -126,27 +116,19 @@ public class VersionUtil {
             }
             BukkitVersion that = (BukkitVersion) o;
             return major == that.major &&
-                    minor == that.minor &&
-                    patch == that.patch &&
-                    revision == that.revision &&
-                    prerelease == that.prerelease;
+                minor == that.minor &&
+                patch == that.patch &&
+                revision == that.revision;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(major, minor, patch, revision, prerelease);
+            return Objects.hashCode(major, minor, patch, revision);
         }
 
         @Override
         public String toString() {
-            StringBuilder sb = new StringBuilder(major + "." + minor);
-            if (patch != 0) {
-                sb.append(".").append(patch);
-            }
-            if (prerelease != -1) {
-                sb.append("-pre").append(prerelease);
-            }
-            return sb.append("-R").append(revision).toString();
+            return major + "." + minor + "." + patch + "-R" + revision;
         }
 
         @Override
@@ -166,13 +148,7 @@ public class VersionUtil {
                     } else if (patch > o.patch) {
                         return 1;
                     } else { // equal patch
-                        if (prerelease < o.prerelease) {
-                            return -1;
-                        } else if (prerelease > o.prerelease) {
-                            return 1;
-                        } else { // equal prerelease
-                            return Double.compare(revision, o.revision);
-                        }
+                        return Double.compare(revision, o.revision);
                     }
                 }
             }

--- a/Essentials/src/items.json
+++ b/Essentials/src/items.json
@@ -9522,9 +9522,30 @@
     "spawneggshulk": "shulker_spawn_egg",
     "shulkspawn": "shulker_spawn_egg",
     "spawnshulk": "shulker_spawn_egg",
-    "sign": {
-        "material": "SIGN"
+    "oak_sign": {
+        "material": "OAK_SIGN"
     },
+    "oaksign": "oak_sign",
+    "acacia_sign": {
+        "material": "ACACIA_SIGN"
+    },
+    "acaciasign": "acacia_sign",
+    "birch_sign": {
+        "material": "BIRCH_SIGN"
+    },
+    "birchsign": "birch_sign",
+    "dark_oak_sign": {
+        "material": "DARK_OAK_SIGN"
+    },
+    "darkoaksign": "dark_oak_sign",
+    "jungle_sign": {
+        "material": "JUNGLE_SIGN"
+    },
+    "junglesign": "jungle_sign",
+    "spruce_sign": {
+        "material": "SPRUCE_SIGN"
+    },
+    "sprucesign": "spruce_sign",
     "silverfish_spawn_egg": {
         "material": "SILVERFISH_SPAWN_EGG"
     },
@@ -10948,11 +10969,39 @@
         "unspawnable": true
     },
     "voidair": "void_air",
-    "wall_sign": {
-        "material": "WALL_SIGN",
+    "oak_wall_sign": {
+        "material": "OAK_WALL_SIGN",
         "unspawnable": true
     },
-    "wallsign": "wall_sign",
+    "oakwallsign": "oak_wall_sign",
+    "acacia_wall_sign": {
+        "material": "ACACIA_WALL_SIGN",
+        "unspawnable": true
+    },
+    "acaciawallsign": "acacia_wall_sign",
+    "birch_wall_sign": {
+        "material": "BIRCH_WALL_SIGN",
+        "unspawnable": true
+    },
+    "birchwallsign": "birch_wall_sign",
+    "dark_oak_wall_sign": {
+        "material": "DARK_OAK_WALL_SIGN",
+        "unspawnable": true
+    },
+    "darkoakwallsign": "dark_oak_wall_sign",
+    "jungle_wall_sign": {
+        "material": "JUNGLE_WALL_SIGN",
+        "unspawnable": true
+    },
+    "junglewallsign": "jungle_wall_sign",
+    "spruce_wall_sign": {
+        "material": "SPRUCE_WALL_SIGN",
+        "unspawnable": true
+    },
+    "sprucewallsign": "spruce_wall_sign",
+    "silverfish_spawn_egg": {
+        "material": "SILVERFISH_SPAWN_EGG"
+    },
     "wall_torch": {
         "material": "WALL_TORCH",
         "unspawnable": true
@@ -23027,5 +23076,99 @@
     "eccomspawner": "dolphinmobspawner",
     "eccomcage": "dolphinmobspawner",
     "eccospawner": "dolphinmobspawner",
-    "eccocage": "dolphinmobspawner"
+    "eccocage": "dolphinmobspawner",
+    "flower_banner_pattern" : {
+        "material": "FLOWER_BANNER_PATTERN"
+    },
+    "creeper_banner_pattern" : {
+        "material": "CREEPER_BANNER_PATTERN"
+    },
+    "creeperbannerpattern": "creeper_banner_pattern",
+    "skull_banner_pattern" : {
+        "material": "SKULL_BANNER_PATTERN"
+    },
+    "skullbannerpattern": "skull_banner_pattern",
+    "mojang_banner_pattern": {
+        "material": "MOJANG_BANNER_PATTERN"
+    },
+    "mojangbannerpattern": "mojang_banner_pattern",
+    "globe_banner_pattern": {
+        "material": "GLOBE_BANNER_PATTERN"
+    },
+    "globebannerpattern": "globe_banner_pattern",
+    "crossbow": {
+        "material": "CROSSBOW"
+    },
+    "blue_dye": {
+        "material": "BLUE_DYE"
+    },
+    "bluedye": "blue_dye",
+    "brown_dye": {
+        "material": "BROWN_DYE"
+    },
+    "browndye": "brown_dye",
+    "black_dye": {
+        "material": "BLACK_DYE"
+    },
+    "blackdye": "black_dye",
+    "white_dye": {
+        "material": "WHITE_DYE"
+    },
+    "whitedye": "white_dye",
+    "leather_horse_armor": {
+        "material": "LEATHER_HORSE_ARMOR"
+    },
+    "leatherhorsearmor": "leather_horse_armor",
+    "lhorsearmor": "leather_horse_armor",
+    "cat_spawn_egg": {
+        "material": "CAT_SPAWN_EGG"
+    },
+    "catspawnegg": "cat_spawn_egg",
+    "categg": "cat_spawn_egg",
+    "eggcat": "cat_spawn_egg",
+    "fox_spawn_egg": {
+        "material": "FOX_SPAWN_EGG"
+    },
+    "foxspawnegg": "fox_spawn_egg",
+    "foxegg": "fox_spawn_egg",
+    "eggfox": "fox_spawn_egg",
+    "panda_spawn_egg": {
+        "material": "PANDA_SPAWN_EGG"
+    },
+    "pandaspawnegg": "panda_spawn_egg",
+    "pandaegg": "panda_spawn_egg",
+    "eggpanda": "panda_spawn_egg",
+    "pillager_spawn_egg": {
+        "material": "PILLAGER_SPAWN_EGG"
+    },
+    "pillagerspawnegg": "pillager_spawn_egg",
+    "pillageregg": "pillager_spawn_egg",
+    "eggpillager": "pillager_spawn_egg",
+    "ravager_spawn_egg": {
+        "material": "RAVAGER_SPAWN_EGG"
+    },
+    "ravagerspawnegg": "ravager_spawn_egg",
+    "ravageregg": "ravager_spawn_egg",
+    "eggravager": "ravager_spawn_egg",
+    "trader_llama_spawn_egg": {
+        "material": "TRADER_LLAMA_SPAWN_EGG"
+    },
+    "traderllamaspawnegg": "trader_llama_spawn_egg",
+    "traderllamaegg": "trader_llama_spawn_egg",
+    "eggtraderllama": "trader_llama_spawn_egg",
+    "wandering_trader_spawn_egg": {
+        "material": "WANDERING_TRADER_SPAWN_EGG"
+    },
+    "wanderingtraderspawnegg": "wandering_trader_spawn_egg",
+    "wanderingtraderegg": "wandering_trader_spawn_egg",
+    "eggwanderingtrader": "wandering_trader_spawn_egg",
+    "suspicious_stew": {
+        "material": "SUSPICIOUS_STEW"
+    },
+    "suspiciousstew": "suspicious_stew",
+    "sweet_berries": {
+        "material": "SWEET_BERRIES"
+    },
+    "sweetberries": "sweet_berries",
+    "berries": "sweet_berries"
 }

--- a/Essentials/src/items.json
+++ b/Essentials/src/items.json
@@ -23170,5 +23170,79 @@
         "material": "SWEET_BERRIES"
     },
     "sweetberries": "sweet_berries",
-    "berries": "sweet_berries"
+    "berries": "sweet_berries",
+    "bamboo": {
+        "material": "BAMBOO"
+    },
+    "bamboo_sapling": {
+        "material": "BAMBOO_SAPLING"
+    },
+    "bamboosapling": "bamboo_sapling",
+    "barrel": {
+        "material": "BARREL"
+    },
+    "bell": {
+        "material": "BELL"
+    },
+    "blast_furnace": {
+        "material": "BLAST_FURNACE"
+    },
+    "blastfurnace": "blast_furnace",
+    "campfire": {
+        "material": "CAMPFIRE"
+    },
+    "cartography_table": {
+        "material": "CARTOGRAPHY_TABLE"
+    },
+    "cartographytable": "cartography_table",
+    "composter": {
+        "material": "COMPOSTER"
+    },
+    "fletching_table": {
+        "material": "FLETCHING_TABLE"
+    },
+    "fletchingtable": "fletching_table",
+    "cornflower": {
+        "material": "CORNFLOWER"
+    },
+    "lily_of_the_valley": {
+        "material": "LILY_OF_THE_VALLEY"
+    },
+    "lilyofthevalley": "lily_of_the_valley",
+    "wither_rose": {
+        "material": "WITHER_ROSE"
+    },
+    "witherrose": "wither_rose",
+    "grindstone": {
+        "material": "GRINDSTONE"
+    },
+    "jigsaw": {
+        "material": "JIGSAW"
+    },
+    "lantern": {
+        "material": "LANTERN"
+    },
+    "lectern": {
+        "material": "LECTERN"
+    },
+    "loom": {
+        "material": "LOOM"
+    },
+    "scaffolding": {
+        "material": "SCAFFOLDING"
+    },
+    "smithing_table": {
+        "material": "SMITHING_TABLE"
+    },
+    "smithingtable": "smithing_table",
+    "smoker": {
+        "material": "SMOKER"
+    },
+    "sweet_berry_bush": {
+        "material": "SWEET_BERRY_BUSH"
+    },
+    "sweetberrybush": "sweet_berry_bush",
+    "stonecutter": {
+        "material": "STONECUTTER"
+    }
 }

--- a/Essentials/test/com/earth2me/essentials/FakeServer.java
+++ b/Essentials/test/com/earth2me/essentials/FakeServer.java
@@ -92,16 +92,6 @@ public class FakeServer implements Server {
     }
 
     @Override
-    public String getServerName() {
-        return "Test Server";
-    }
-
-    @Override
-    public String getServerId() {
-        return "Test Server";
-    }
-
-    @Override
     public int broadcastMessage(String string) {
         int i = 0;
         for (Player player : players) {

--- a/Essentials/test/com/earth2me/essentials/UtilTest.java
+++ b/Essentials/test/com/earth2me/essentials/UtilTest.java
@@ -197,10 +197,24 @@ public class UtilTest extends TestCase {
         assertEquals(v.getMinor(), 13);
         assertEquals(v.getPatch(), 2);
         assertEquals(v.getRevision(), 0.1);
-        v = VersionUtil.BukkitVersion.fromString("1.9-R1.4");
+        assertEquals(v.getPrerelease(), -1);
+        v = VersionUtil.BukkitVersion.fromString("1.9-R1.4"); // not real
         assertEquals(v.getMajor(), 1);
         assertEquals(v.getMinor(), 9);
         assertEquals(v.getPatch(), 0);
         assertEquals(v.getRevision(), 1.4);
+        assertEquals(v.getPrerelease(), -1);
+        v = VersionUtil.BukkitVersion.fromString("1.14-pre5");
+        assertEquals(v.getMajor(), 1);
+        assertEquals(v.getMinor(), 14);
+        assertEquals(v.getPatch(), 0);
+        assertEquals(v.getRevision(), 0.0);
+        assertEquals(v.getPrerelease(), 5);
+        v = VersionUtil.BukkitVersion.fromString("1.13.2-pre1-R0.1"); // not real
+        assertEquals(v.getMajor(), 1);
+        assertEquals(v.getMinor(), 13);
+        assertEquals(v.getPatch(), 2);
+        assertEquals(v.getRevision(), 0.1);
+        assertEquals(v.getPrerelease(), 1);
     }
 }

--- a/Essentials/test/com/earth2me/essentials/UtilTest.java
+++ b/Essentials/test/com/earth2me/essentials/UtilTest.java
@@ -197,24 +197,10 @@ public class UtilTest extends TestCase {
         assertEquals(v.getMinor(), 13);
         assertEquals(v.getPatch(), 2);
         assertEquals(v.getRevision(), 0.1);
-        assertEquals(v.getPrerelease(), -1);
-        v = VersionUtil.BukkitVersion.fromString("1.9-R1.4"); // not real
+        v = VersionUtil.BukkitVersion.fromString("1.9-R1.4");
         assertEquals(v.getMajor(), 1);
         assertEquals(v.getMinor(), 9);
         assertEquals(v.getPatch(), 0);
         assertEquals(v.getRevision(), 1.4);
-        assertEquals(v.getPrerelease(), -1);
-        v = VersionUtil.BukkitVersion.fromString("1.14-pre5");
-        assertEquals(v.getMajor(), 1);
-        assertEquals(v.getMinor(), 14);
-        assertEquals(v.getPatch(), 0);
-        assertEquals(v.getRevision(), 0);
-        assertEquals(v.getPrerelease(), 5);
-        v = VersionUtil.BukkitVersion.fromString("1.13.2-pre1-R0.1"); // not real
-        assertEquals(v.getMajor(), 1);
-        assertEquals(v.getMinor(), 13);
-        assertEquals(v.getPatch(), 2);
-        assertEquals(v.getRevision(), 0.1);
-        assertEquals(v.getPrerelease(), 1);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.14-pre5-SNAPSHOT</version>
+            <version>1.14-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request adds much of the mob and item work for you minus backward compatibility.

# Changelog:
* Targets 1.14-R0.1
* Adds 1.14 Mobs
* Adds 1.14 Items
  * Updated Signs as Well
* Adds 1.14 Blocks
* Fixes Misc Build Errors

# Notes While Testing:
* Signs work as intended
* Sometimes while moving after being AFK there is an error due to Spigot's new enforcement of async/sync events:
  * ```java.lang.IllegalStateException: AfkStatusChangeEvent cannot be triggered asynchronously from another thread.
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:502) ~[spigot-1.14.jar:git-Spigot-1eece4f-fe1199c]
        at com.earth2me.essentials.User.setAfk(User.java:463) ~[?:?]
        at com.earth2me.essentials.User.updateActivity(User.java:560) ~[?:?]
        at com.earth2me.essentials.EssentialsPlayerListener.delayedJoin(EssentialsPlayerListener.java:221) ~[?:?]
        at com.earth2me.essentials.EssentialsPlayerListener$1.run(EssentialsPlayerListener.java:198) ~[?:?]
        at org.bukkit.craftbukkit.v1_14_R1.scheduler.CraftTask.run(CraftTask.java:81) ~[spigot-1.14.jar:git-Spigot-1eece4f-fe1199c]
        at org.bukkit.craftbukkit.v1_14_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:54) [spigot-1.14.jar:git-Spigot-1eece4f-fe1199c]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:1.8.0_211]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:1.8.0_211]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_211]```

Hope this helps :)