### PR TITLE
Enable control of entity transformations in EssentialsProtect

### DIFF
--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -758,6 +758,16 @@ protect:
     # Monsters won't follow players.
     # permission essentials.protect.entitytarget.bypass disables this.
     entitytarget: false
+    # Prevent certain transformations.
+    transformation:
+      creeper-charge: false
+      villager-infection: false
+      villager-cure: false
+      villager-to-witch: false
+      pig-transformation: false
+      zombie-drowning: false
+      # Prevent brown and red mooshrooms switch on lightning strike
+      mooshroom-switching: false
     # Prevent the spawning of creatures.
     spawn:
       creeper: false

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -761,19 +761,19 @@ protect:
     # Prevent certain transformations.
     transformation:
       # Prevent creepers becoming charged when struck by lightning.
-      creeper-charge: false
+      charged-creeper: false
       # Prevent villagers becoming zombie villagers.
-      villager-infection: false
+      zombie-villager: false
       # Prevent zombie villagers being cured.
-      villager-cure: false
+      villager: false
       # Prevent villagers becoming witches when struck by lightning.
-      villager-to-witch: false
+      witch: false
       # Prevent pigs becoming zombie pigmen when struck by lightning.
-      pig-transformation: false
+      zombie-pigman: false
       # Prevent zombies turning into drowneds, and husks turning into zombies.
-      zombie-drowning: false
+      drowned: false
       # Prevent mooshrooms changing colour when struck by lightning.
-      mooshroom-switching: false
+      mooshroom: false
     # Prevent the spawning of creatures.
     spawn:
       creeper: false

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -770,7 +770,7 @@ protect:
       villager-to-witch: false
       # Prevent pigs becoming zombie pigmen when struck by lightning.
       pig-transformation: false
-      # Prevent zombies turning into drowneds.
+      # Prevent zombies turning into drowneds, and husks turning into zombies.
       zombie-drowning: false
       # Prevent mooshrooms changing colour when struck by lightning.
       mooshroom-switching: false

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -760,14 +760,6 @@ protect:
     entitytarget: false
     # Prevent certain transformations.
     transformation:
-      creeper-charge: false
-      villager-infection: false
-      villager-cure: false
-      villager-to-witch: false
-      pig-transformation: false
-      zombie-drowning: false
-      # Prevent brown and red mooshrooms switch on lightning strike
-    transformation:
       # Prevent creepers becoming charged when struck by lightning.
       creeper-charge: false
       # Prevent villagers becoming zombie villagers.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -767,6 +767,20 @@ protect:
       pig-transformation: false
       zombie-drowning: false
       # Prevent brown and red mooshrooms switch on lightning strike
