### PR TITLE
Fix bed message on some older versions of MC

### DIFF
--- a/Essentials/src/com/earth2me/essentials/utils/MaterialUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/MaterialUtil.java
@@ -32,7 +32,7 @@ public class MaterialUtil {
 
     static {
 
-        BEDS = EnumUtil.getAllMatching(Material.class, "BED", "WHITE_BED", "ORANGE_BED",
+        BEDS = EnumUtil.getAllMatching(Material.class, "BED", "BED_BLOCK", "WHITE_BED", "ORANGE_BED",
             "MAGENTA_BED", "LIGHT_BLUE_BED", "YELLOW_BED", "LIME_BED", "PINK_BED", "GRAY_BED",
             "LIGHT_GRAY_BED", "CYAN_BED", "PURPLE_BED", "BLUE_BED", "BROWN_BED", "GREEN_BED",
             "RED_BED", "BLACK_BED");


### PR DESCRIPTION
Fixes #3045. Some older versions of MC use "BED_BLOCK" to represent beds.

Very briefly tested in 1.8.8, 1.12.2, 1.15.2. Seems to be fine.