### PR TITLE
Do not send console message if the list is empty for debug logging when a player enters a command

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -833,8 +833,7 @@ public class EssentialsPlayerListener implements Listener {
 
             event.getCommands().removeIf(str -> shouldHideFromUser(str, user));
 
-            if (ess.getSettings().isDebug()) {
-                removedCmds.removeAll(event.getCommands());
+            if (ess.getSettings().isDebug() && removedCmds.removeAll(event.getCommands())) {
                 ess.getLogger().info("Removed commands: " + removedCmds.toString());
             }
         }


### PR DESCRIPTION
Screenshot about empty array:
![kép](https://user-images.githubusercontent.com/30026208/72207993-fb5e6a00-349d-11ea-9fac-b4e10bba37cc.png)

_Do I need to look for additional debug log messages that may be empty and unnecessarily written to the console?_