### PR TITLE
Fix Vanished Players using Pressure Plates.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -625,10 +625,11 @@ public class EssentialsPlayerListener implements Listener {
                 }
                 break;
             case PHYSICAL:  			
-			       if(event.getItem().getType().toString().contains("pressure_plate")) {
-                       if(user.isVanished()){
-                           event.setCancelled(true);
-		    	}}
+                if(event.getItem().getType().toString().contains("pressure_plate")) {
+	           final User user = ess.getUser(event.getPlayer());
+                 if(user.isVanished()){
+                    event.setCancelled(true);
+		}}
                 updateActivity = false;
                 break;
         }

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -164,7 +164,6 @@ public class EssentialsPlayerListener implements Listener {
             user.setGodModeEnabled(false);
         }
         if (user.isVanished()) {
-            user.setVanished(false);
         }
         user.setLogoutLocation();
         if (user.isRecipeSee()) {
@@ -625,11 +624,12 @@ public class EssentialsPlayerListener implements Listener {
                 }
                 break;
             case PHYSICAL:  			
-                if(event.getItem().getType().toString().contains("pressure_plate")) {
+                if(event.getClickedBlock().getType().toString().contains("PRESSURE_PLATE")) {
 	           final User user = ess.getUser(event.getPlayer());
-                 if(user.isVanished()){
-                    event.setCancelled(true);
-		}}
+                    if(user.isVanished()){
+                        event.setCancelled(true);
+		    }
+		}
                 updateActivity = false;
                 break;
         }

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -164,6 +164,7 @@ public class EssentialsPlayerListener implements Listener {
             user.setGodModeEnabled(false);
         }
         if (user.isVanished()) {
+	    user.setVanished(false);
         }
         user.setLogoutLocation();
         if (user.isRecipeSee()) {

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -624,7 +624,11 @@ public class EssentialsPlayerListener implements Listener {
                     }
                 }
                 break;
-            case PHYSICAL:
+            case PHYSICAL:  			
+			       if(event.getItem().getType().toString().contains("pressure_plate")) {
+                       if(user.isVanished()){
+                           event.setCancelled(true);
+		    	}}
                 updateActivity = false;
                 break;
         }


### PR DESCRIPTION
When in vanish and trying to remain hidden, we sometimes find ourselves bumping into pressure plates, which can trigger redstone, doors, pistons and more. This tiny addition hopefully prevents pressure plates from exposing vanished admins trying to survey the server.