### PR TITLE
Don't assume full-perms when CommandSource isn't a User

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandseen.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandseen.java
@@ -28,7 +28,7 @@ public class Commandseen extends EssentialsCommand {
 
     @Override
     protected void run(final Server server, final CommandSource sender, final String commandLabel, final String[] args) throws Exception {
-        seen(server, sender, commandLabel, args, true, true, true, true);
+        seen(server, sender, commandLabel, args, sender.getSender().hasPermission("essentials.seen.banreason"), sender.getSender().hasPermission("essentials.seen.ip"), sender.getSender().hasPermission("essentials.seen.location"), sender.getSender().hasPermission("essentials.seen.ipsearch"));
     }
 
     @Override


### PR DESCRIPTION
This has been causing issues with plugins that run commands with non-player senders (or wrapped player objects).

If this change seems reasonable to EssX authors, I'm willing to do it for other affected commands as well.