### PR TITLE
Implement toggle for command block logging

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -487,7 +487,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             }
 
             if (bSenderBlock != null) {
-                Bukkit.getLogger().log(Level.INFO, "CommandBlock at {0},{1},{2} issued server command: /{3} {4}", new Object[]{bSenderBlock.getX(), bSenderBlock.getY(), bSenderBlock.getZ(), commandLabel, EssentialsCommand.getFinalArg(args, 0)});
+                if (getSettings().doCommandBlockCommandLogging()) {
+                    Bukkit.getLogger().log(Level.INFO, "CommandBlock at {0},{1},{2} issued server command: /{3} {4}", new Object[]{bSenderBlock.getX(), bSenderBlock.getY(), bSenderBlock.getZ(), commandLabel, EssentialsCommand.getFinalArg(args, 0)});
+                }
             } else if (user == null) {
                 Bukkit.getLogger().log(Level.INFO, "{0} issued server command: /{1} {2}", new Object[]{cSender.getName(), commandLabel, EssentialsCommand.getFinalArg(args, 0)});
             }

--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -487,7 +487,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             }
 
             if (bSenderBlock != null) {
-                if (getSettings().doCommandBlockCommandLogging()) {
+                if (getSettings().logCommandBlockCommands()) {
                     Bukkit.getLogger().log(Level.INFO, "CommandBlock at {0},{1},{2} issued server command: /{3} {4}", new Object[]{bSenderBlock.getX(), bSenderBlock.getY(), bSenderBlock.getZ(), commandLabel, EssentialsCommand.getFinalArg(args, 0)});
                 }
             } else if (user == null) {

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -329,5 +329,5 @@ public interface ISettings extends IConf {
 
     boolean isSafeUsermap();
 
-    boolean doCommandBlockCommandLogging();
+    boolean logCommandBlockCommands();
 }

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -328,4 +328,6 @@ public interface ISettings extends IConf {
     boolean allowOldIdSigns();
 
     boolean isSafeUsermap();
+
+    boolean doCommandBlockCommandLogging();
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -544,7 +544,7 @@ public class Settings implements net.ess3.api.ISettings {
         forceEnableRecipe = _isForceEnableRecipe();
         allowOldIdSigns = _allowOldIdSigns();
         isSafeUsermap = _isSafeUsermap();
-        doCommandBlockCommandLogging = _doCommandBlockCommandLogging();
+        logCommandBlockCommands = _logCommandBlockCommands();
     }
 
     void _lateLoadItemSpawnBlacklist() {
@@ -1554,14 +1554,14 @@ public class Settings implements net.ess3.api.ISettings {
         return isSafeUsermap;
     }
 
-    private boolean doCommandBlockCommandLogging;
+    private boolean logCommandBlockCommands;
 
-    private boolean _doCommandBlockCommandLogging() {
+    private boolean _logCommandBlockCommands() {
         return config.getBoolean("log-command-block-commands", true);
     }
 
     @Override
-    public boolean doCommandBlockCommandLogging() {
-        return doCommandBlockCommandLogging;
+    public boolean logCommandBlockCommands() {
+        return logCommandBlockCommands;
     }
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -544,6 +544,7 @@ public class Settings implements net.ess3.api.ISettings {
         forceEnableRecipe = _isForceEnableRecipe();
         allowOldIdSigns = _allowOldIdSigns();
         isSafeUsermap = _isSafeUsermap();
+        doCommandBlockCommandLogging = _doCommandBlockCommandLogging();
     }
 
     void _lateLoadItemSpawnBlacklist() {
@@ -1551,5 +1552,16 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean isSafeUsermap() {
         return isSafeUsermap;
+    }
+
+    private boolean doCommandBlockCommandLogging;
+
+    private boolean _doCommandBlockCommandLogging() {
+        return config.getBoolean("log-command-block-commands", true);
+    }
+
+    @Override
+    public boolean doCommandBlockCommandLogging() {
+        return doCommandBlockCommandLogging;
     }
 }

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -563,6 +563,10 @@ allow-world-in-broadcastworld: true
 # You should only change this to false if you use Minecraft China.
 safe-usermap-names: true
 
+# Should Essentials output logs when a command block executes a command?
+# Example: CommandBlock at <x>,<y>,<z> issued server command: /<command>
+log-command-block-commands: true
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                   EssentialsHome                     | #


### PR DESCRIPTION
Just a simple config toggle for whether or not command block commands should be logged.

closes #1153, closes #162 