### PR TITLE
 clone itemstacks after matching

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandworth.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandworth.java
@@ -8,6 +8,7 @@ import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -25,7 +26,10 @@ public class Commandworth extends EssentialsCommand {
         BigDecimal totalWorth = BigDecimal.ZERO;
         String type = "";
 
-        List<ItemStack> is = ess.getItemDb().getMatching(user, args);
+        List<ItemStack> is = new ArrayList<>();
+        for(ItemStack item : ess.getItemDb().getMatching(user, args)) {
+            is.add(item.clone());
+        }
         int count = 0;
 
         boolean isBulk = is.size() > 1;


### PR DESCRIPTION
Because if you don't, items start disappearing when you set zerostack amount to 0.

as I noticed myself when doing /worth on items on git-Paper-648 (MC: 1.13.2) with EssentialsX 2.17.1.17