### PR TITLE
Add config file for custom item aliases

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -19,6 +19,7 @@ package com.earth2me.essentials;
 
 import com.earth2me.essentials.commands.*;
 import com.earth2me.essentials.items.AbstractItemDb;
+import com.earth2me.essentials.items.CustomItemResolver;
 import com.earth2me.essentials.items.FlatItemDb;
 import com.earth2me.essentials.items.LegacyItemDb;
 import com.earth2me.essentials.metrics.Metrics;
@@ -32,12 +33,18 @@ import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.textreader.SimpleTextInput;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.VersionUtil;
-import com.google.common.base.Function;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
-import net.ess3.api.*;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import net.ess3.api.IEssentials;
 import net.ess3.api.ISettings;
+import net.ess3.api.*;
 import net.ess3.nms.PotionMetaProvider;
 import net.ess3.nms.SpawnEggProvider;
 import net.ess3.nms.SpawnerProvider;
@@ -76,14 +83,6 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.yaml.snakeyaml.error.YAMLException;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -97,6 +96,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     private transient List<IConf> confList;
     private transient Backup backup;
     private transient AbstractItemDb itemDb;
+    private transient CustomItemResolver customItemResolver;
     private transient final Methods paymentMethod = new Methods();
     private transient PermissionsHandler permissionsHandler;
     private transient AlternativeCommandsHandler alternativeCommandsHandler;
@@ -216,13 +216,25 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
                 warps = new Warps(getServer(), this.getDataFolder());
                 confList.add(warps);
-                execTimer.mark("Init(Spawn/Warp)");
+                execTimer.mark("Init(Warp)");
 
                 worth = new Worth(this.getDataFolder());
                 confList.add(worth);
+                execTimer.mark("Init(Worth)");
+
                 itemDb = getItemDbFromConfig();
                 confList.add(itemDb);
-                execTimer.mark("Init(Worth/ItemDB)");
+                execTimer.mark("Init(ItemDB)");
+
+                customItemResolver = new CustomItemResolver(this);
+                try {
+                    itemDb.registerResolver(this, "custom_items", customItemResolver);
+                    confList.add(customItemResolver);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    customItemResolver = null;
+                }
+                execTimer.mark("Init(CustomItemResolver)");
 
                 jails = new Jails(this);
                 confList.add(jails);
@@ -873,13 +885,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
     @Override
     public Iterable<User> getOnlineUsers() {
-        return Iterables.transform(getOnlinePlayers(), new Function<Player, User>() {
-
-            @Override
-            public User apply(Player player) {
-                return getUser(player);
-            }
-        });
+        return getOnlinePlayers().stream().map(this::getUser).collect(Collectors.toList());
     }
 
     @Override
