### PR TITLE
Fix tab completion for Exp command

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandexp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandexp.java
@@ -179,23 +179,22 @@ public class Commandexp extends EssentialsCommand {
             }
             return options;
         } else if (args.length == 2) {
-            if ((args[0].equalsIgnoreCase("set") && user.isAuthorized("essentials.exp.set")) || (args[0].equalsIgnoreCase("give") && user.isAuthorized("essentials.exp.give"))) {
-                String levellessArg = args[1].toLowerCase(Locale.ENGLISH).replace("l", "");
+            if ((args[0].equalsIgnoreCase("set") && user.isAuthorized("essentials.exp.set")) || (args[0].equalsIgnoreCase("give") && user.isAuthorized("essentials.exp.give")) || (args[0].equalsIgnoreCase("take") && user.isAuthorized("essentials.exp.take"))) {
+                String levellessArg = args[1].toLowerCase(Locale.ENGLISH).replaceAll("l", "");
                 if (NumberUtil.isInt(levellessArg)) {
-                    return Lists.newArrayList(levellessArg, args[1] + "l");
-                } else {
-                    return Collections.emptyList();
+                    return Lists.newArrayList(levellessArg + "l");
                 }
-            } else if (args[0].equalsIgnoreCase("show") && user.isAuthorized("essentials.exp.others")) {
-                return getPlayers(server, user);
-            } else {
-                return Collections.emptyList();
             }
-        } else if (args.length == 3 && (args[0].equalsIgnoreCase("set") && user.isAuthorized("essentials.exp.set.others")) || (args[0].equalsIgnoreCase("give") && user.isAuthorized("essentials.exp.give.others"))) {
-            return getPlayers(server, user);
-        } else {
-            return Collections.emptyList();
+            if (user.isAuthorized("essentials.exp.others")) {
+                return getPlayers(server, user);
+            }
+        } else if (args.length == 3 && !(args[0].equalsIgnoreCase("show") || args[0].equalsIgnoreCase("reset"))) {
+            String levellessArg = args[2].toLowerCase(Locale.ENGLISH).replaceAll("l", "");
+            if (NumberUtil.isInt(levellessArg)) {
+                return Lists.newArrayList(levellessArg + "l");
+            }
         }
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
Fixes #3000.

So, the tab completions for the exp command were really wacky in how they worked. Not sure if it was a bug or just poorly designed. I changed it up a bit so that it is slightly more sane, although I didn't rewrite it from the ground up.

Notable changes:
- It correctly suggests completing either player or level now as appropriate.
- When completing level, it will not infinitely ask you to add "l" to the end, and will stop tab completing if you added an "l".
- Tab completing levels now correctly works with the "take" sub command.
- Removed the unnecessary check for "show" when completing for players, because literally every command can take a player as the second argument.
- Many unnecessary branches were removed, which slightly cleaned up the code.

I tested the following tab completions and they all worked after the changes:
```
/xp <TAB>
/xp give <TAB>
/xp give 1<TAB>
/xp give <player> 1<TAB>
/xp reset <TAB>
/xp set <TAB>
/xp set 1<TAB>
/xp set <player> 1<TAB>
/xp show <TAB>
/xp take <TAB>
/xp take 1<TAB>
/xp take <player> 1<TAB>
```
