### PR TITLE
Add displayname placeholders to self-AFK messages

### DIFF
--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -615,7 +615,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             if (broadcast && !isHidden()) {
                 setDisplayNick();
                 final String msg = tl("userIsNotAway", getDisplayName());
-                final String selfmsg = tl("userIsNotAwaySelf");
+                final String selfmsg = tl("userIsNotAwaySelf", getDisplayName());
                 if (!msg.isEmpty() && ess.getSettings().broadcastAfkMessage()) {
                     // exclude user from receiving general AFK announcement in favor of personal message
                     ess.broadcastMessage(this, msg, u -> u == this);
@@ -668,7 +668,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             if (!isHidden()) {
                 setDisplayNick();
                 final String msg = tl("userIsAway", getDisplayName());
-                final String selfmsg = tl("userIsAwaySelf");
+                final String selfmsg = tl("userIsAwaySelf", getDisplayName());
                 if (!msg.isEmpty() && ess.getSettings().broadcastAfkMessage()) {
                     // exclude user from receiving general AFK announcement in favor of personal message
                     ess.broadcastMessage(this, msg, u -> u == this);

--- a/Essentials/src/com/earth2me/essentials/commands/Commandafk.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandafk.java
@@ -60,17 +60,17 @@ public class Commandafk extends EssentialsCommand {
         if (!user.toggleAfk(AfkStatusChangeEvent.Cause.COMMAND)) {
             if (!user.isHidden()) {
                 msg = tl("userIsNotAway", user.getDisplayName());
-                selfmsg = tl("userIsNotAwaySelf");
+                selfmsg = tl("userIsNotAwaySelf", user.getDisplayName());
             }
             user.updateActivity(false, AfkStatusChangeEvent.Cause.COMMAND);
         } else {
             if (!user.isHidden()) {
                 if (message != null) {
                     msg = tl("userIsAwayWithMessage", user.getDisplayName(), message);
-                    selfmsg = tl("userIsAwaySelfWithMessage", message);
+                    selfmsg = tl("userIsAwaySelfWithMessage", user.getDisplayName(), message);
                 } else {
                     msg = tl("userIsAway", user.getDisplayName());
-                    selfmsg = tl("userIsAwaySelf");
+                    selfmsg = tl("userIsAwaySelf", user.getDisplayName());
                 }
             }
             user.setAfkMessage(message);


### PR DESCRIPTION
As a result of #2780 (oops) the self-AFK messages can no longer exactly match the regular AFK messages as the placeholder for the player's displayname was left out for the self messages.

This PR adds those placeholders so that those who would prefer that these messages are the same can simply copy their messages from the normal `userIs*Away*` keys to the new `userIs*AwaySelf*` keys.