### PR TITLE
Update to 1.15

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Mob.java
+++ b/Essentials/src/com/earth2me/essentials/Mob.java
@@ -89,7 +89,8 @@ public enum Mob {
     PILLAGER("Pillager", Enemies.ENEMY, "PILLAGER"),
     RAVAGER("Ravager", Enemies.ENEMY, "RAVAGER"),
     TRADER_LLAMA("TraderLlama", Enemies.FRIENDLY, "TRADER_LLAMA"),
-    WANDERING_TRADER("WanderingTrader", Enemies.FRIENDLY, "WANDERING_TRADER")
+    WANDERING_TRADER("WanderingTrader", Enemies.FRIENDLY, "WANDERING_TRADER"),
+    BEE("Bee", Enemies.NEUTRAL, "BEE")
     ;
 
     public static final Logger logger = Logger.getLogger("Essentials");

--- a/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
+++ b/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
@@ -437,19 +437,6 @@ public class OfflinePlayer implements Player {
     }
 
     @Override
-    public void awardAchievement(Achievement a) {
-    }
-
-    @Override
-    public void removeAchievement(Achievement achievement) {
-    }
-
-    @Override
-    public boolean hasAchievement(Achievement achievement) {
-        return false;
-    }
-
-    @Override
     public void incrementStatistic(Statistic ststc) {
     }
 

--- a/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
+++ b/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
@@ -437,6 +437,19 @@ public class OfflinePlayer implements Player {
     }
 
     @Override
+    public void awardAchievement(Achievement a) {
+    }
+
+    @Override
+    public void removeAchievement(Achievement achievement) {
+    }
+
+    @Override
+    public boolean hasAchievement(Achievement achievement) {
+        return false;
+    }
+
+    @Override
     public void incrementStatistic(Statistic ststc) {
     }
 

--- a/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
+++ b/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
@@ -436,19 +436,6 @@ public class OfflinePlayer implements Player {
         return true;
     }
 
-    //@Override
-//    public void awardAchievement(Achievement a) {
-//    }
-
-    //@Override
-//    public void removeAchievement(Achievement achievement) {
-//    }
-
-    //@Override
-//    public boolean hasAchievement(Achievement achievement) {
-//        return false;
-//    }
-
     @Override
     public void incrementStatistic(Statistic ststc) {
     }

--- a/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
+++ b/Essentials/src/com/earth2me/essentials/OfflinePlayer.java
@@ -436,18 +436,18 @@ public class OfflinePlayer implements Player {
         return true;
     }
 
-    @Override
-    public void awardAchievement(Achievement a) {
-    }
+    //@Override
+//    public void awardAchievement(Achievement a) {
+//    }
 
-    @Override
-    public void removeAchievement(Achievement achievement) {
-    }
+    //@Override
+//    public void removeAchievement(Achievement achievement) {
+//    }
 
-    @Override
-    public boolean hasAchievement(Achievement achievement) {
-        return false;
-    }
+    //@Override
+//    public boolean hasAchievement(Achievement achievement) {
+//        return false;
+//    }
 
     @Override
     public void incrementStatistic(Statistic ststc) {

--- a/Essentials/src/com/earth2me/essentials/utils/VersionUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/VersionUtil.java
@@ -25,8 +25,9 @@ public class VersionUtil {
     public static final BukkitVersion v1_14_2_R01 = BukkitVersion.fromString("1.14.2-R0.1-SNAPSHOT");
     public static final BukkitVersion v1_14_3_R01 = BukkitVersion.fromString("1.14.3-R0.1-SNAPSHOT");
     public static final BukkitVersion v1_14_4_R01 = BukkitVersion.fromString("1.14.4-R0.1-SNAPSHOT");
+    public static final BukkitVersion v1_15_R01 = BukkitVersion.fromString("1.15-R0.1-SNAPSHOT");
 
-    private static final Set<BukkitVersion> supportedVersions = ImmutableSet.of(v1_8_8_R01, v1_9_4_R01, v1_10_2_R01, v1_11_2_R01, v1_12_2_R01, v1_13_2_R01, v1_14_4_R01);
+    private static final Set<BukkitVersion> supportedVersions = ImmutableSet.of(v1_8_8_R01, v1_9_4_R01, v1_10_2_R01, v1_11_2_R01, v1_12_2_R01, v1_13_2_R01, v1_14_4_R01, v1_15_R01);
 
     private static BukkitVersion serverVersion = null;
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.14.4-R0.1-SNAPSHOT</version>
+            <version>1.15-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request updates Essentials to target 1.15. Additionally, if you're already reviewing this, may you review #2824 as well as it's very minor

# Changelog

* Compiled against 1.15
* Added 1.15 to VersionUtil
* Added 1.15 Mobs
* Removed achievement-related methods for OfflinePlayer

# WIP
* ~~Testing~~
* `items.json` needs to be generated
  * I tried using `essx-scripts` for this but it looked scary so I didn't commit it :o
* ~~\> 1.15 compatibility in `OfflinePlayer` due to the `Achievement` class being removed~~
  * Appears to work on 1.14 without these methods present