### PR TITLE
Adds a permission node that keeps a player's inventory on death

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
@@ -159,6 +159,14 @@ public class EssentialsEntityListener implements Listener {
         }
     }
 
+    @EventHandler(priority = EventPriority.LOW)
+    public void onPlayerDeathInvEvent(final PlayerDeathEvent event) {
+        final User user = ess.getUser(event.getEntity());
+        if (user.isAuthorized("essentials.keepinv")) {
+            event.setKeepInventory(true);
+        }
+    }
+
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onFoodLevelChange(final FoodLevelChangeEvent event) {
         if (event.getEntity() instanceof Player) {


### PR DESCRIPTION
Closes https://github.com/EssentialsX/Essentials/issues/2524. 

Adds a permission node, `essentials.keepinv` so on player death their inventory will not be wiped.