### PR TITLE
Make MockBukkit compatible #3105

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -113,6 +113,11 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     private transient Kits kits;
 
     public Essentials() {
+
+    }
+
+    protected Essentials(JavaPluginLoader loader, PluginDescriptionFile description, File dataFolder, File file) {
+        super(loader, description, dataFolder, file);
     }
 
     public Essentials(final Server server) {


### PR DESCRIPTION
Per #3105, made MockBukkit compatible. This will have no effect for most users, but allows plugin developers with Vault as a testing dependency to use it with MockBukkit.