### PR TITLE
Clarify easter egg config description

### DIFF
--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -503,7 +503,7 @@ last-message-reply-recipient: true
 # Default is 180 (3 minutes)
 last-message-reply-recipient-timeout: 180
 
-# Toggles whether or not clicking mobs with a milk bucket turns them into a baby.
+# Toggles whether or not left clicking mobs with a milk bucket turns them into a baby.
 milk-bucket-easter-egg: true
 
 # Toggles whether or not the fly status message should be sent to players on join


### PR DESCRIPTION
Clarifies the config to state that a left click is required for the easter egg. Closes #2992 