+    transformation:
+      # Prevent creepers becoming charged when struck by lightning.
+      creeper-charge: false
+      # Prevent villagers becoming zombie villagers.
+      villager-infection: false
+      # Prevent zombie villagers being cured.
+      villager-cure: false
+      # Prevent villagers becoming witches when struck by lightning.
+      villager-to-witch: false
+      # Prevent pigs becoming zombie pigmen when struck by lightning.
+      pig-transformation: false
+      # Prevent zombies turning into drowneds.
+      zombie-drowning: false
+      # Prevent mooshrooms changing colour when struck by lightning.
       mooshroom-switching: false
     # Prevent the spawning of creatures.
     spawn:

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
@@ -56,6 +56,11 @@ public class EssentialsProtectEntityListener implements Listener {
             final EntityDamageByEntityEvent edEvent = (EntityDamageByEntityEvent) event;
             final Entity eAttack = edEvent.getDamager();
 
+            if (target instanceof Villager && prot.getSettingBool(ProtectConfig.prevent_villager_death)) {
+                event.setCancelled(true);
+                return;
+            }
+
             User attacker = null;
             if (eAttack instanceof Player) {
                 attacker = ess.getUser((Player) eAttack);

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
@@ -2,6 +2,7 @@ package com.earth2me.essentials.protect;
 
 import com.earth2me.essentials.User;
 import net.ess3.api.IEssentials;
+import org.bukkit.Difficulty;
 import org.bukkit.entity.*;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.EventHandler;
@@ -28,11 +29,6 @@ public class EssentialsProtectEntityListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityDamage(final EntityDamageEvent event) {
         final Entity target = event.getEntity();
-
-        if (target instanceof Villager && prot.getSettingBool(ProtectConfig.prevent_villager_death)) {
-            event.setCancelled(true);
-            return;
-        }
 
         User user = null;
         if (target instanceof Player) {
@@ -168,6 +164,29 @@ public class EssentialsProtectEntityListener implements Listener {
             event.setCancelled(true);
         }
 
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onEntityTransform(final EntityTransformEvent event) {
+        final Entity entity = event.getEntity();
+        final EntityTransformEvent.TransformReason reason = event.getTransformReason();
+        if (reason == EntityTransformEvent.TransformReason.INFECTION && prot.getSettingBool(ProtectConfig.prevent_villager_infection)) {
+            event.setCancelled(true);
+        } else if (reason == EntityTransformEvent.TransformReason.CURED && prot.getSettingBool(ProtectConfig.prevent_villager_cure)) {
+            event.setCancelled(true);
+        } else if (reason == EntityTransformEvent.TransformReason.LIGHTNING) {
+            if (entity instanceof Villager && prot.getSettingBool(ProtectConfig.prevent_villager_to_witch)) {
+                event.setCancelled(true);
+            } else if (entity instanceof Pig && prot.getSettingBool(ProtectConfig.prevent_pig_transformation)) {
+                event.setCancelled(true);
+            } else if (entity instanceof Creeper && prot.getSettingBool(ProtectConfig.prevent_creeper_charge)) {
+                event.setCancelled(true);
+            } else if (entity instanceof MushroomCow && prot.getSettingBool(ProtectConfig.prevent_mooshroom_switching)) {
+                event.setCancelled(true);
+            }
+        } else if (reason == EntityTransformEvent.TransformReason.DROWNED && prot.getSettingBool(ProtectConfig.prevent_zombie_drowning)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
@@ -2,7 +2,6 @@ package com.earth2me.essentials.protect;
 
 import com.earth2me.essentials.User;
 import net.ess3.api.IEssentials;
-import org.bukkit.Difficulty;
 import org.bukkit.entity.*;
 import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.EventHandler;
@@ -30,6 +29,11 @@ public class EssentialsProtectEntityListener implements Listener {
     public void onEntityDamage(final EntityDamageEvent event) {
         final Entity target = event.getEntity();
 
+        if (target instanceof Villager && prot.getSettingBool(ProtectConfig.prevent_villager_death)) {
+            event.setCancelled(true);
+            return;
+        }
+
         User user = null;
         if (target instanceof Player) {
             user = ess.getUser((Player) target);
@@ -55,11 +59,6 @@ public class EssentialsProtectEntityListener implements Listener {
         if (event instanceof EntityDamageByEntityEvent) {
             final EntityDamageByEntityEvent edEvent = (EntityDamageByEntityEvent) event;
             final Entity eAttack = edEvent.getDamager();
-
-            if (target instanceof Villager && prot.getSettingBool(ProtectConfig.prevent_villager_death)) {
-                event.setCancelled(true);
-                return;
-            }
 
             User attacker = null;
             if (eAttack instanceof Player) {

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/ProtectConfig.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/ProtectConfig.java
@@ -42,7 +42,14 @@ public enum ProtectConfig {
     prevent_villager_death("protect.prevent.villager-death", false),
     prevent_enderdragon_blockdmg("protect.prevent.enderdragon-blockdamage", true),
     prevent_entitytarget("protect.prevent.entitytarget", false),
-    enderdragon_fakeexplosions("protect.enderdragon-fakeexplosions", false);
+    enderdragon_fakeexplosions("protect.enderdragon-fakeexplosions", false),
+    prevent_creeper_charge("protect.prevent.transformation.creeper-charge", false),
+    prevent_villager_infection("protect.prevent.transformation.villager-infection", false),
+    prevent_villager_cure("protect.prevent.transformation.villager-cure", false),
+    prevent_villager_to_witch("protect.prevent.transformation.villager-to-witch", false),
+    prevent_pig_transformation("protect.prevent.transformation.pig-transformation", false),
+    prevent_zombie_drowning("protect.prevent.transformation.zombie-drowning", false),
+    prevent_mooshroom_switching("protect.prevent.transformation.mooshroom-switching", false);
     private final String configName;
     private final String defValueString;
     private final boolean defValueBoolean;

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/ProtectConfig.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/ProtectConfig.java
@@ -43,13 +43,13 @@ public enum ProtectConfig {
     prevent_enderdragon_blockdmg("protect.prevent.enderdragon-blockdamage", true),
     prevent_entitytarget("protect.prevent.entitytarget", false),
     enderdragon_fakeexplosions("protect.enderdragon-fakeexplosions", false),
-    prevent_creeper_charge("protect.prevent.transformation.creeper-charge", false),
-    prevent_villager_infection("protect.prevent.transformation.villager-infection", false),
-    prevent_villager_cure("protect.prevent.transformation.villager-cure", false),
-    prevent_villager_to_witch("protect.prevent.transformation.villager-to-witch", false),
-    prevent_pig_transformation("protect.prevent.transformation.pig-transformation", false),
-    prevent_zombie_drowning("protect.prevent.transformation.zombie-drowning", false),
-    prevent_mooshroom_switching("protect.prevent.transformation.mooshroom-switching", false);
+    prevent_creeper_charge("protect.prevent.transformation.charged-creeper", false),
+    prevent_villager_infection("protect.prevent.transformation.zombie-villager", false),
+    prevent_villager_cure("protect.prevent.transformation.villager", false),
+    prevent_villager_to_witch("protect.prevent.transformation.witch", false),
+    prevent_pig_transformation("protect.prevent.transformation.zombie-pigman", false),
+    prevent_zombie_drowning("protect.prevent.transformation.drowned", false),
+    prevent_mooshroom_switching("protect.prevent.transformation.mooshroom", false);
     private final String configName;
     private final String defValueString;
     private final boolean defValueBoolean;


### PR DESCRIPTION
This allows users to prevent any of the following transformations:

- Creeper charging
- Villager infected by zombie villagers
- Villager being cured
- Villagers turning into witches
- Pigs turning into zombie pigmen
- Zombies turning into Drowned (and husks turning into Zombies)
- Mooshrooms switching colors

Configurations are in a new subsection, `protect.prevent.transformation`. All options are disabled by default.