### PR TITLE
Implements missing createExplosion methods in FakeWorld

### DIFF
--- a/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java
+++ b/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java
@@ -377,6 +377,21 @@ public class FakeWorld implements World {
     public boolean createExplosion(Location lctn, float f, boolean bln) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
+    
+    @Override
+    public boolean createExplosion(double d, double d1, double d2, float f, boolean bln, boolean bln1, Entity entity) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public boolean createExplosion(Location lctn, float f, boolean bln, boolean bln1) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public boolean createExplosion(Location lctn, float f, boolean bln, boolean bln1, Entity entity) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
 
     @Override
     public <T extends Entity> T spawn(Location lctn, Class<T> type) throws IllegalArgumentException {

--- a/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java
+++ b/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java
@@ -380,17 +380,17 @@ public class FakeWorld implements World {
     
     @Override
     public boolean createExplosion(double d, double d1, double d2, float f, boolean bln, boolean bln1, Entity entity) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public boolean createExplosion(Location lctn, float f, boolean bln, boolean bln1) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
     public boolean createExplosion(Location lctn, float f, boolean bln, boolean bln1, Entity entity) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override


### PR DESCRIPTION
Fixes the below error. I'm not sure why this crept up, but may be due to recent Spigot changes. Similar to #2670. 

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project EssentialsX: Compilation failure
[ERROR] /C:/Users/Ryan/Programming/Java/Spigot/Essentials/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java:[27,8] com.earth2me.essentials.craftbukkit.FakeWorld is not abstract and does not override abstract method createExplosion(org.bukkit.Location,float,boolean,boolean,org.bukkit.entity.Entity) in org.bukkit.World
`