### PR TITLE
Make drop-items-if-full work on Essentials kits

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkit.java
@@ -81,8 +81,9 @@ public class Commandkit extends EssentialsCommand {
 
                 kit.checkDelay(userFrom);
                 kit.checkAffordable(userFrom);
+                if (!kit.expandItems(userTo))
+                    continue;
                 kit.setTime(userFrom);
-                kit.expandItems(userTo);
                 kit.chargeUser(userTo);
 
                 if (!userFrom.equals(userTo)) {

--- a/Essentials/src/com/earth2me/essentials/craftbukkit/InventoryWorkaround.java
+++ b/Essentials/src/com/earth2me/essentials/craftbukkit/InventoryWorkaround.java
@@ -80,6 +80,25 @@ public final class InventoryWorkaround {
         }
         return addItems(fakeInventory, items);
     }
+    
+    public static Map<Integer, ItemStack> addAllOversizedItems(final Inventory inventory, final int oversizedStacks, final ItemStack... items) {
+        ItemStack[] contents = inventory.getContents();
+
+        final Inventory fakeInventory;
+        if (isCombinedInventory(inventory)) {
+            fakeInventory = makeTruncatedPlayerInventory((PlayerInventory) inventory);
+        } else {
+            fakeInventory = Bukkit.getServer().createInventory(null, inventory.getType());
+            fakeInventory.setContents(contents);
+        }
+        Map<Integer, ItemStack> overflow = addOversizedItems(fakeInventory, oversizedStacks, items);
+        if (overflow.isEmpty()) {
+            addOversizedItems(inventory, oversizedStacks, items);
+            return null;
+        }
+        return overflow;
+    }
+
 
     // Returns what it couldn't store
     public static Map<Integer, ItemStack> addItems(final Inventory inventory, final ItemStack... items) {

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -252,6 +252,7 @@ kitError=\u00a74There are no valid kits.
 kitError2=\u00a74That kit is improperly defined. Contact an administrator.
 kitGiveTo=\u00a76Giving kit\u00a7c {0}\u00a76 to \u00a7c{1}\u00a76.
 kitInvFull=\u00a74Your inventory was full, placing kit on the floor.
+kitInvFullNoDrop=\u00a74There is not enough room in your inventory for that kit.
 kitItem=\u00a76- \u00a7f{0}
 kitNotFound=\u00a74That kit does not exist.
 kitOnce=\u00a74You can''t use that kit again.


### PR DESCRIPTION
Fixes #2736 

This changes the way the kit command works by creating an ArrayList of items and making sure all can be added before giving the kit if drop-items-if-full is false. Works with oversized stacks.

More testing is recommended. I believe I have included proper economy support, but haven't actually tested it because I don't have an economy plugin on my test server right now. This is also a fairly significant change to the way this command works, so more testing is always better.