### PR TITLE
Escape pipe character on item lore

### DIFF
--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -162,7 +162,7 @@ public class MetaItemStack {
             stack.setItemMeta(meta);
         } else if (split.length > 1 && (split[0].equalsIgnoreCase("lore") || split[0].equalsIgnoreCase("desc")) && hasMetaPermission(sender, "lore", false, true, ess)) {
             final List<String> lore = new ArrayList<String>();
-            for (String line : split[1].split("\\|")) {
+            for (String line : split[1].split("[^\\\\](\\|)")) {
                 lore.add(FormatUtil.replaceFormat(line.replace('_', ' ')));
             }
             final ItemMeta meta = stack.getItemMeta();


### PR DESCRIPTION
I just adjusted the regex used to split the item lore into multiple lines in order to allow escaping of the pipe character using `\|`.

Addresses issue #2830.