### PR TITLE
Added support for human readable banner colors

### DIFF
--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -7,8 +7,6 @@ import com.earth2me.essentials.utils.*;
 import com.google.common.base.Joiner;
 import net.ess3.api.IEssentials;
 import net.ess3.nms.refl.ReflUtil;
-
-import org.apache.commons.lang.ArrayUtils;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.FireworkEffect;
@@ -198,7 +196,7 @@ public class MetaItemStack {
             final BookMeta meta = (BookMeta) stack.getItemMeta();
             meta.setTitle(title);
             stack.setItemMeta(meta);
-        } else if (split.length > 1 && split[0].equalsIgnoreCase("power") && (MaterialUtil.isFirework(stack.getType()))&& hasMetaPermission(sender, "firework-power", false, true, ess)) {
+        } else if (split.length > 1 && split[0].equalsIgnoreCase("power") && (MaterialUtil.isFirework(stack.getType())) && hasMetaPermission(sender, "firework-power", false, true, ess)) {
             final int power = NumberUtil.isInt(split[1]) ? Integer.parseInt(split[1]) : 0;
             final FireworkMeta meta = (FireworkMeta) stack.getItemMeta();
             meta.setPower(power > 3 ? 4 : power);
@@ -226,9 +224,9 @@ public class MetaItemStack {
                 String input = color[0];
                 if (input.startsWith("#")) { // Hex
                     meta.setColor(Color.fromRGB(
-                        Integer.valueOf(input.substring(1, 3), 16),
-                        Integer.valueOf(input.substring(3, 5), 16),
-                        Integer.valueOf(input.substring(5, 7), 16)));
+                            Integer.valueOf(input.substring(1, 3), 16),
+                            Integer.valueOf(input.substring(3, 5), 16),
+                            Integer.valueOf(input.substring(5, 7), 16)));
                 } else { // Int
                     meta.setColor(Color.fromRGB(Integer.parseInt(input)));
                 }
