### PR TITLE
Add passenger dismounting for teleports

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -119,6 +119,8 @@ public interface ISettings extends IConf {
 
     boolean isForceDisableTeleportSafety();
 
+    boolean isTeleportPassengerDismount();
+
     double getTeleportCooldown();
 
     double getTeleportDelay();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -158,6 +158,11 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     @Override
+    public boolean isTeleportPassengerDismount() {
+        return config.getBoolean("teleport-passenger-dismount", true);
+    }
+
+    @Override
     public double getTeleportDelay() {
         return config.getDouble("teleport-delay", 0);
     }

--- a/Essentials/src/com/earth2me/essentials/Teleport.java
+++ b/Essentials/src/com/earth2me/essentials/Teleport.java
@@ -10,6 +10,7 @@ import net.ess3.api.events.UserWarpEvent;
 import net.ess3.api.events.UserTeleportEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -130,6 +131,15 @@ public class Teleport implements ITeleport {
         }
 
         teleportee.setLastLocation();
+
+        if (!teleportee.getBase().getPassengers().isEmpty()) {
+            if (!ess.getSettings().isTeleportPassengerDismount()) {
+                throw new Exception(tl("passengerTeleportFail"));
+            }
+            for (Entity entity : teleportee.getBase().getPassengers()) {
+                entity.leaveVehicle();
+            }
+        }
 
         if (LocationUtil.isBlockUnsafeForUser(teleportee, loc.getWorld(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ())) {
             if (ess.getSettings().isTeleportSafetyEnabled()) {

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -78,6 +78,11 @@ teleport-safety: true
 # teleport-safety and this option need to be set to true to force teleportation to dangerous locations.
 force-disable-teleport-safety: false
 
+# If a player has any passengers, the teleport will fail. Should their passengers be dismounted before they are teleported?
+# If this is set to true, Essentials will dismount the player's passengers before teleporting.
+# If this is set to false, attempted teleports will be canceled with a warning.
+teleport-passenger-dismount: true
+
 # The delay, in seconds, required between /home, /tp, etc.
 teleport-cooldown: 0
 

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -381,6 +381,7 @@ openingDisposal=\u00a76Opening disposal menu...
 orderBalances=\u00a76Ordering balances of\u00a7c {0} \u00a76users, please wait...
 oversizedMute=§4You may not mute a player for this period of time.
 oversizedTempban=\u00a74You may not ban a player for this period of time.
+passengerTeleportFail=\u00a74You cannot be teleported while carrying passengers.
 payConfirmToggleOff=\u00a76You will no longer be prompted to confirm payments.
 payConfirmToggleOn=\u00a76You will now be prompted to confirm payments.
 payMustBePositive=\u00a74Amount to pay must be positive.


### PR DESCRIPTION
Adds a `teleport-passenger-dismount` config option (true by default) which will dismount all the player's passengers before teleporting the player. This is needed as a player cannot teleport with a passenger.

Closes #2087