### PR TITLE
Attempt to parse loop command input as a UUID

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsLoopCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsLoopCommand.java
@@ -4,6 +4,7 @@ import com.earth2me.essentials.ChargeException;
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
+import com.earth2me.essentials.utils.StringUtil;
 import net.ess3.api.MaxMoneyException;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
@@ -23,7 +24,11 @@ public abstract class EssentialsLoopCommand extends EssentialsCommand {
             throw new PlayerNotFoundException();
         }
 
-        if (matchWildcards && searchTerm.contentEquals("**")) {
+        final UUID uuid = StringUtil.toUUID(searchTerm);
+        if (uuid != null) {
+            final User matchedUser = ess.getUser(uuid);
+            updatePlayer(server, sender, matchedUser, commandArgs);
+        } else if (matchWildcards && searchTerm.contentEquals("**")) {
             for (UUID sUser : ess.getUserMap().getAllUniqueUsers()) {
                 final User matchedUser = ess.getUser(sUser);
                 updatePlayer(server, sender, matchedUser, commandArgs);

--- a/Essentials/src/com/earth2me/essentials/utils/StringUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/StringUtil.java
@@ -2,6 +2,7 @@ package com.earth2me.essentials.utils;
 
 import java.util.Collection;
 import java.util.Locale;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 
@@ -71,6 +72,14 @@ public class StringUtil {
             }
         }
         return buf.toString();
+    }
+
+    public static UUID toUUID(String input) {
+        try {
+            return UUID.fromString(input);
+        } catch (IllegalArgumentException ignored) {}
+
+        return null;
     }
 
     private StringUtil() {


### PR DESCRIPTION
Related: #2424

This allows loop commands to accept UUIDs as parameters, which should for example allow users to [set other people's nicknames by UUID](https://github.com/EssentialsX/Essentials/issues/2424).