### PR TITLE
Fixes #2879 - Command cooldowns not persistent

### DIFF
--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -857,7 +857,7 @@ public abstract class UserData extends PlayerExtension implements IConf {
     private Map<Pattern, Long> commandCooldowns;
 
     private Map<Pattern, Long> _getCommandCooldowns() {
-        if (!config.isConfigurationSection("timestamps.command-cooldowns")) {
+        if (!config.contains("timestamps.command-cooldowns")) {
             return null;
         }
 


### PR DESCRIPTION
Fixes #2879

## PR Synopsis

This PR corrects a check for the command cooldowns list in the userdata file. This fixes cooldowns apparently not being persisted across restarts.

## Explanation

The original issue stated that "The cooldown works just fine while the server is still running, however, seems to be ignored once the server has been restarted." This means that there is an issue with parsing the cooldowns once the server boots back up again.

When user cooldowns are parsed, they are first checked to see whether there is a section available to parse in the first place. However, it is misinterpreted as a configuration section rather than a list. This leads to the check returning `false` regardless of whether or not the timestamps exist. By switching the check to a `contains`, the logic for this check is corrected.