### PR TITLE
Fixes #2712 - Allow self-afk toggle with single-word message

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandafk.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandafk.java
@@ -24,10 +24,6 @@ public class Commandafk extends EssentialsCommand {
                 afkUser = getPlayer(server, user, args, 0);
                 message = args.length > 1 ? getFinalArg(args, 1) : null;
             } catch (PlayerNotFoundException e) {
-                // If only one arg is passed, assume the command executor is targeting another player.
-                if (args.length == 1) {
-                    throw e;
-                }
                 message = getFinalArg(args, 0);
             }
             toggleAfk(user, afkUser, message);


### PR DESCRIPTION
# PR Synopsis

Fixes #2712 

This PR introduces a change that will permit players with the permission to toggle their own AFK status using a one-word message.

# Rationale

Users that are able to set the AFK status of others cannot toggle their own AFK state if the message given is only one word long. For example, the following command would fail to work:

```
/afk Fishing!
```

This is because the command logic is inflexible and believes the first argument to always be the player name.

The changes proposed rectifies this by simply assuming that any arguments given to the AFK command are part of the AFK message rather than assuming that the intended player was not found.

# Impact

Users who accidentally misspell a target player's name may inadvertently change their AFK status. However, this is mitigated by the fact that the AFK command provides tab-completion for player names, so in practice, this should happen very rarely. Even if it did happen, it is possible to again change the AFK state by retyping the `/afk` command.

Regardless, I believe that the potential negative impacts of this PR are far outweighed by the capability to toggle your own AFK status more consistently.