### PR TITLE
Fixes #1996 - Jail should also block gamemode changes

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Jails.java
+++ b/Essentials/src/com/earth2me/essentials/Jails.java
@@ -16,10 +16,7 @@ import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.*;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.plugin.PluginManager;
 
@@ -197,6 +194,14 @@ public class Jails extends AsyncStorageObjectHolder<com.earth2me.essentials.sett
 
         @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
         public void onJailPlayerInteract(final PlayerInteractEvent event) {
+            final User user = ess.getUser(event.getPlayer());
+            if (user.isJailed()) {
+                event.setCancelled(true);
+            }
+        }
+
+        @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+        public void onJailPlayerGameModeChange(PlayerGameModeChangeEvent event) {
             final User user = ess.getUser(event.getPlayer());
             if (user.isJailed()) {
                 event.setCancelled(true);


### PR DESCRIPTION
## PR Synopsis

Fixes #1996

This PR introduces a change that would prevent jailed players from having their gamemode changed.

## Rationale

As stated in the original issue, "Some plugins like CreativeParkour attempt to teleport and alter the player's gamemode. The teleport is blocked of course, but they end up in creative gamemode."

The changes proposed cancel `PlayerGameModeChangeEvent` if the target player is currently jailed in order to resolve this issue.

## Impact

This is a very broad method of blocking players from changing gamemodes. If an admin wanted to change the player's gamemode, they will need to unjail them before doing so and then rejail them as necessary.

People who might expect the gamemode of jailed users to be capable of change (such as the fictional admins mentioned above) may find this to be inconvenient. However, I personally don't know of anyone who would need to do this. Again, it is still possible to change the player's gamemode by unjailing and rejailing in the potential rare case that it is necessary to do so.

