### PR TITLE
Save materials in unlimited by name

### DIFF
--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -234,10 +235,10 @@ public abstract class UserData extends PlayerExtension implements IConf {
         config.save();
     }
 
-    private List<Material> unlimited;
+    private Set<Material> unlimited;
 
-    private List<Material> _getUnlimited() {
-        List<Material> retlist = new ArrayList<>();
+    private Set<Material> _getUnlimited() {
+        Set<Material> retlist = new HashSet<>();
         List<String> configList = config.getStringList("unlimited");
         for(String s : configList) {
             Material mat = Material.matchMaterial(s);
@@ -249,7 +250,7 @@ public abstract class UserData extends PlayerExtension implements IConf {
         return retlist;
     }
 
-    public List<Material> getUnlimited() {
+    public Set<Material> getUnlimited() {
         return unlimited;
     }
 
@@ -258,13 +259,20 @@ public abstract class UserData extends PlayerExtension implements IConf {
     }
 
     public void setUnlimited(ItemStack stack, boolean state) {
-        if (unlimited.contains(stack.getType())) {
-            unlimited.remove(stack.getType());
-        }
+        boolean wasUpdated;
         if (state) {
-            unlimited.add(stack.getType());
+            wasUpdated = unlimited.add(stack.getType());
+        } else {
+            wasUpdated = unlimited.remove(stack.getType());
         }
-        config.setProperty("unlimited", unlimited);
+
+        if (wasUpdated) {
+            applyUnlimited();
+        }
+    }
+
+    private void applyUnlimited() {
+        config.setProperty("unlimited", unlimited.stream().map(Enum::name).collect(Collectors.toList()));
         config.save();
     }
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandunlimited.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandunlimited.java
@@ -5,8 +5,10 @@ import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -32,14 +34,10 @@ public class Commandunlimited extends EssentialsCommand {
             final String list = getList(target);
             user.sendMessage(list);
         } else if (args[0].equalsIgnoreCase("clear")) {
-            final List<Material> itemList = target.getUnlimited();
+            final Set<Material> itemList = new HashSet<>(target.getUnlimited());
 
-            int index = 0;
-            while (itemList.size() > index) {
-                final Material item = itemList.get(index);
-                if (!toggleUnlimited(user, target, item.toString())) {
-                    index++;
-                }
+            for (Material m : itemList) {
+                toggleUnlimited(user, target, m.toString());
             }
         } else {
             toggleUnlimited(user, target, args[0]);
@@ -50,7 +48,7 @@ public class Commandunlimited extends EssentialsCommand {
         final StringBuilder output = new StringBuilder();
         output.append(tl("unlimitedItems")).append(" ");
         boolean first = true;
-        final List<Material> items = target.getUnlimited();
+        final Set<Material> items = target.getUnlimited();
         if (items.isEmpty()) {
             output.append(tl("none"));
         }


### PR DESCRIPTION
There was a mistake where materials in unlimited would instead be saved
as a bukkit Material instead of its name. Instead, save it by the name.

Fixes #2778 