### PR TITLE
Improve scheduler methods to use Java 1.8 lambdas

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Backup.java
+++ b/Essentials/src/com/earth2me/essentials/Backup.java
@@ -25,12 +25,7 @@ public class Backup implements Runnable {
         this.ess = ess;
         server = ess.getServer();
         if (!ess.getOnlinePlayers().isEmpty()) {
-            ess.runTaskAsynchronously(new Runnable() {
-                @Override
-                public void run() {
-                    startTask();
-                }
-            });
+            ess.runTaskAsynchronously(this::startTask);
         }
     }
 

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -192,12 +192,8 @@ public class EssentialsPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerJoin(final PlayerJoinEvent event) {
         final String joinMessage = event.getJoinMessage();
-        ess.runTaskAsynchronously(new Runnable() {
-            @Override
-            public void run() {
-                delayedJoin(event.getPlayer(), joinMessage);
-            }
-        });
+        ess.runTaskAsynchronously(() -> delayedJoin(event.getPlayer(), joinMessage));
+
         if (ess.getSettings().allowSilentJoinQuit() || ess.getSettings().isCustomJoinMessage()) {
             event.setJoinMessage(null);
         }
@@ -445,12 +441,7 @@ public class EssentialsPlayerListener implements Listener {
         final User user = ess.getUser(event.getPlayer());
         if (user.hasUnlimited(new ItemStack(event.getBucket()))) {
             event.getItemStack().setType(event.getBucket());
-            ess.scheduleSyncDelayedTask(new Runnable() {
-                @Override
-                public void run() {
-                    user.getBase().updateInventory();
-                }
-            });
+            ess.scheduleSyncDelayedTask(user.getBase()::updateInventory);
         }
     }
 
@@ -627,6 +618,8 @@ public class EssentialsPlayerListener implements Listener {
             case PHYSICAL:
                 updateActivity = false;
                 break;
+            default:
+                break;
         }
 
         if (updateActivity) {
@@ -746,12 +739,7 @@ public class EssentialsPlayerListener implements Listener {
 
         if (refreshPlayer != null) {
             final Player player = refreshPlayer;
-            ess.scheduleSyncDelayedTask(new Runnable() {
-                @Override
-                public void run() {
-                    player.updateInventory();
-                }
-            }, 1);
+            ess.scheduleSyncDelayedTask(player::updateInventory, 1);
         }
     }
 
@@ -786,19 +774,14 @@ public class EssentialsPlayerListener implements Listener {
 
         if (refreshPlayer != null) {
             final Player player = refreshPlayer;
-            ess.scheduleSyncDelayedTask(new Runnable() {
-                @Override
-                public void run() {
-                    player.updateInventory();
-                }
-            }, 1);
+            ess.scheduleSyncDelayedTask(player::updateInventory, 1);
         }
     }
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerFishEvent(final PlayerFishEvent event) {
         final User user = ess.getUser(event.getPlayer());
-            user.updateActivityOnInteract(true);
+        user.updateActivityOnInteract(true);
     }
 
     private static boolean isEntityPickupEvent() {


### PR DESCRIPTION
I don't think I found all the scheduler tasks, but I did what was needed to change. These changes apply only to Java 1.8 and higher. I guess Essentials no longer supports Java 1.7 ~~because the main page has not yet changed from Java 1.7, but actually here in GitHub ReadMe is 1.8~~.