### PR TITLE
Properly escape pipe character on item lore

### DIFF
--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -163,7 +163,7 @@ public class MetaItemStack {
         } else if (split.length > 1 && (split[0].equalsIgnoreCase("lore") || split[0].equalsIgnoreCase("desc")) && hasMetaPermission(sender, "lore", false, true, ess)) {
             final List<String> lore = new ArrayList<String>();
             for (String line : split[1].split("(?<!\\\\)\\|")) {
-                lore.add(FormatUtil.replaceFormat(line.replace('_', ' ').replace("\|", "|")));
+                lore.add(FormatUtil.replaceFormat(line.replace('_', ' ').replace("\\|", "|")));
             }
             final ItemMeta meta = stack.getItemMeta();
             meta.setLore(lore);

--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -162,8 +162,8 @@ public class MetaItemStack {
             stack.setItemMeta(meta);
         } else if (split.length > 1 && (split[0].equalsIgnoreCase("lore") || split[0].equalsIgnoreCase("desc")) && hasMetaPermission(sender, "lore", false, true, ess)) {
             final List<String> lore = new ArrayList<String>();
-            for (String line : split[1].split("[^\\\\](\\|)")) {
-                lore.add(FormatUtil.replaceFormat(line.replace('_', ' ')));
+            for (String line : split[1].split("(?<!\\\\)\\|")) {
+                lore.add(FormatUtil.replaceFormat(line.replace('_', ' ').replace("\|", "|")));
             }
             final ItemMeta meta = stack.getItemMeta();
             meta.setLore(lore);


### PR DESCRIPTION
Using negative lookbehind instead of negated characters set.
Fixes #2962, #2984

Yeah, not the best solution, but it fixes the problem.