### PR TITLE
Add permissions defaults to plugin.yml for op-affecting commands

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -284,6 +284,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             permissionsHandler = new PermissionsHandler(this, settings.useBukkitPermissions());
             alternativeCommandsHandler = new AlternativeCommandsHandler(this);
 
+            // Register hat permissions
+            Commandhat.registerPermissionsIfNecessary(getServer().getPluginManager());
+
             timer = new EssentialsTimer(this);
             scheduleSyncRepeatingTask(timer, 1000, 50);
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandhat.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhat.java
@@ -2,11 +2,15 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.plugin.PluginManager;
 
 import java.util.Collections;
 import java.util.List;
@@ -17,6 +21,31 @@ import static com.earth2me.essentials.I18n.tl;
 public class Commandhat extends EssentialsCommand {
     public Commandhat() {
         super("hat");
+    }
+
+    /**
+     * The prefix for hat prevention commands
+     */
+    private static final String PERM_PREFIX = "essentials.hat.prevent-type.";
+
+    /**
+     * Register permissions used by this command.
+     *
+     * @param toRegister The plugin manager to register permissions in.
+     */
+    public static void registerPermissionsIfNecessary(PluginManager toRegister) {
+        Permission hatPerm = toRegister.getPermission(PERM_PREFIX + "*");
+        if (hatPerm != null) {
+            return;
+        }
+
+        ImmutableMap.Builder<String, Boolean> children = ImmutableMap.builder();
+        for (Material mat : Material.values()) {
+            final String matPerm = PERM_PREFIX + mat.name().toLowerCase();
+            children.put(matPerm, true);
+            toRegister.addPermission(new Permission(matPerm, "Prevent using " + mat + " as a type of hat.", PermissionDefault.FALSE));
+        }
+        toRegister.addPermission(new Permission(PERM_PREFIX + "*", "Prevent all types of hats", PermissionDefault.FALSE, children.build()));
     }
 
     @Override

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -7,7 +7,7 @@ website: http://tiny.cc/EssentialsCommands
 description: Provides an essential, core set of commands for Bukkit.
 softdepend: [Vault]
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits, md_5, Iaccidentally, drtshock, vemacs, SupaHam, md678685]
-api-version: 1.13
+api-version: "1.13"
 commands:
   afk:
     description: Marks you as away-from-keyboard.
@@ -574,3 +574,69 @@ permissions:
   essentials.near.exclude:
     default: false
     description: If the player should be excluded from near lookups.
+  essentials.keepxp:
+    default: false
+    description: Allows the user to keep their exp on death, instead of dropping it.
+  essentials.invsee.preventmodify:
+    default: false
+    description: Prevents other players from modifying the players inventory.
+  essentials.afk.auto:
+    default: false
+    description: Players with this permission will be set to afk after a period of inaction as defined in the config file.
+  essentials.home.compass:
+    default: false
+    description: Point the player's compass at their first home. compass-towards-home-perm needs to be enabled in the configuration.
+  essentials.ban.exempt:
+    default: false
+    description: Prevent a specified group or player from being banned
+  essentials.kick.exempt:
+    default: false
+    description: Prevents the player from being kicked.
+  essentials.chat.ignoreexempt:
+    default: false
+    description: Someone with this permission will not be ignored, even if they are on another persons ignore list
+  essentials.kit.exemptdelay:
+    default: false
+    description: Exempts you from the kit delay feature, this affects signs as well as command.
+  essentials.mute.exempt:
+    default: false
+    description: Prevent a specified group or player from being muted
+  essentials.sethome.bed:
+    default: false
+    description: Allows the player to right click a bed during daytime to update their 'bed' home.
+  essentials.silentjoin:
+    default: false
+    description: Allow to join silently
+  essentials.silentjoin.vanish:
+    default: false
+    description: Allow to join silently, and get put in vanish mode
+  essentials.silentquit:
+    default: false
+    description: Suppress leave/quit messages for users with this permission.
+  essentials.sleepingignored:
+    default: false
+    description: User isn't required to be sleeping, for time to be reset.
+  essentials.sudo.exempt:
+    default: false
+    description: Prevents the holder from being sudo'ed by another user
+  essentials.tempban.exempt:
+    default: false
+    description: Prevents a specified group or player from being tempbanned
+  essentials.nick.allowunsafe:
+    default: false
+    description: If a player has this, they can set their username to any value. Use with caution, as this has the potential to break userdata files.
+  essentials.balancetop.exclude:
+    default: false
+    description: Players with this permission are excluded from the balancetop
+  essentials.exempt:
+    default: false
+    description: Parent permission to be exempt from many moderator actions
+    children:
+      essentials.invsee.preventmodify: true
+      essentials.ban.exempt: true
+      essentials.kick.exempt: true
+      essentials.mute.exempt: true
+      essentials.chat.ignoreexempt: true
+      essentials.sudo.exempt: true
+      essentials.tempban.exempt: true
+      essentials.exempt.protect: true

--- a/EssentialsAntiBuild/src/plugin.yml
+++ b/EssentialsAntiBuild/src/plugin.yml
@@ -7,4 +7,14 @@ website: http://tiny.cc/EssentialsCommands
 description: Provides build protection.
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits, Iaccidentally]
 depend: [Essentials]
-api-version: 1.13
+api-version: "1.13"
+
+permissions:
+  essentials.exempt.protect:
+    default: false
+    description: Exempt from EssentialsProtect/EssentialsAntiBuild protections
+    children:
+      essentials.protect.alerts.notrigger: true
+      essentials.protect.exemptbreak: true
+      essentials.protect.exemptplacement: true
+      essentials.protect.exemptusage: true


### PR DESCRIPTION
This aims to reduce the unintended consequences of granting all Essentials permissions or giving a player op, by defaulting permissions some more permissions to false

Outstanding issue is the hat restrict-items permissions... what do?

there's also a new `essentials.exempt` metapermission to have one parent that controls exemption from kick/ban/mute/etc

this will change behaviour for ops to some extent. are we fine with that?

behaviours I was feeling uncertain about:

 - essentials.help.* as defaults?
 - defaulting notify permissions to false?
