### PR TITLE
Added option to clear the player data on ban

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -337,4 +337,6 @@ public interface ISettings extends IConf {
     Set<Predicate<String>> getNickBlacklist();
 
     double getMaxProjectileSpeed();
+
+    boolean clearPlayerDataOnBan();
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -558,6 +558,7 @@ public class Settings implements net.ess3.api.ISettings {
         logCommandBlockCommands = _logCommandBlockCommands();
         nickBlacklist = _getNickBlacklist();
         maxProjectileSpeed = _getMaxProjectileSpeed();
+        clearPlayerDataOnBan = _clearPlayerDataOnBan();
     }
 
     void _lateLoadItemSpawnBlacklist() {
@@ -1622,5 +1623,16 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public double getMaxProjectileSpeed() {
         return maxProjectileSpeed;
+    }
+
+    private boolean clearPlayerDataOnBan;
+
+    private boolean _clearPlayerDataOnBan() {
+        return config.getBoolean("clear-player-data-on-ban", false);
+    }
+
+    @Override
+    public boolean clearPlayerDataOnBan() {
+        return clearPlayerDataOnBan;
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandban.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandban.java
@@ -59,7 +59,7 @@ public class Commandban extends EssentialsCommand {
 
         // Just clears the player inventory, enderchest, reseting player time
         // clear homes, set money to 0 and reset invulnerability after tp
-        if (ess.getSettings().isClearPlayerData()) {
+        if (ess.getSettings().clearPlayerDataOnBan()) {
             user.getBase().clearInventory();
             user.getBase().getEnderChest().clear();
             user.getBase().resetPlayerTime();

--- a/Essentials/src/com/earth2me/essentials/commands/Commandban.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandban.java
@@ -56,6 +56,18 @@ public class Commandban extends EssentialsCommand {
         String banDisplay = tl("banFormat", banReason, senderName);
 
         user.getBase().kickPlayer(banDisplay);
+
+        // Just clears the player inventory, enderchest, reseting player time
+        // clear homes, set money to 0 and reset invulnerability after tp
+        if (ess.getSettings().isClearPlayerData()) {
+            user.getBase().clearInventory();
+            user.getBase().getEnderChest().clear();
+            user.getBase().resetPlayerTime();
+            user.getHomes().clear();
+            user.setMoney(new java.math.BigDecimal(0));
+            user.resetInvulnerabilityAfterTeleport();
+        }
+
         server.getLogger().log(Level.INFO, tl("playerBanned", senderName, user.getName(), banDisplay));
 
         if (nomatch) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandban.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandban.java
@@ -60,7 +60,7 @@ public class Commandban extends EssentialsCommand {
         // Just clears the player inventory, enderchest, reseting player time
         // clear homes, set money to 0 and reset invulnerability after tp
         if (ess.getSettings().clearPlayerDataOnBan()) {
-            user.getBase().clearInventory();
+            user.getBase().getInventory().clear();
             user.getBase().getEnderChest().clear();
             user.getBase().resetPlayerTime();
             user.getHomes().clear();

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbanip.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbanip.java
@@ -60,16 +60,16 @@ public class Commandbanip extends EssentialsCommand {
             if (player.getAddress().getAddress().getHostAddress().equalsIgnoreCase(ipAddress)) {
                 player.kickPlayer(banDisplay);
 
-                User base = ess.getUser(player);
+                User user = ess.getUser(player);
                 // Just clears the player inventory, enderchest, reseting player time
                 // clear homes, set money to 0 and reset invulnerability after tp
                 if (ess.getSettings().clearPlayerDataOnBan()) {
-                    base.clearInventory();
-                    base.getEnderChest().clear();
-                    base.resetPlayerTime();
-                    base.getHomes().clear();
-                    base.setMoney(new java.math.BigDecimal(0));
-                    base.resetInvulnerabilityAfterTeleport();
+                    user.getBase().getInventory().clear();
+                    user.getBase().getEnderChest().clear();
+                    user.getBase().resetPlayerTime();
+                    user.getHomes().clear();
+                    user.setMoney(new java.math.BigDecimal(0));
+                    user.resetInvulnerabilityAfterTeleport();
                 }
             }
         }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbanip.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbanip.java
@@ -56,20 +56,21 @@ public class Commandbanip extends EssentialsCommand {
         ess.getServer().getBanList(BanList.Type.IP).addBan(ipAddress, banReason, null, senderName);
         server.getLogger().log(Level.INFO, tl("playerBanIpAddress", senderName, ipAddress, banReason));
 
-        // Just clears the player inventory, enderchest, reseting player time
-        // clear homes, set money to 0 and reset invulnerability after tp
-        if (ess.getSettings().clearPlayerDataOnBan()) {
-            user.getBase().clearInventory();
-            user.getBase().getEnderChest().clear();
-            user.getBase().resetPlayerTime();
-            user.getHomes().clear();
-            user.setMoney(new java.math.BigDecimal(0));
-            user.resetInvulnerabilityAfterTeleport();
-        }
-
         for (Player player : ess.getServer().getOnlinePlayers()) {
             if (player.getAddress().getAddress().getHostAddress().equalsIgnoreCase(ipAddress)) {
                 player.kickPlayer(banDisplay);
+
+                User base = ess.getUser(player);
+                // Just clears the player inventory, enderchest, reseting player time
+                // clear homes, set money to 0 and reset invulnerability after tp
+                if (ess.getSettings().clearPlayerDataOnBan()) {
+                    base.clearInventory();
+                    base.getEnderChest().clear();
+                    base.resetPlayerTime();
+                    base.getHomes().clear();
+                    base.setMoney(new java.math.BigDecimal(0));
+                    base.resetInvulnerabilityAfterTeleport();
+                }
             }
         }
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbanip.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbanip.java
@@ -56,6 +56,17 @@ public class Commandbanip extends EssentialsCommand {
         ess.getServer().getBanList(BanList.Type.IP).addBan(ipAddress, banReason, null, senderName);
         server.getLogger().log(Level.INFO, tl("playerBanIpAddress", senderName, ipAddress, banReason));
 
+        // Just clears the player inventory, enderchest, reseting player time
+        // clear homes, set money to 0 and reset invulnerability after tp
+        if (ess.getSettings().clearPlayerDataOnBan()) {
+            user.getBase().clearInventory();
+            user.getBase().getEnderChest().clear();
+            user.getBase().resetPlayerTime();
+            user.getHomes().clear();
+            user.setMoney(new java.math.BigDecimal(0));
+            user.resetInvulnerabilityAfterTeleport();
+        }
+
         for (Player player : ess.getServer().getOnlinePlayers()) {
             if (player.getAddress().getAddress().getHostAddress().equalsIgnoreCase(ipAddress)) {
                 player.kickPlayer(banDisplay);

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -472,25 +472,32 @@ repair-enchanted: true
 # Warning: Mixing and overleveling some enchantments can cause issues with clients, servers and plugins.
 unsafe-enchantments: false
 
-#Do you want Essentials to keep track of previous location for /back in the teleport listener?
-#If you set this to true any plugin that uses teleport will have the previous location registered.
+# Do you want Essentials to keep track of previous location for /back in the teleport listener?
+# If you set this to true any plugin that uses teleport will have the previous location registered.
 register-back-in-listener: false
 
-#Delay to wait before people can cause attack damage after logging in.
+# Delay to wait before people can cause attack damage after logging in.
 login-attack-delay: 5
 
-#Set the max fly speed, values range from 0.1 to 1.0
+# Set the max fly speed, values range from 0.1 to 1.0
 max-fly-speed: 0.8
 
-#Set the max walk speed, values range from 0.1 to 1.0
+# Set the max walk speed, values range from 0.1 to 1.0
 max-walk-speed: 0.8
 
-#Set the maximum amount of mail that can be sent within a minute.
+# Set the maximum amount of mail that can be sent within a minute.
 mails-per-minute: 1000
 
 # Set the maximum time /tempban can be used for in seconds.
 # Set to -1 to disable, and essentials.tempban.unlimited can be used to override.
 max-tempban-time: -1
+
+# Do you want to clear player data when banning a player from server?
+# This can be useful for server cleaning.
+# If true will be removed from server: clears player inventory, homes, enderchest
+# resetting the player time, reset money to 0 and reset invulnerability after teleport.
+# This will applies to /ban and /banip
+clear-player-data-on-ban: false
 
 # Changes the default /reply functionality. This can be changed on a per-player basis using /rtoggle.
 # If true, /r goes to the person you messaged last, otherwise the first person that messaged you.


### PR DESCRIPTION
This was added because it is easier to do server cleaning if we ban a lot of players for some reason. This way we can do server cleaning to make our work easier. For the `tempban` was not added because the player may have been banned for only half an hour or other time, so do not lose the data.

**This changes will applies to these commands:**
- banip
- ban

I may not have found all the possible removable things, I only know a few.