### PR TITLE
Fix VersionUtil not working on 1.14.3

### DIFF
--- a/Essentials/src/com/earth2me/essentials/utils/VersionUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/VersionUtil.java
@@ -23,8 +23,9 @@ public class VersionUtil {
     public static final BukkitVersion v1_14_R01 = BukkitVersion.fromString("1.14-R0.1-SNAPSHOT");
     public static final BukkitVersion v1_14_1_R01 = BukkitVersion.fromString("1.14.1-R0.1-SNAPSHOT");
     public static final BukkitVersion v1_14_2_R01 = BukkitVersion.fromString("1.14.2-R0.1-SNAPSHOT");
+    public static final BukkitVersion v1_14_3 = BukkitVersion.fromString("1.14.3-SNAPSHOT");
 
-    private static final Set<BukkitVersion> supportedVersions = ImmutableSet.of(v1_8_8_R01, v1_9_4_R01, v1_10_2_R01, v1_11_2_R01, v1_12_2_R01, v1_13_2_R01, v1_14_2_R01);
+    private static final Set<BukkitVersion> supportedVersions = ImmutableSet.of(v1_8_8_R01, v1_9_4_R01, v1_10_2_R01, v1_11_2_R01, v1_12_2_R01, v1_13_2_R01, v1_14_3);
 
     private static BukkitVersion serverVersion = null;
 
@@ -40,7 +41,7 @@ public class VersionUtil {
     }
 
     public static class BukkitVersion implements Comparable<BukkitVersion> {
-        private static final Pattern VERSION_PATTERN = Pattern.compile("^(\\d+)\\.(\\d+)\\.?([0-9]*)?-(?:pre(\\d))?-?R?([\\d.]+)?(?:-SNAPSHOT)?");
+        private static final Pattern VERSION_PATTERN = Pattern.compile("^(\\d+)\\.(\\d+)\\.?([0-9]*)?(?:-pre(\\d))?(?:-?R?([\\d.]+))?(?:-SNAPSHOT)?");
 
         private final int major;
         private final int minor;

--- a/Essentials/test/com/earth2me/essentials/UtilTest.java
+++ b/Essentials/test/com/earth2me/essentials/UtilTest.java
@@ -216,5 +216,11 @@ public class UtilTest extends TestCase {
         assertEquals(v.getPatch(), 2);
         assertEquals(v.getRevision(), 0.1);
         assertEquals(v.getPrerelease(), 1);
+        v = VersionUtil.BukkitVersion.fromString("1.14.3-SNAPSHOT");
+        assertEquals(v.getMajor(), 1);
+        assertEquals(v.getMinor(), 14);
+        assertEquals(v.getPatch(), 3);
+        assertEquals(v.getRevision(), 0.0);
+        assertEquals(v.getPrerelease(), -1);
     }
 }


### PR DESCRIPTION
Either md_5 made a mistake with the version string or it's even more inconsistent now!

Anyways this pull request fixes issues with the 1.14.3 regex format and adds 1.14.3 to supported versions