### PR TITLE
Update Mockito to allow tests to pass in newer versions of Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.8.47</version>
+            <version>3.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## PR Synopsis

This PR updates the Mockito to the [newest](https://mvnrepository.com/artifact/org.mockito/mockito-core/3.2.0) version available in Maven Central.

## Rationale

When building EssentialsX on Java versions 11 and up, Maven tests fail with [this error](https://bin.privacytools.io/?9d3b27c5dd77bf9d#FACapEiij9HTX6AD42ncIPLMXvIBiaPKABmgfmeyngM=), stating that the Java version X is unknown to ByteBuddy.

The changes proposed in this PR updates Mockito, which now uses a newer version of ByteBuddy that supports the newer version of Java, thus allowing the tests to pass again.

Although it could be argued that EssentialsX targets specifically Java version 8 as specified through the [`pom.xml`](https://github.com/EssentialsX/Essentials/blob/1ff73b383749ff8548c579039cce8bd6d9d8e35e/pom.xml#L87-L90) file, the changes proposed in this PR allows EssentialsX to support developers working on newer versions of Java while still retaining support for those working on older versions as well. While this contingent of developers remains small, I believe that the benefit of mitigating problems in the future far outweigh the present impacts discussed below.

## Impact

The impact on existing users and developers working on EssentialsX will be relatively low. Users **will not** notice any changes to EssentialsX. Developers will need to allow Maven to pull `mockito-core:3.2.0` from Maven Central; however, this is done automatically in the build process. There will be virtually no interference with the normal development process.

These changes have a relatively low footprint. If bugs or problems arise in the future as a result of this change, it will be easy to revert with little to no impact to both users and developers.

## Additional information
Java versions tested:

- Java 8 (build passes)
```
openjdk version "1.8.0_232"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_232-b09)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.232-b09, mixed mode)
```

- Java 11 (build fails)
```
openjdk version "11.0.5" 2019-10-15
OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.5+10)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.5+10, mixed mode)
```

- Java 12 (build fails)
```
openjdk version "12.0.2" 2019-07-16
OpenJDK Runtime Environment AdoptOpenJDK (build 12.0.2+10)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 12.0.2+10, mixed mode, sharing)
```

- Java 13 (build fails)
```
openjdk version "13.0.1" 2019-10-15
OpenJDK Runtime Environment AdoptOpenJDK (build 13.0.1+9)
OpenJDK 64-Bit Server VM AdoptOpenJDK (build 13.0.1+9, mixed mode, sharing)
```