### PR TITLE
Splits essentials.ext Permission

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -332,6 +332,8 @@ public interface ISettings extends IConf {
   
     boolean isSafeUsermap();
 
+    boolean isExtOthersSeparate();
+
     boolean logCommandBlockCommands();
 
     Set<Predicate<String>> getNickBlacklist();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -556,6 +556,7 @@ public class Settings implements net.ess3.api.ISettings {
         allowOldIdSigns = _allowOldIdSigns();
         isWaterSafe = _isWaterSafe();
         isSafeUsermap = _isSafeUsermap();
+        isExtOthersSeparate = _isExtOthersSeparate();
         logCommandBlockCommands = _logCommandBlockCommands();
         nickBlacklist = _getNickBlacklist();
         maxProjectileSpeed = _getMaxProjectileSpeed();
@@ -1581,6 +1582,13 @@ public class Settings implements net.ess3.api.ISettings {
     public boolean isSafeUsermap() {
         return isSafeUsermap;
     }
+
+    private boolean isExtOthersSeparate;
+
+    private boolean _isExtOthersSeparate() { return config.getBoolean("ext-others-separate", false); }
+
+    @Override
+    public boolean isExtOthersSeparate() { return isExtOthersSeparate; }
 
     private boolean logCommandBlockCommands;
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandext.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandext.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
+import com.earth2me.essentials.Settings;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
@@ -33,7 +34,7 @@ public class Commandext extends EssentialsLoopCommand {
             return;
         }
 
-        if (user.isAuthorized("essentials.ext.others")) {
+        if (user.isAuthorized("essentials.ext.others") || !ess.getSettings().isExtOthersSeparate()) {
             loopOnlinePlayers(server, user.getSource(), true, true, args[0], null);
         } else {
             throw new Exception(tl("denyExtOthers"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandext.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandext.java
@@ -33,7 +33,12 @@ public class Commandext extends EssentialsLoopCommand {
             return;
         }
 
-        loopOnlinePlayers(server, user.getSource(), true, true, args[0], null);
+        if (user.isAuthorized("essentials.ext.others")) {
+            loopOnlinePlayers(server, user.getSource(), true, true, args[0], null);
+        } else {
+            throw new Exception(tl("denyExtOthers"));
+        }
+
     }
 
     @Override

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -574,6 +574,11 @@ is-water-safe: false
 # You should only change this to false if you use Minecraft China.
 safe-usermap-names: true
 
+# Should essentials.ext be a separate oermission from essentials.ext.others?
+# If false, those with essentials.ext can also extinguish others with explicitly having essentials.ext.others.
+# If true, players need essentials.ext.others to extinguish other players.
+ext-others-separate: false
+
 # Should Essentials output logs when a command block executes a command?
 # Example: CommandBlock at <x>,<y>,<z> issued server command: /<command>
 log-command-block-commands: true

--- a/Essentials/src/messages_en.properties
+++ b/Essentials/src/messages_en.properties
@@ -90,6 +90,7 @@ deniedAccessCommand=§c{0} §4was denied access to command.
 denyBookEdit=§4You cannot unlock this book.
 denyChangeAuthor=§4You cannot change the author of this book.
 denyChangeTitle=§4You cannot change the title of this book.
+denyExtOthers=§4You do not have permission to extinguish others.
 depth=§6You are at sea level.
 depthAboveSea=§6You are§c {0} §6block(s) above sea level.
 depthBelowSea=§6You are§c {0} §6block(s) below sea level.


### PR DESCRIPTION
Takes essentials.ext and splits it into essentials.ext (Extinguish one's self) and essentials.ext.others (Extinguishing others). Adds a permission denied message if a user tries to extinguish another user if they do not have essentials.ext.others.

Fixes #2796 