### PR TITLE
Fixes #3039 - unlimited arrow spawning through /fireball

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -808,7 +808,7 @@ public class EssentialsPlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW)
     public void onPlayerPickupFireball(final PlayerPickupArrowEvent event) {
-        if (event.getArrow().getCustomName().equals("Fireball Arrow")) {
+        if (event.getArrow().hasMetadata("Essentials Projectile Arrow")) {
             event.setCancelled(true);
         }
     }

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -808,7 +808,7 @@ public class EssentialsPlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW)
     public void onPlayerPickupFireball(final PlayerPickupArrowEvent event) {
-        if (event.getArrow().hasMetadata("Essentials Projectile Arrow")) {
+        if (event.getArrow().hasMetadata("Ess_Fireball_Projectile")) {
             event.setCancelled(true);
         }
     }

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -806,6 +806,13 @@ public class EssentialsPlayerListener implements Listener {
         user.updateActivityOnInteract(true);
     }
 
+    @EventHandler
+    public void onPlayerPickupFireball(final PlayerPickupArrowEvent event) {
+        if (event.getArrow().getCustomName().equals("Fireball Arrow")) {
+            event.setCancelled(true);
+        }
+    }
+
     private final class PickupListenerPre1_12 implements Listener {
         @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
         public void onPlayerPickupItem(final org.bukkit.event.player.PlayerPickupItemEvent event) {

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -806,7 +806,7 @@ public class EssentialsPlayerListener implements Listener {
         user.updateActivityOnInteract(true);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOW)
     public void onPlayerPickupFireball(final PlayerPickupArrowEvent event) {
         if (event.getArrow().getCustomName().equals("Fireball Arrow")) {
             event.setCancelled(true);

--- a/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
@@ -77,7 +77,7 @@ public class Commandfireball extends EssentialsCommand {
         projectile.setShooter(user.getBase());
         projectile.setVelocity(direction);
         projectile.setCustomName("Fireball Arrow");
-        projectile.setMetadata("Essentials Projectile Arrow", new FixedMetadataValue(ess, true));
+        projectile.setMetadata("Ess_Fireball_Projectile", new FixedMetadataValue(ess, true));
         projectile.setCustomNameVisible(false);
 
         if (ride) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
@@ -16,7 +16,6 @@ import static com.earth2me.essentials.I18n.tl;
 
 public class Commandfireball extends EssentialsCommand {
     private static final Map<String, Class<? extends Projectile>> types;
-    private List<UUID> disabled = new ArrayList<>();
 
     static {
         ImmutableMap.Builder<String, Class<? extends Projectile>> builder = ImmutableMap.<String, Class<? extends Projectile>>builder()

--- a/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.bukkit.Server;
 import org.bukkit.entity.*;
+import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.util.Vector;
 
 import java.util.*;
@@ -76,6 +77,7 @@ public class Commandfireball extends EssentialsCommand {
         projectile.setShooter(user.getBase());
         projectile.setVelocity(direction);
         projectile.setCustomName("Fireball Arrow");
+        projectile.setMetadata("Essentials Projectile Arrow", new FixedMetadataValue(ess, true));
         projectile.setCustomNameVisible(false);
 
         if (ride) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
@@ -76,9 +76,7 @@ public class Commandfireball extends EssentialsCommand {
         Projectile projectile = user.getWorld().spawn(user.getBase().getEyeLocation().add(direction.getX(), direction.getY(), direction.getZ()), types.get(type));
         projectile.setShooter(user.getBase());
         projectile.setVelocity(direction);
-        projectile.setCustomName("Fireball Arrow");
         projectile.setMetadata("Ess_Fireball_Projectile", new FixedMetadataValue(ess, true));
-        projectile.setCustomNameVisible(false);
 
         if (ride) {
             projectile.addPassenger(user.getBase());

--- a/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandfireball.java
@@ -9,15 +9,14 @@ import org.bukkit.Server;
 import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.earth2me.essentials.I18n.tl;
 
 public class Commandfireball extends EssentialsCommand {
     private static final Map<String, Class<? extends Projectile>> types;
+    private List<UUID> disabled = new ArrayList<>();
 
     static {
         ImmutableMap.Builder<String, Class<? extends Projectile>> builder = ImmutableMap.<String, Class<? extends Projectile>>builder()
@@ -77,6 +76,8 @@ public class Commandfireball extends EssentialsCommand {
         Projectile projectile = user.getWorld().spawn(user.getBase().getEyeLocation().add(direction.getX(), direction.getY(), direction.getZ()), types.get(type));
         projectile.setShooter(user.getBase());
         projectile.setVelocity(direction);
+        projectile.setCustomName("Fireball Arrow");
+        projectile.setCustomNameVisible(false);
 
         if (ride) {
             projectile.addPassenger(user.getBase());

--- a/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java
+++ b/Essentials/src/com/earth2me/essentials/craftbukkit/FakeWorld.java
@@ -604,6 +604,26 @@ public class FakeWorld implements World {
     }
 
     @Override
+    public long getTicksPerWaterSpawns() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void setTicksPerWaterSpawns(int i) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public long getTicksPerAmbientSpawns() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void setTicksPerAmbientSpawns(int i) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
     public <T extends Entity> Collection<T> getEntitiesByClass(Class<T> type) {
         throw new UnsupportedOperationException("Not supported yet.");
     }

--- a/Essentials/test/com/earth2me/essentials/FakeServer.java
+++ b/Essentials/test/com/earth2me/essentials/FakeServer.java
@@ -798,6 +798,16 @@ public class FakeServer implements Server {
     }
 
     @Override
+    public int getTicksPerWaterSpawns() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public int getTicksPerAmbientSpawns() {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
     public List<Recipe> getRecipesFor(ItemStack is) {
         throw new UnsupportedOperationException("Not supported yet.");
     }


### PR DESCRIPTION
This PR introduces a simple fix to https://github.com/EssentialsX/Essentials/issues/3039 by setting a non-visible custom name for any projectile launched by the `/fireball` command. In an "arrow" pickup listener (this applies to tridents and etcetera), the arrow's name is checked and if it matches the custom name, the event is cancelled.

[Before Changes](https://i.imgur.com/8T9ss7a.gifv)
[After Changes](https://i.imgur.com/j1Uid7a.gifv)