@@ -273,7 +271,7 @@ public class MetaItemStack {
     }
 
     public void addFireworkMeta(final CommandSource sender, final boolean allowShortName, final String string, final IEssentials ess) throws Exception {
-    if (MaterialUtil.isFirework(stack.getType())) {
+        if (MaterialUtil.isFirework(stack.getType())) {
             final String[] split = splitPattern.split(string, 2);
             if (split.length < 2) {
                 return;
@@ -491,7 +489,8 @@ public class MetaItemStack {
                     PatternType type = PatternType.valueOf(split[0].toUpperCase());
                     DyeColor color = ColorUtil.getDyeColor(split[1]);
                     pattern = new org.bukkit.block.banner.Pattern(color, type);
-                } catch (IllegalArgumentException ignored) {}
+                } catch (IllegalArgumentException ignored) {
+                }
             }
 
             if (stack.getType().toString().equals("SHIELD")) {
@@ -502,6 +501,9 @@ public class MetaItemStack {
                 if (baseColor != null) {
                     banner.setBaseColor(baseColor);
                 } else if (pattern != null) {
+                    if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.BukkitVersion.fromString("1.13.0-R0.1-SNAPSHOT"))) {
+                        return; // Avoid applying patterns on 1.13 till we have found a fix (avoids errors)
+                    }
                     banner.addPattern(pattern);
                 }
                 banner.update();

--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 import static com.earth2me.essentials.I18n.tl;
+import static com.earth2me.essentials.utils.VersionUtil.v1_13_0_R01;
 
 
 public class MetaItemStack {
@@ -501,7 +502,7 @@ public class MetaItemStack {
                 if (baseColor != null) {
                     banner.setBaseColor(baseColor);
                 } else if (pattern != null) {
-                    if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.BukkitVersion.fromString("1.13.0-R0.1-SNAPSHOT"))) {
+                    if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(v1_13_0_R01)) {
                         return; // Avoid applying patterns on 1.13 till we have found a fix (avoids errors)
                     }
                     banner.addPattern(pattern);

--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -488,7 +488,7 @@ public class MetaItemStack {
                 baseColor = ColorUtil.getDyeColor(split[1]);
             } else {
                 try {
-                    PatternType type = PatternType.valueOf(split[0]);
+                    PatternType type = PatternType.valueOf(split[0].toUpperCase());
                     DyeColor color = ColorUtil.getDyeColor(split[1]);
                     pattern = new org.bukkit.block.banner.Pattern(color, type);
                 } catch (IllegalArgumentException ignored) {}
@@ -498,24 +498,24 @@ public class MetaItemStack {
                 // Hacky fix for accessing Shield meta - https://github.com/drtshock/Essentials/pull/745#issuecomment-234843795
                 BlockStateMeta meta = (BlockStateMeta) stack.getItemMeta();
                 Banner banner = (Banner) meta.getBlockState();
+
                 if (baseColor != null) {
                     banner.setBaseColor(baseColor);
                 } else if (pattern != null) {
                     banner.addPattern(pattern);
                 }
-
                 banner.update();
+
                 meta.setBlockState(banner);
                 stack.setItemMeta(meta);
             } else {
-                final BannerMeta meta = (BannerMeta) stack.getItemMeta();
                 if (baseColor != null) {
-                    meta.setBaseColor(baseColor);
+                    stack.setType(Material.valueOf(baseColor.name() + "_BANNER"));
                 } else if (pattern != null) {
+                    final BannerMeta meta = (BannerMeta) stack.getItemMeta();
                     meta.addPattern(pattern);
+                    stack.setItemMeta(meta);
                 }
-
-                stack.setItemMeta(meta);
             }
         }
     }

--- a/Essentials/src/com/earth2me/essentials/utils/ColorUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/ColorUtil.java
@@ -1,0 +1,14 @@
+package com.earth2me.essentials.utils;
+
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
+
+public class ColorUtil {
+    public static DyeColor getDyeColor(String value) {
+        try {
+            return DyeColor.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException ignored) {
+            return DyeColor.getByColor(Color.fromRGB(Integer.valueOf(value)));
+        }
+    }
+}


### PR DESCRIPTION
This PR is still work in progress however I'd like some input on it. I implemented the suggestion in #2493, but I'm running in a couple of issues.

1. Applying a pattern to a banner works fine, but applying a pattern to a shield doesn't (throws a `NullPointerException` which I can't seem to fix).

```
java.lang.NullPointerException: null
	at org.bukkit.craftbukkit.v1_13_R2.block.CraftBanner.applyTo(CraftBanner.java:97) ~[patched_1.13.2.jar:git-Paper-486]
	at org.bukkit.craftbukkit.v1_13_R2.block.CraftBanner.applyTo(CraftBanner.java:17) ~[patched_1.13.2.jar:git-Paper-486]
	at org.bukkit.craftbukkit.v1_13_R2.block.CraftBlockEntityState.getSnapshotNBT(CraftBlockEntityState.java:103) ~[patched_1.13.2.jar:git-Paper-486]
	at org.bukkit.craftbukkit.v1_13_R2.inventory.CraftMetaBlockState.setBlockState(CraftMetaBlockState.java:564) ~[patched_1.13.2.jar:git-Paper-486]
	at com.earth2me.essentials.MetaItemStack.addBannerMeta(MetaItemStack.java:508) ~[?:?]
	at com.earth2me.essentials.MetaItemStack.addStringMeta(MetaItemStack.java:219) ~[?:?]
	at com.earth2me.essentials.MetaItemStack.parseStringMeta(MetaItemStack.java:133) ~[?:?]
	at com.earth2me.essentials.commands.Commandgive.run(Commandgive.java:71) ~[?:?]
	at com.earth2me.essentials.commands.EssentialsCommand.run(EssentialsCommand.java:166) ~[?:?]
	at com.earth2me.essentials.commands.EssentialsCommand.run(EssentialsCommand.java:161) ~[?:?]
	at com.earth2me.essentials.Essentials.onCommandEssentials(Essentials.java:545) ~[?:?]
	at com.earth2me.essentials.Essentials.onCommand(Essentials.java:458) ~[?:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:44) ~[patched_1.13.2.jar:git-Paper-486]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:149) ~[patched_1.13.2.jar:git-Paper-486]
	at org.bukkit.craftbukkit.v1_13_R2.CraftServer.dispatchCommand(CraftServer.java:732) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.PlayerConnection.handleCommand(PlayerConnection.java:1792) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.PlayerConnection.a(PlayerConnection.java:1595) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.PacketPlayInChat.a(PacketPlayInChat.java:45) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.PacketPlayInChat.a(PacketPlayInChat.java:5) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:12) ~[patched_1.13.2.jar:git-Paper-486]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_101]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_101]
	at net.minecraft.server.v1_13_R2.SystemUtils.a(SystemUtils.java:109) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.MinecraftServer.b(MinecraftServer.java:1016) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.DedicatedServer.b(DedicatedServer.java:439) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.MinecraftServer.a(MinecraftServer.java:943) ~[patched_1.13.2.jar:git-Paper-486]
	at net.minecraft.server.v1_13_R2.MinecraftServer.run(MinecraftServer.java:841) ~[patched_1.13.2.jar:git-Paper-486]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_101]
```

~~2. I get the feeling that using a number as a color is broken, which should be possible as that logic hasn't changed. Could someone provide me with a command that uses a number for the color that worked before so I can confirm if it still works?~~ Tested with `/give user banner 1 basecolor:16351261` and works fine.

Closes #123, closes #2493