### PR TITLE
Fix bug with removing all of an item

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
@@ -124,7 +124,7 @@ public class Commandclearinventory extends EssentialsCommand {
             for (Material mat : mats) {
                 if (amount == -1) // amount -1 means all items will be cleared
                 {
-                    ItemStack stack = new ItemStack(mat, BASE_AMOUNT, data);
+                    ItemStack stack = new ItemStack(mat, BASE_AMOUNT);
                     ItemStack removedStack = player.getInventory().removeItem(stack).get(0);
                     final int removedAmount = (BASE_AMOUNT - removedStack.getAmount());
                     if (removedAmount > 0 || showExtended) {


### PR DESCRIPTION
Fixes #2986. 

It looks like the deprecated ItemStack constructor is the culprit of this bug, which causes removing the items to fail on the next line. Tested the fix on 1.8.8 and 1.15.2, and it looks to be working fine all around.