@@ -895,6 +901,11 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     @Override
     public PotionMetaProvider getPotionMetaProvider() {
         return potionMetaProvider;
+    }
+
+    @Override
+    public CustomItemResolver getCustomItemResolver() {
+        return customItemResolver;
     }
 
     private static void addDefaultBackPermissionsToWorld(World w) {

--- a/Essentials/src/com/earth2me/essentials/items/CustomItemResolver.java
+++ b/Essentials/src/com/earth2me/essentials/items/CustomItemResolver.java
@@ -13,7 +13,7 @@ import org.bukkit.inventory.ItemStack;
 public class CustomItemResolver implements IItemDb.ItemResolver, IConf {
     private final EssentialsConf config;
     private final Essentials ess;
-    private final HashMap<String, String> customItems = new HashMap<>();
+    private final HashMap<String, String> map = new HashMap<>();
 
     public CustomItemResolver(Essentials ess) {
         config = new EssentialsConf(new File(ess.getDataFolder(), "custom_items.yml"));
@@ -23,7 +23,7 @@ public class CustomItemResolver implements IItemDb.ItemResolver, IConf {
 
     @Override
     public ItemStack apply(String item) {
-        if (customItems.containsKey(item)) {
+        if (map.containsKey(item)) {
             try {
                 return ess.getItemDb().get(item);
             } catch (Exception ignored) {}
@@ -34,12 +34,12 @@ public class CustomItemResolver implements IItemDb.ItemResolver, IConf {
 
     @Override
     public Collection<String> getNames() {
-        return customItems.keySet();
+        return map.keySet();
     }
 
     @Override
     public void reloadConfig() {
-        customItems.clear();
+        map.clear();
         config.load();
 
         ConfigurationSection section = config.getConfigurationSection("aliases");
@@ -53,9 +53,29 @@ public class CustomItemResolver implements IItemDb.ItemResolver, IConf {
             String target = section.getString(alias);
 
             if (target != null && !section.contains(target) && existsInItemDb(target)) {
-                customItems.put(alias, target);
+                map.put(alias, target);
             }
         }
+    }
+
+    public void setAlias(String alias, String target) {
+        if (map.containsKey(alias) && map.get(alias).equalsIgnoreCase(target)) {
+            return;
+        }
+
+        map.put(alias, target);
+        save();
+    }
+
+    public void removeAlias(String alias) {
+        if (map.remove(alias) != null) {
+            save();
+        }
+    }
+
+    private void save() {
+        config.setProperty("aliases", map);
+        config.save();
     }
 
     private boolean existsInItemDb(String item) {

--- a/Essentials/src/com/earth2me/essentials/items/CustomItemResolver.java
+++ b/Essentials/src/com/earth2me/essentials/items/CustomItemResolver.java
@@ -1,0 +1,69 @@
+package com.earth2me.essentials.items;
+
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.EssentialsConf;
+import com.earth2me.essentials.IConf;
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import net.ess3.api.IItemDb;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
+
+public class CustomItemResolver implements IItemDb.ItemResolver, IConf {
+    private final EssentialsConf config;
+    private final Essentials ess;
+    private final HashMap<String, String> customItems = new HashMap<>();
+
+    public CustomItemResolver(Essentials ess) {
+        config = new EssentialsConf(new File(ess.getDataFolder(), "custom_items.yml"));
+        this.ess = ess;
+        config.setTemplateName("custom_items.yml");
+    }
+
+    @Override
+    public ItemStack apply(String item) {
+        if (customItems.containsKey(item)) {
+            try {
+                return ess.getItemDb().get(item);
+            } catch (Exception ignored) {}
+        }
+
+        return null;
+    }
+
+    @Override
+    public Collection<String> getNames() {
+        return customItems.keySet();
+    }
+
+    @Override
+    public void reloadConfig() {
+        customItems.clear();
+        config.load();
+
+        ConfigurationSection section = config.getConfigurationSection("aliases");
+        if (section == null || section.getKeys(false).isEmpty()) {
+            ess.getLogger().warning("No aliases found in custom_items.yml.");
+            return;
+        }
+
+        for (String alias : section.getKeys(false)) {
+            if (!section.isString(alias)) continue;
+            String target = section.getString(alias);
+
+            if (target != null && !section.contains(target) && existsInItemDb(target)) {
+                customItems.put(alias, target);
+            }
+        }
+    }
+
+    private boolean existsInItemDb(String item) {
+        try {
+            ess.getItemDb().get(item);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/Essentials/src/custom_items.yml
+++ b/Essentials/src/custom_items.yml
@@ -1,0 +1,8 @@
+# This file stores custom item aliases.
+# We recommend you use the `/itemdb alias` command to manage these.
+
+# NOTE: If you try and alias an item to another entry in this file, the alias won't work.
+aliases:
+  bluepaint: blue_dye
+  snad: sand
+  breakfast: cooked_porkchop

--- a/Essentials/src/net/ess3/api/IEssentials.java
+++ b/Essentials/src/net/ess3/api/IEssentials.java
@@ -1,5 +1,6 @@
 package net.ess3.api;
 
+import com.earth2me.essentials.items.CustomItemResolver;
 import net.ess3.nms.PotionMetaProvider;
 import net.ess3.nms.SpawnEggProvider;
 
@@ -12,4 +13,6 @@ public interface IEssentials extends com.earth2me.essentials.IEssentials {
     SpawnEggProvider getSpawnEggProvider();
 
     PotionMetaProvider getPotionMetaProvider();
+
+    CustomItemResolver getCustomItemResolver();
 }


### PR DESCRIPTION
Add a `custom_items.yml` that allows admins to easily add custom item aliases to the item database.

Not only is this easier than manually editing the `items.csv` or `items.json` files, but this method works regardless of which item database is in use as it uses the [item resolver API](https://github.com/EssentialsX/Essentials/pull/2472).

To be added later: `/itemdb alias create`, `/itemdb alias list` and `/itemdb alias delete` commands to manage this file.