### PR TITLE
Fix zh-CN GeoIP locale issue

### DIFF
--- a/EssentialsGeoIP/src/com/earth2me/essentials/geoip/EssentialsGeoIPPlayerListener.java
+++ b/EssentialsGeoIP/src/com/earth2me/essentials/geoip/EssentialsGeoIPPlayerListener.java
@@ -155,6 +155,10 @@ public class EssentialsGeoIPPlayerListener implements Listener, IConf {
             if (config.getBoolean("enable-locale")) {
                 // Get geolocation based on Essentials' locale. If the locale is not avaliable, use "en".
                 String locale = ess.getI18n().getCurrentLocale().toString().replace('_', '-');
+                // This fixes an inconsistency where Essentials uses "zh" but MaxMind expects "zh-CN".
+                if ("zh".equalsIgnoreCase(locale)) {
+                    locale = "zh-CN";
+                }
                 mmreader = new DatabaseReader.Builder(databaseFile).locales(Arrays.asList(locale,"en")).build();
             } else {
                 mmreader = new DatabaseReader.Builder(databaseFile).build();


### PR DESCRIPTION
Closes #3036.

This is one proposed fix, which is to simply check for the zh locale from Essentials when building the database reader. There is no other locale in Essentials that has a mismatch with what MaxMind expects, except for this one, so it should work fine.

The other possible fix would be to rename the messages_zh.properties file to messages_zh_CN.properties, but this would break existing config for those users.