### PR TITLE
Only register EntityTransformEvent in 1.13.2+

### DIFF
--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtect.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtect.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.protect;
 
 import com.earth2me.essentials.metrics.Metrics;
+import com.earth2me.essentials.utils.VersionUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
@@ -48,6 +49,11 @@ public class EssentialsProtect extends JavaPlugin implements IProtect {
 
         final EssentialsProtectEntityListener entityListener = new EssentialsProtectEntityListener(this);
         pm.registerEvents(entityListener, this);
+
+        if (VersionUtil.getServerBukkitVersion().isHigherThan(VersionUtil.v1_13_2_R01)) {
+            final EssentialsProtectEntityListener1_13_2_R1 entityListener1_13_2_r1 = new EssentialsProtectEntityListener1_13_2_R1(this);
+            pm.registerEvents(entityListener1_13_2_r1, this);
+        }
 
         final EssentialsProtectWeatherListener weatherListener = new EssentialsProtectWeatherListener(this);
         pm.registerEvents(weatherListener, this);

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
@@ -171,29 +171,6 @@ public class EssentialsProtectEntityListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onEntityTransform(final EntityTransformEvent event) {
-        final Entity entity = event.getEntity();
-        final EntityTransformEvent.TransformReason reason = event.getTransformReason();
-        if (reason == EntityTransformEvent.TransformReason.INFECTION && prot.getSettingBool(ProtectConfig.prevent_villager_infection)) {
-            event.setCancelled(true);
-        } else if (reason == EntityTransformEvent.TransformReason.CURED && prot.getSettingBool(ProtectConfig.prevent_villager_cure)) {
-            event.setCancelled(true);
-        } else if (reason == EntityTransformEvent.TransformReason.LIGHTNING) {
-            if (entity instanceof Villager && prot.getSettingBool(ProtectConfig.prevent_villager_to_witch)) {
-                event.setCancelled(true);
-            } else if (entity instanceof Pig && prot.getSettingBool(ProtectConfig.prevent_pig_transformation)) {
-                event.setCancelled(true);
-            } else if (entity instanceof Creeper && prot.getSettingBool(ProtectConfig.prevent_creeper_charge)) {
-                event.setCancelled(true);
-            } else if (entity instanceof MushroomCow && prot.getSettingBool(ProtectConfig.prevent_mooshroom_switching)) {
-                event.setCancelled(true);
-            }
-        } else if (reason == EntityTransformEvent.TransformReason.DROWNED && prot.getSettingBool(ProtectConfig.prevent_zombie_drowning)) {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onCreatureSpawn(final CreatureSpawnEvent event) {
         if (event.getEntity() instanceof Player) {
             return;

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener1_13_2_R1.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener1_13_2_R1.java
@@ -1,0 +1,45 @@
+package com.earth2me.essentials.protect;
+
+import net.ess3.api.IEssentials;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.MushroomCow;
+import org.bukkit.entity.Pig;
+import org.bukkit.entity.Villager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityTransformEvent;
+
+public class EssentialsProtectEntityListener1_13_2_R1 implements Listener {
+    private final IProtect prot;
+    private final IEssentials ess;
+
+    EssentialsProtectEntityListener1_13_2_R1(final IProtect prot) {
+        this.prot = prot;
+        this.ess = prot.getEssentialsConnect().getEssentials();
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onEntityTransform(final EntityTransformEvent event) {
+        final Entity entity = event.getEntity();
+        final EntityTransformEvent.TransformReason reason = event.getTransformReason();
+        if (reason == EntityTransformEvent.TransformReason.INFECTION && prot.getSettingBool(ProtectConfig.prevent_villager_infection)) {
+            event.setCancelled(true);
+        } else if (reason == EntityTransformEvent.TransformReason.CURED && prot.getSettingBool(ProtectConfig.prevent_villager_cure)) {
+            event.setCancelled(true);
+        } else if (reason == EntityTransformEvent.TransformReason.LIGHTNING) {
+            if (entity instanceof Villager && prot.getSettingBool(ProtectConfig.prevent_villager_to_witch)) {
+                event.setCancelled(true);
+            } else if (entity instanceof Pig && prot.getSettingBool(ProtectConfig.prevent_pig_transformation)) {
+                event.setCancelled(true);
+            } else if (entity instanceof Creeper && prot.getSettingBool(ProtectConfig.prevent_creeper_charge)) {
+                event.setCancelled(true);
+            } else if (entity instanceof MushroomCow && prot.getSettingBool(ProtectConfig.prevent_mooshroom_switching)) {
+                event.setCancelled(true);
+            }
+        } else if (reason == EntityTransformEvent.TransformReason.DROWNED && prot.getSettingBool(ProtectConfig.prevent_zombie_drowning)) {
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the problem mentioned in #2931 which was introduced in #2836. This is caused as a result of EntityTransformEvent being a relatively new event introduced in Spigot [856adc3e6af](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/856adc3e6afc3e9c0495ac27e38b96b144e54b1e), which was after the update to 1.13.2 in Spigot [f311182396b](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/f311182396bd74b106efebc926ea4d0b92cfba80).

**Tests**
Before changes:
```
[13:34:08 INFO]: Starting minecraft server version 1.13.1
[13:34:08 INFO]: This server is running CraftBukkit version git-Spigot-f6a273b-a639ae4 (MC: 1.13.1) (Implementing API version 1.13.1-R0.1-SNAPSHOT)
[13:34:15 INFO]: [EssentialsProtect] Enabling EssentialsProtect v2.17.1.50
[13:34:15 INFO]: [EssentialsProtect] Continuing to enable Protect.
[13:34:15 ERROR]: [EssentialsProtect] Plugin EssentialsProtect v2.17.1.50 has failed to register events for class com.earth2me.essentials.protect.EssentialsProtectEntityListener because org/bukkit/event/entity/EntityTransformEvent does not exist.
```
```
[13:35:11 INFO]: Starting minecraft server version 1.13.2
[13:35:11 INFO]: This server is running CraftBukkit version git-Spigot-f56e2e7-1748af8 (MC: 1.13.2) (Implementing API version 1.13.2-R0.1-SNAPSHOT)
[13:35:19 INFO]: [EssentialsProtect] Enabling EssentialsProtect v2.17.1.50
[13:35:19 INFO]: [EssentialsProtect] Continuing to enable Protect.
```
After changes:
```
[13:30:58 INFO]: Starting minecraft server version 1.13.1
[13:30:59 INFO]: This server is running CraftBukkit version git-Spigot-f6a273b-a639ae4 (MC: 1.13.1) (Implementing API version 1.13.1-R0.1-SNAPSHOT)
[13:31:25 INFO]: [EssentialsProtect] Enabling EssentialsProtect v2.17.1.50
[13:31:25 INFO]: [EssentialsProtect] Continuing to enable Protect.
```
```
[13:33:00 INFO]: Starting minecraft server version 1.13.2
[13:33:00 INFO]: This server is running CraftBukkit version git-Spigot-f56e2e7-1748af8 (MC: 1.13.2) (Implementing API version 1.13.2-R0.1-SNAPSHOT)
[13:33:08 INFO]: [EssentialsProtect] Enabling EssentialsProtect v2.17.1.50
[13:33:08 INFO]: [EssentialsProtect] Continuing to enable Protect.
```

Closes #2931