### PR TITLE
Add beezooka command

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandbeezooka.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbeezooka.java
@@ -1,0 +1,35 @@
+package com.earth2me.essentials.commands;
+
+import com.earth2me.essentials.Mob;
+import com.earth2me.essentials.User;
+import com.earth2me.essentials.utils.VersionUtil;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.entity.Entity;
+
+import static com.earth2me.essentials.I18n.tl;
+
+public class Commandbeezooka extends EssentialsCommand {
+
+    public Commandbeezooka() {
+        super("beezooka");
+    }
+
+    @Override
+    protected void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
+        if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_15_R01)) {
+            user.sendMessage(tl("unsupportedFeature"));
+            return;
+        }
+
+        final Entity bee = Mob.BEE.spawn(user.getWorld(), server, user.getBase().getEyeLocation());
+        bee.setVelocity(user.getBase().getEyeLocation().getDirection().multiply(2));
+
+        ess.scheduleSyncDelayedTask(() -> {
+            final Location loc = bee.getLocation();
+            bee.remove();
+            loc.getWorld().createExplosion(loc, 0F);
+        }, 20);
+    }
+
+}

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -569,6 +569,7 @@ unlimitedItemPermission=\u00a74No permission for unlimited item \u00a7c{0}\u00a7
 unlimitedItems=\u00a76Unlimited items\:\u00a7r
 unmutedPlayer=\u00a76Player\u00a7c {0} \u00a76unmuted.
 unsafeTeleportDestination=\u00a74The teleport destination is unsafe and teleport-safety is disabled.
+unsupportedFeature=\u00a74This feature is not supported on the current server version.
 unvanishedReload=\u00a74A reload has forced you to become visible.
 upgradingFilesError=Error while upgrading the files.
 uptime=\u00a76Uptime\:\u00a7c {0}

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -41,6 +41,10 @@ commands:
     description: Bans an IP address.
     usage: /<command> <address>
     aliases: [ebanip]
+  beezooka:
+    description: Throw an exploding bee at your opponent.
+    usage: /<command>
+    aliases: [ebeezooka,beecannon,ebeecannon]
   book:
     description: Allows reopening and editing of sealed books.
     usage: /<command> [title|author [name]]


### PR DESCRIPTION
This PR introduces the `/beezooka` command as suggested in #2975. The command acts similarly to `/kittycannon` with the exception of the Bee being tamed, instead flying around for a small amount of time before exploding.

Sample usage:
![beezooka](https://user-images.githubusercontent.com/10545540/74099459-11804880-4b78-11ea-9c3d-499b06d912fb.gif)

As Bees do not exist below version 1.15, an error will display when attempting to run the command on such a version:
![image](https://user-images.githubusercontent.com/10545540/74099477-4d1b1280-4b78-11ea-91c2-fa675994a85f.png)

closes #2975 