### PR TITLE
Truncate kit item strings

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Kit.java
+++ b/Essentials/src/com/earth2me/essentials/Kit.java
@@ -122,17 +122,9 @@ public class Kit {
             throw new Exception(tl("kitNotFound"));
         }
         try {
-            final List<String> itemList = new ArrayList<String>();
             final Object kitItems = kit.get("items");
             if (kitItems instanceof List) {
-                for (Object item : (List) kitItems) {
-                    if (item instanceof String) {
-                        itemList.add(item.toString());
-                        continue;
-                    }
-                    throw new Exception("Invalid kit item: " + item.toString());
-                }
-                return itemList;
+                return (List) kitItems;
             }
             throw new Exception("Invalid item list");
         } catch (Exception e) {

--- a/Essentials/src/com/earth2me/essentials/Kit.java
+++ b/Essentials/src/com/earth2me/essentials/Kit.java
@@ -122,9 +122,17 @@ public class Kit {
             throw new Exception(tl("kitNotFound"));
         }
         try {
+            final List<String> itemList = new ArrayList<String>();
             final Object kitItems = kit.get("items");
             if (kitItems instanceof List) {
-                return (List) kitItems;
+                for (Object item : (List) kitItems) {
+                    if (item instanceof String) {
+                        itemList.add(item.toString());
+                        continue;
+                    }
+                    throw new Exception("Invalid kit item: " + item.toString());
+                }
+                return itemList;
             }
             throw new Exception("Invalid item list");
         } catch (Exception e) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
@@ -2,6 +2,7 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.Kit;
 import com.earth2me.essentials.User;
+import org.apache.commons.lang.StringUtils;
 import org.bukkit.Server;
 
 import java.util.ArrayList;
@@ -28,7 +29,9 @@ public class Commandshowkit extends EssentialsCommand {
             Kit kit = new Kit(kitName, ess);
             user.sendMessage(tl("kitContains", kitName));
             for (String s : kit.getItems()) {
-                user.sendMessage(tl("kitItem", s));
+                int maxStringLength = 384;
+
+                user.sendMessage(tl("kitItem", StringUtils.abbreviate(s, maxStringLength)));
             }
         }
     }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
@@ -31,11 +31,7 @@ public class Commandshowkit extends EssentialsCommand {
             for (String s : kit.getItems()) {
                 int maxStringLength = 384;
 
-                try {
-                    user.sendMessage(tl("kitItem", StringUtils.abbreviate(s, maxStringLength)));
-                } catch (ClassCastException e) {
-                    throw new Exception("Invalid kit item: " + s);
-                }
+                user.sendMessage(tl("kitItem", StringUtils.abbreviate(s, maxStringLength)));
             }
         }
     }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
@@ -2,7 +2,6 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.Kit;
 import com.earth2me.essentials.User;
-import org.apache.commons.lang.StringUtils;
 import org.bukkit.Server;
 
 import java.util.ArrayList;
@@ -31,7 +30,12 @@ public class Commandshowkit extends EssentialsCommand {
             for (String s : kit.getItems()) {
                 int maxStringLength = 384;
 
-                user.sendMessage(tl("kitItem", StringUtils.abbreviate(s, maxStringLength)));
+                if (s.length() > maxStringLength) {
+                   // To prevent performance loss, don't display item metadata if it's too long
+                    // Keep item name and amount, remove the metadata, and inform the user
+                    s = s.substring(0, s.indexOf(" ", s.indexOf(" ") + 1)) + " (item metadata is too long to display)";
+                }
+                user.sendMessage(tl("kitItem", s));
             }
         }
     }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandshowkit.java
@@ -31,7 +31,11 @@ public class Commandshowkit extends EssentialsCommand {
             for (String s : kit.getItems()) {
                 int maxStringLength = 384;
 
-                user.sendMessage(tl("kitItem", StringUtils.abbreviate(s, maxStringLength)));
+                try {
+                    user.sendMessage(tl("kitItem", StringUtils.abbreviate(s, maxStringLength)));
+                } catch (ClassCastException e) {
+                    throw new Exception("Invalid kit item: " + s);
+                }
             }
         }
     }


### PR DESCRIPTION
The showkit command can currently be exploited to choke and crash a server, if items with a lot of data are added to a kit. Each item string is truncated in the command output to resolve this.

A 384 character limit seems to be the sweet spot for usability and performance. 512 and above makes the TPS drop considerably.