### PR TITLE
Improvements for delkit

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commanddelkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddelkit.java
@@ -2,15 +2,11 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Kit;
-import com.earth2me.essentials.User;
-import com.earth2me.essentials.utils.StringUtil;
+import com.google.common.collect.Lists;
 import org.bukkit.Server;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
-import java.util.logging.Level;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -35,7 +31,15 @@ public class Commanddelkit extends EssentialsCommand {
             }
 
             ess.getKits().removeKit(kitName);
-            sender.sendMessage(tl("deleteKit", kit));
+            sender.sendMessage(tl("deleteKit", kitName));
         }
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        if (args.length == 1) {
+            return Lists.newArrayList(ess.getKits().getKits().getKeys(false));
+        }
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
3 improvements for delkit within this PR:

1) Cleaned up unused imports
2) Show actual kit name when deleting instead of memory address (this is the reason originally for making this)
3) Implement tab completion

I've tested to make sure the changes are properly functioning. See below:

Before:
![2019-12-29_01 12 09](https://user-images.githubusercontent.com/17698576/71555204-4bd5c200-29de-11ea-9fe3-eb88db08ef48.png)

After:
![2019-12-29_01 48 50](https://user-images.githubusercontent.com/17698576/71555207-56905700-29de-11ea-9277-271bb0656d64.png)
![2019-12-29_01 48 25](https://user-images.githubusercontent.com/17698576/71555208-58f2b100-29de-11ea-8257-742fa7bb3150.png)