### PR TITLE
Near exclude permission

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
@@ -88,7 +88,7 @@ public class Commandnear extends EssentialsCommand {
         Queue<User> nearbyPlayers = new PriorityQueue<>((o1, o2) -> (int) (o1.getLocation().distanceSquared(loc) - o2.getLocation().distanceSquared(loc)));
 
         for (User player : ess.getOnlineUsers()) {
-            if (!player.equals(user) && !player.getBase().hasPermission("essentials.near.exclude") && (!player.isHidden(user.getBase()) || showHidden || user.getBase().canSee(player.getBase()))) {
+            if (!player.equals(user) && !player.isAuthorized("essentials.near.exclude") && (!player.isHidden(user.getBase()) || showHidden || user.getBase().canSee(player.getBase()))) {
                 final Location playerLoc = player.getLocation();
                 if (playerLoc.getWorld() != world) {
                     continue;

--- a/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnear.java
@@ -88,7 +88,7 @@ public class Commandnear extends EssentialsCommand {
         Queue<User> nearbyPlayers = new PriorityQueue<>((o1, o2) -> (int) (o1.getLocation().distanceSquared(loc) - o2.getLocation().distanceSquared(loc)));
 
         for (User player : ess.getOnlineUsers()) {
-            if (!player.equals(user) && (!player.isHidden(user.getBase()) || showHidden || user.getBase().canSee(player.getBase()))) {
+            if (!player.equals(user) && !player.getBase().hasPermission("essentials.near.exclude") && (!player.isHidden(user.getBase()) || showHidden || user.getBase().canSee(player.getBase()))) {
                 final Location playerLoc = player.getLocation();
                 if (playerLoc.getWorld() != world) {
                     continue;

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -564,3 +564,6 @@ permissions:
   essentials.keepinv:
     default: false
     description: Controls whether players keep their inventory on death.
+  essentials.near.exclude:
+    default: false
+    description: If the player should be excluded from near lookups.


### PR DESCRIPTION
Closes #2916. 

Simple addition. LuckPerms 5 seems to support the defaults well too.