### PR TITLE
Add vanished metadata value

### DIFF
--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -792,6 +792,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 }
             }
             setHidden(true);
+            this.getBase().setMetadata("vanished", new FixedMetadataValue(Essentials, true));
             ess.getVanishedPlayersNew().add(getName());
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, false));
@@ -801,6 +802,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 p.showPlayer(getBase());
             }
             setHidden(false);
+            this.getBase().removeMetadata("vanished", Essentials);
             ess.getVanishedPlayersNew().remove(getName());
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().removePotionEffect(PotionEffectType.INVISIBILITY);

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -24,6 +24,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
@@ -792,7 +794,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 }
             }
             setHidden(true);
-            this.getBase().setMetadata("vanished", new FixedMetadataValue(Essentials, true));
+            this.getBase().setMetadata("vanished", new FixedMetadataValue((Plugin)this.ess, true));
             ess.getVanishedPlayersNew().add(getName());
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, false));
@@ -802,7 +804,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 p.showPlayer(getBase());
             }
             setHidden(false);
-            this.getBase().removeMetadata("vanished", Essentials);
+            this.getBase().removeMetadata("vanished", (Plugin)this.ess);
             ess.getVanishedPlayersNew().remove(getName());
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().removePotionEffect(PotionEffectType.INVISIBILITY);

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -25,7 +25,6 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.metadata.FixedMetadataValue;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
@@ -794,7 +793,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 }
             }
             setHidden(true);
-            this.getBase().setMetadata("vanished", new FixedMetadataValue((Plugin)this.ess, true));
+            this.getBase().setMetadata("vanished", new FixedMetadataValue(this.ess, true));
             ess.getVanishedPlayersNew().add(getName());
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, false));
@@ -804,7 +803,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 p.showPlayer(getBase());
             }
             setHidden(false);
-            this.getBase().removeMetadata("vanished", (Plugin)this.ess);
+            this.getBase().removeMetadata("vanished", this.ess);
             ess.getVanishedPlayersNew().remove(getName());
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().removePotionEffect(PotionEffectType.INVISIBILITY);


### PR DESCRIPTION
This will do what asked in Feature Request #3121 

Please check if I called the plugin correctly as it is the only thing im not 100% sure of, if that is right then it works perfectly! 

What Im asking if it is correct is this: FixedMetadataValue(Essentials, true) , the value should be FixedMetadataValue(Plugin, boolean)

Thanks!

Closes #3121