### PR TITLE
Implemented Server Uptime Placeholder

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -31,6 +31,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.Map.Entry;
@@ -174,7 +175,8 @@ public class EssentialsPlayerListener implements Listener {
             final String msg = ess.getSettings().getCustomQuitMessage()
                     .replace("{PLAYER}", player.getDisplayName())
                     .replace("{USERNAME}", player.getName())
-                    .replace("{ONLINE}", NumberFormat.getInstance().format(ess.getOnlinePlayers().size()));
+                    .replace("{ONLINE}", NumberFormat.getInstance().format(ess.getOnlinePlayers().size()))
+                    .replace("{UPTIME}", DateUtil.formatDateDiff(ManagementFactory.getRuntimeMXBean().getStartTime()));
 
             event.setQuitMessage(msg.isEmpty() ? null : msg);
         }
@@ -279,7 +281,8 @@ public class EssentialsPlayerListener implements Listener {
                     String msg = ess.getSettings().getCustomJoinMessage()
                             .replace("{PLAYER}", player.getDisplayName()).replace("{USERNAME}", player.getName())
                             .replace("{UNIQUE}", NumberFormat.getInstance().format(ess.getUserMap().getUniqueUsers()))
-                            .replace("{ONLINE}", NumberFormat.getInstance().format(ess.getOnlinePlayers().size()));
+                            .replace("{ONLINE}", NumberFormat.getInstance().format(ess.getOnlinePlayers().size()))
+                            .replace("{UPTIME}", DateUtil.formatDateDiff(ManagementFactory.getRuntimeMXBean().getStartTime()));
                     if (!msg.isEmpty()) {
                         ess.getServer().broadcastMessage(msg);
                     }


### PR DESCRIPTION
This PR implements a {UPTIME} placeholder that can be used in the MOTD.

Closes #2069

![image](https://user-images.githubusercontent.com/21014720/78153684-f35cf900-7400-11ea-8b43-f30949c36f34.png)
