### PR TITLE
Add teleport warmup event to API

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Teleport.java
+++ b/Essentials/src/com/earth2me/essentials/Teleport.java
@@ -124,7 +124,7 @@ public class Teleport implements ITeleport {
         teleportee.setLastLocation();
         Location loc = target.getLocation();
 
-        UserTeleportEvent event = new UserTeleportEvent(teleportee, target, cause);
+        UserTeleportEvent event = new UserTeleportEvent(teleportee, cause);
         Bukkit.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled()) {
             return;

--- a/Essentials/src/com/earth2me/essentials/Teleport.java
+++ b/Essentials/src/com/earth2me/essentials/Teleport.java
@@ -7,6 +7,7 @@ import net.ess3.api.IEssentials;
 import net.ess3.api.ITeleport;
 import net.ess3.api.IUser;
 import net.ess3.api.events.UserWarpEvent;
+import net.ess3.api.events.UserTeleportEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -122,6 +123,12 @@ public class Teleport implements ITeleport {
         cancel(false);
         teleportee.setLastLocation();
         Location loc = target.getLocation();
+
+        UserTeleportEvent event = new UserTeleportEvent(teleportee, target, cause);
+        Bukkit.getServer().getPluginManager().callEvent(event);
+        if (event.isCancelled()) {
+            return;
+        }
 
         if (LocationUtil.isBlockUnsafeForUser(teleportee, loc.getWorld(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ())) {
             if (ess.getSettings().isTeleportSafetyEnabled()) {
@@ -286,10 +293,10 @@ public class Teleport implements ITeleport {
     public void warp(IUser teleportee, String warp, Trade chargeFor, TeleportCause cause) throws Exception {
         UserWarpEvent event = new UserWarpEvent(teleportee, warp, chargeFor);
         Bukkit.getServer().getPluginManager().callEvent(event);
-
-        if(event.isCancelled()) {
+        if (event.isCancelled()) {
             return;
         }
+
         warp = event.getWarp();
         Location loc = ess.getWarps().getWarp(warp);
         teleportee.sendMessage(tl("warpingTo", warp, loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));

--- a/Essentials/src/com/earth2me/essentials/Teleport.java
+++ b/Essentials/src/com/earth2me/essentials/Teleport.java
@@ -121,14 +121,15 @@ public class Teleport implements ITeleport {
 
     protected void now(IUser teleportee, ITarget target, TeleportCause cause) throws Exception {
         cancel(false);
-        teleportee.setLastLocation();
         Location loc = target.getLocation();
 
-        UserTeleportEvent event = new UserTeleportEvent(teleportee, cause);
+        UserTeleportEvent event = new UserTeleportEvent(teleportee, cause, loc);
         Bukkit.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled()) {
             return;
         }
+
+        teleportee.setLastLocation();
 
         if (LocationUtil.isBlockUnsafeForUser(teleportee, loc.getWorld(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ())) {
             if (ess.getSettings().isTeleportSafetyEnabled()) {

--- a/Essentials/src/net/ess3/api/events/UserTeleportEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserTeleportEvent.java
@@ -1,0 +1,49 @@
+package net.ess3.api.events;
+
+import net.ess3.api.IUser;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+/**
+ * Called when the player teleports
+ */
+public class UserTeleportEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private IUser user;
+    private TeleportCause cause;
+    private boolean cancelled = false;
+
+    public UserTeleportEvent(IUser user, TeleportCause cause) {
+        this.user = user;
+        this.cause = cause;
+    }
+
+    public IUser getUser() {
+        return user;
+    }
+
+    public TeleportCause getTeleportCause() {
+        return cause;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        cancelled = b;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/Essentials/src/net/ess3/api/events/UserTeleportEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserTeleportEvent.java
@@ -2,6 +2,7 @@ package net.ess3.api.events;
 
 import net.ess3.api.IUser;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.Location;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -13,11 +14,13 @@ public class UserTeleportEvent extends Event implements Cancellable {
 
     private IUser user;
     private TeleportCause cause;
+    private Location target;
     private boolean cancelled = false;
 
-    public UserTeleportEvent(IUser user, TeleportCause cause) {
+    public UserTeleportEvent(IUser user, TeleportCause cause, Location target) {
         this.user = user;
         this.cause = cause;
+        this.target = target;
     }
 
     public IUser getUser() {
@@ -26,6 +29,10 @@ public class UserTeleportEvent extends Event implements Cancellable {
 
     public TeleportCause getTeleportCause() {
         return cause;
+    }
+
+    public Location getLocation() {
+        return target;
     }
 
     @Override


### PR DESCRIPTION
This PR adds the event when the player uses the `/teleport` command, the event is called so that teleportation can be cancelled by this event.

Closes, #2506 