### PR TITLE
Add legacy mod support for kits

### DIFF
--- a/Essentials/src/com/earth2me/essentials/items/LegacyItemDb.java
+++ b/Essentials/src/com/earth2me/essentials/items/LegacyItemDb.java
@@ -164,12 +164,14 @@ public class LegacyItemDb extends AbstractItemDb {
         }
 
         if (itemid < 1) {
-            throw new Exception(tl("unknownItemName", itemname));
+            Material matFromName = Material.matchMaterial(itemname.toUpperCase());
+            if (matFromName != null) {
+                itemid = matFromName.getId();
+            }
         }
 
-        ItemData data = legacyIds.get(itemid);
-        if (data == null) {
-            throw new Exception(tl("unknownItemId", itemid));
+        if (itemid < 1) {
+            throw new Exception(tl("unknownItemName", itemname));
         }
 
         Material mat = getFromLegacy(itemid, (byte) metaData);


### PR DESCRIPTION
Fixes modded items in kits on Thermos (1.7.10) and Magma (1.12.2) servers.

Basically just added a normal Material.valueOf call as a backup and removed verification that the item is in legacyIds