### PR TITLE
Fix CustomItemResolver causing a StackOverflowError

### DIFF
--- a/Essentials/src/com/earth2me/essentials/items/CustomItemResolver.java
+++ b/Essentials/src/com/earth2me/essentials/items/CustomItemResolver.java
@@ -25,7 +25,7 @@ public class CustomItemResolver implements IItemDb.ItemResolver, IConf {
     public ItemStack apply(String item) {
         if (map.containsKey(item)) {
             try {
-                return ess.getItemDb().get(item);
+                return ess.getItemDb().get(map.get(item));
             } catch (Exception ignored) {}
         }
 


### PR DESCRIPTION
CustomItemResolver was fetching the custom item from the item database instead of the resolved custom item which caused a StackOverflowError

Fixes #3018