### PR TITLE
Add a cause enum to UserBalanceUpdateEvent

### DIFF
--- a/Essentials/src/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/com/earth2me/essentials/api/Economy.java
@@ -8,6 +8,7 @@ import com.earth2me.essentials.utils.StringUtil;
 import com.google.common.base.Charsets;
 import net.ess3.api.IEssentials;
 import net.ess3.api.MaxMoneyException;
+import net.ess3.api.events.UserBalanceUpdateEvent;
 import org.bukkit.entity.Player;
 
 import java.io.File;
@@ -144,7 +145,7 @@ public class Economy {
             throw new NoLoanPermittedException();
         }
         try {
-            user.setMoney(balance);
+            user.setMoney(balance, UserBalanceUpdateEvent.Cause.API);
         } catch (MaxMoneyException ex) {
             //TODO: Update API to show max balance errors
         }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandeco.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandeco.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.NumberUtil;
 import com.google.common.collect.Lists;
 import net.ess3.api.MaxMoneyException;
+import net.ess3.api.events.UserBalanceUpdateEvent;
 import org.bukkit.Server;
 
 import java.math.BigDecimal;
@@ -54,7 +55,7 @@ public class Commandeco extends EssentialsLoopCommand {
     protected void updatePlayer(final Server server, final CommandSource sender, final User player, final String[] args) throws NotEnoughArgumentsException, ChargeException, MaxMoneyException {
         switch (cmd) {
             case GIVE:
-                player.giveMoney(amount, sender);
+                player.giveMoney(amount, sender, UserBalanceUpdateEvent.Cause.COMMAND_ECO);
                 break;
 
             case TAKE:
@@ -72,10 +73,10 @@ public class Commandeco extends EssentialsLoopCommand {
         BigDecimal money = player.getMoney();
         BigDecimal minBalance = ess.getSettings().getMinMoney();
         if (money.subtract(amount).compareTo(minBalance) >= 0) {
-            player.takeMoney(amount, sender);
+            player.takeMoney(amount, sender, UserBalanceUpdateEvent.Cause.COMMAND_ECO);
         } else if (sender == null) {
             try {
-                player.setMoney(minBalance);
+                player.setMoney(minBalance, UserBalanceUpdateEvent.Cause.COMMAND_ECO);
             } catch (MaxMoneyException ex) {
                 // Take shouldn't be able to throw a max money exception
             }
@@ -90,7 +91,7 @@ public class Commandeco extends EssentialsLoopCommand {
         BigDecimal maxBalance = ess.getSettings().getMaxMoney();
         boolean underMinimum = (amount.compareTo(minBalance) < 0);
         boolean aboveMax = (amount.compareTo(maxBalance) > 0);
-        player.setMoney(underMinimum ? minBalance : aboveMax ? maxBalance : amount);
+        player.setMoney(underMinimum ? minBalance : aboveMax ? maxBalance : amount, UserBalanceUpdateEvent.Cause.COMMAND_ECO);
         player.sendMessage(tl("setBal", NumberUtil.displayCurrency(player.getMoney(), ess)));
         if (sender != null) {
             sender.sendMessage(tl("setBalOthers", player.getDisplayName(), NumberUtil.displayCurrency(player.getMoney(), ess)));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
@@ -9,6 +9,7 @@ import com.earth2me.essentials.utils.StringUtil;
 
 import com.google.common.collect.Lists;
 import net.ess3.api.MaxMoneyException;
+import net.ess3.api.events.UserBalanceUpdateEvent;
 import org.bukkit.Server;
 
 import java.math.BigDecimal;
@@ -73,7 +74,7 @@ public class Commandpay extends EssentialsLoopCommand {
                 user.getConfirmingPayments().put(player, amount);
                 return;
             }
-            user.payUser(player, amount);
+            user.payUser(player, amount, UserBalanceUpdateEvent.Cause.COMMAND_PAY);
             user.getConfirmingPayments().remove(player);
             Trade.log("Command", "Pay", "Player", user.getName(), new Trade(amount, ess), player.getName(), new Trade(amount, ess), user.getLocation(), ess);
         } catch (MaxMoneyException ex) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandsell.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandsell.java
@@ -4,6 +4,7 @@ import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.NumberUtil;
 import com.google.common.collect.Lists;
+import net.ess3.api.events.UserBalanceUpdateEvent;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
@@ -94,7 +95,7 @@ public class Commandsell extends EssentialsCommand {
         user.getBase().getInventory().removeItem(ris);
         user.getBase().updateInventory();
         Trade.log("Command", "Sell", "Item", user.getName(), new Trade(ris, ess), user.getName(), new Trade(result, ess), user.getLocation(), ess);
-        user.giveMoney(result);
+        user.giveMoney(result, null, UserBalanceUpdateEvent.Cause.COMMAND_SELL);
         user.sendMessage(tl("itemSold", NumberUtil.displayCurrency(result, ess), amount, is.getType().toString().toLowerCase(Locale.ENGLISH), NumberUtil.displayCurrency(worth, ess)));
         logger.log(Level.INFO, tl("itemSoldConsole", user.getDisplayName(), is.getType().toString().toLowerCase(Locale.ENGLISH), NumberUtil.displayCurrency(result, ess), amount, NumberUtil.displayCurrency(worth, ess)));
         return result;

--- a/Essentials/src/net/ess3/api/events/UserBalanceUpdateEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserBalanceUpdateEvent.java
@@ -64,6 +64,7 @@ public class UserBalanceUpdateEvent extends Event {
         COMMAND_ECO,
         COMMAND_PAY,
         COMMAND_SELL,
+        API,
         SPECIAL, // Reserved for API usage
         UNKNOWN
     }

--- a/Essentials/src/net/ess3/api/events/UserBalanceUpdateEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserBalanceUpdateEvent.java
@@ -64,6 +64,7 @@ public class UserBalanceUpdateEvent extends Event {
         COMMAND_ECO,
         COMMAND_PAY,
         COMMAND_SELL,
+        SPECIAL, // Reserved for API usage
         UNKNOWN
     }
 }

--- a/Essentials/src/net/ess3/api/events/UserBalanceUpdateEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserBalanceUpdateEvent.java
@@ -15,12 +15,19 @@ public class UserBalanceUpdateEvent extends Event {
     private final Player player;
     private final BigDecimal originalBalance;
     private BigDecimal balance;
+    private Cause cause;
 
+    @Deprecated
     public UserBalanceUpdateEvent(Player player, BigDecimal originalBalance, BigDecimal balance) {
+        this(player, originalBalance, balance, Cause.UNKNOWN);
+    }
+
+    public UserBalanceUpdateEvent(Player player, BigDecimal originalBalance, BigDecimal balance, Cause cause) {
         super(!Bukkit.getServer().isPrimaryThread());
         this.player = player;
         this.originalBalance = originalBalance;
         this.balance = balance;
+        this.cause = cause;
     }
 
     @Override
@@ -47,5 +54,16 @@ public class UserBalanceUpdateEvent extends Event {
 
     public BigDecimal getOldBalance() {
         return originalBalance;
+    }
+
+    public Cause getCause() {
+        return cause;
+    }
+
+    public enum Cause {
+        COMMAND_ECO,
+        COMMAND_PAY,
+        COMMAND_SELL,
+        UNKNOWN
     }
 }


### PR DESCRIPTION
Basically, I just needed this for one of my plugins; otherwise, this could be useful for people using this event who want to see where the user's balance is being updated from.