### PR TITLE
[W.I.P] Vanish Enhancements

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -337,4 +337,6 @@ public interface ISettings extends IConf {
     Set<Predicate<String>> getNickBlacklist();
 
     double getMaxProjectileSpeed();
+
+    boolean isFakeMessageOnVanish();
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1623,4 +1623,9 @@ public class Settings implements net.ess3.api.ISettings {
     public double getMaxProjectileSpeed() {
         return maxProjectileSpeed;
     }
+
+    @Override
+    public boolean isFakeMessageOnVanish() {
+        return config.getBoolean("fake-message-vanish", false);
+    }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandvanish.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandvanish.java
@@ -7,6 +7,9 @@ import org.bukkit.Server;
 import static com.earth2me.essentials.I18n.tl;
 
 import net.ess3.api.events.VanishStatusChangeEvent;
+import org.bukkit.entity.Player;
+
+import java.text.NumberFormat;
 
 
 public class Commandvanish extends EssentialsToggleCommand {
@@ -45,6 +48,24 @@ public class Commandvanish extends EssentialsToggleCommand {
         }
         if (!sender.isPlayer() || !sender.getPlayer().equals(user.getBase())) {
             sender.sendMessage(tl("vanish", user.getDisplayName(), enabled ? tl("enabled") : tl("disabled")));
+        }
+
+        // Check if the setting is enabled
+        if (ess.getSettings().isFakeMessageOnVanish()) {
+            final Player player = user.getBase();
+            String msg;
+            if (enabled) {
+                msg = ess.getSettings().getCustomQuitMessage()
+                        .replace("{PLAYER}", player.getDisplayName())
+                        .replace("{USERNAME}", player.getName())
+                        .replace("{ONLINE}", NumberFormat.getInstance().format(ess.getOnlinePlayers().size()));
+            } else {
+                msg = ess.getSettings().getCustomJoinMessage()
+                        .replace("{PLAYER}", player.getDisplayName()).replace("{USERNAME}", player.getName())
+                        .replace("{UNIQUE}", NumberFormat.getInstance().format(ess.getUserMap().getUniqueUsers()))
+                        .replace("{ONLINE}", NumberFormat.getInstance().format(ess.getOnlinePlayers().size()));
+            }
+            ess.getServer().broadcastMessage(msg);
         }
     }
 }

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -435,6 +435,10 @@ death-messages: true
 # In addition, people with essentials.silentjoin.vanish will be vanished on join.
 allow-silent-join-quit: false
 
+# Would you like to send a join / leave message when a player goes into vanish?
+# This can be useful when watching hackers
+fake-message-vanish: false
+
 # You can set a custom join message here, set to "none" to disable.
 # You may use color codes, use {USERNAME} the player's name or {PLAYER} for the player's displayname.
 custom-join-message: "none"


### PR DESCRIPTION
Allow the ability to toggle fake join / leave messages when a player goes in and out of vanish.

Currently it utilizes the custom join / leave messages so we might have to just use that unless we can obtain the default join / leave messages the game provides.