### PR TITLE
Fix specifying item types and amounts in /clear

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
@@ -1,13 +1,12 @@
 package com.earth2me.essentials.commands;
 
-import static com.earth2me.essentials.I18n.tl;
-
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
+import com.earth2me.essentials.utils.ArrayUtil;
 import com.earth2me.essentials.utils.NumberUtil;
 import com.earth2me.essentials.utils.StringUtil;
-
+import com.earth2me.essentials.utils.VersionUtil;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
@@ -15,20 +14,22 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
 
+import static com.earth2me.essentials.I18n.tl;
+
 
 public class Commandclearinventory extends EssentialsCommand {
+
+    private static final int BASE_AMOUNT = 100000;
+    private static final int EXTENDED_CAP = 8;
 
     public Commandclearinventory() {
         super("clearinventory");
     }
 
-    private static final int BASE_AMOUNT = 100000;
-    private static final int EXTENDED_CAP = 8;
-
     @Override
     public void run(Server server, User user, String commandLabel, String[] args) throws Exception {
         parseCommand(server, user.getSource(), commandLabel, args, user.isAuthorized("essentials.clearinventory.others"),
-            user.isAuthorized("essentials.clearinventory.all") || user.isAuthorized("essentials.clearinventory.multiple"));
+                user.isAuthorized("essentials.clearinventory.all") || user.isAuthorized("essentials.clearinventory.multiple"));
     }
 
     @Override
@@ -37,12 +38,11 @@ public class Commandclearinventory extends EssentialsCommand {
     }
 
     private void parseCommand(Server server, CommandSource sender, String commandLabel, String[] args, boolean allowOthers, boolean allowAll)
-        throws Exception {
-        Collection<Player> players = new ArrayList<Player>();
+            throws Exception {
+        Collection<Player> players = new ArrayList<>();
         User senderUser = ess.getUser(sender.getPlayer());
         String previousClearCommand = "";
-        
-        int offset = 0;
+        String[] handlerArgs = args;
 
         if (sender.isPlayer()) {
             players.add(sender.getPlayer());
@@ -53,10 +53,10 @@ public class Commandclearinventory extends EssentialsCommand {
 
         if (allowAll && args.length > 0 && args[0].contentEquals("*")) {
             sender.sendMessage(tl("inventoryClearingFromAll"));
-            offset = 1;
+            handlerArgs = ArrayUtil.removeFirst(args, 1);
             players = ess.getOnlinePlayers();
         } else if (allowOthers && args.length > 0 && args[0].trim().length() > 2) {
-            offset = 1;
+            handlerArgs = ArrayUtil.removeFirst(args, 1);
             players = server.matchPlayer(args[0].trim());
         }
 
@@ -76,76 +76,101 @@ public class Commandclearinventory extends EssentialsCommand {
         }
 
         for (Player player : players) {
-            clearHandler(sender, player, args, offset, players.size() < EXTENDED_CAP);
+            handleClear(sender, player, handlerArgs, players.size() < EXTENDED_CAP);
         }
     }
 
-    protected void clearHandler(CommandSource sender, Player player, String[] args, int offset, boolean showExtended) throws Exception {
+    private void handleClear(CommandSource sender, Player player, String[] args, boolean showExtended) throws Exception {
+        ClearHandlerType type = ClearHandlerType.ALL_EXCEPT_ARMOR;
+        Material mat = null;
         short data = -1;
-        int type = -1;
         int amount = -1;
-        final Set<Material> mats = new HashSet<>();
 
-        if (args.length > (offset + 1) && NumberUtil.isInt(args[(offset + 1)])) {
-            amount = Integer.parseInt(args[(offset + 1)]);
-        }
-        if (args.length > offset) {
-            if (args[offset].equalsIgnoreCase("**")) {
-                type = -2;
-            } else if (!args[offset].equalsIgnoreCase("*")) {
-                final String[] split = args[offset].split(",");
+        if (args.length > 0) {
+            if (args[0].equalsIgnoreCase("**")) {
+                type = ClearHandlerType.ALL_INCLUDING_ARMOR;
+            } else if (!args[0].equalsIgnoreCase("*")) {
+                final String[] split = args[0].split(":");
+                final ItemStack item = ess.getItemDb().get(split[0]);
+                type = ClearHandlerType.SPECIFIC_ITEM;
+                mat = item.getType();
 
-                for (String name : split) {
-                    try {
-                        mats.add(ess.getItemDb().get(name).getType());
-                    } catch (Exception ignored) {}
+                if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_13_0_R01)) {
+                    if (split.length > 1 && NumberUtil.isInt(split[1])) {
+                        data = Short.parseShort(split[1]);
+                    } else {
+                        data = item.getDurability();
+                    }
                 }
-
-                type = 1;
             }
         }
 
-        if (type == -1) // type -1 represents wildcard or all items
-        {
+        if (type != ClearHandlerType.SPECIFIC_ITEM) {
+            clearAll(sender, player, type, showExtended);
+            return;
+        }
+
+        if (args.length > 1 && NumberUtil.isInt(args[1])) {
+            amount = Integer.parseInt(args[1]);
+        }
+
+        if (data == -1) { // data -1 means that all subtypes will be cleared, or we're on 1.13+
+            if (amount == -1) {
+                ItemStack stack = new ItemStack(mat);
+                if (showExtended) {
+                    sender.sendMessage(tl("inventoryClearingAllStack", stack.getType().toString().toLowerCase(Locale.ENGLISH), player.getDisplayName()));
+                }
+                player.getInventory().remove(mat);
+            } else {
+                if (amount < 0) {
+                    amount = 1;
+                }
+                ItemStack stack = new ItemStack(mat, amount);
+                clearAmount(sender, player, showExtended, amount, stack);
+            }
+        } else { // there's a data value here
+            if (amount == -1) { // amount -1 means all items will be cleared
+                ItemStack stack = new ItemStack(mat, BASE_AMOUNT, data);
+                ItemStack removedStack = player.getInventory().removeItem(stack).get(0);
+                final int removedAmount = (BASE_AMOUNT - removedStack.getAmount());
+                if (removedAmount > 0 || showExtended) {
+                    sender.sendMessage(tl("inventoryClearingStack", removedAmount, stack.getType().toString().toLowerCase(Locale.ENGLISH), player.getDisplayName()));
+                }
+            } else {
+                if (amount < 0) {
+                    amount = 1;
+                }
+                ItemStack stack = new ItemStack(mat, amount, data);
+                clearAmount(sender, player, showExtended, amount, stack);
+            }
+        }
+    }
+
+    private void clearAmount(CommandSource sender, Player player, boolean showExtended, int amount, ItemStack stack) {
+        if (player.getInventory().containsAtLeast(stack, amount)) {
+            sender.sendMessage(tl("inventoryClearingStack", amount, stack.getType().toString().toLowerCase(Locale.ENGLISH), player.getDisplayName()));
+            player.getInventory().removeItem(stack);
+        } else {
+            if (showExtended) {
+                sender.sendMessage(tl("inventoryClearFail", player.getDisplayName(), amount, stack.getType().toString().toLowerCase(Locale.ENGLISH)));
+            }
+        }
+    }
+
+    private void clearAll(CommandSource sender, Player player, ClearHandlerType type, boolean showExtended) {
+        if (type == ClearHandlerType.ALL_EXCEPT_ARMOR) { // wildcard; all items except for armor
             if (showExtended) {
                 sender.sendMessage(tl("inventoryClearingAllItems", player.getDisplayName()));
             }
-            InventoryWorkaround.clearInventoryNoArmor(player.getInventory());
-            InventoryWorkaround.setItemInOffHand(player, null);
-        } else if (type == -2) // type -2 represents double wildcard or all items and armor
-        {
+        } else if (type == ClearHandlerType.ALL_INCLUDING_ARMOR) { // double wildcard; all items including armor
             if (showExtended) {
                 sender.sendMessage(tl("inventoryClearingAllArmor", player.getDisplayName()));
             }
-            InventoryWorkaround.clearInventoryNoArmor(player.getInventory());
-            InventoryWorkaround.setItemInOffHand(player, null);
             player.getInventory().setArmorContents(null);
-        } else {
-            for (Material mat : mats) {
-                if (amount == -1) // amount -1 means all items will be cleared
-                {
-                    ItemStack stack = new ItemStack(mat, BASE_AMOUNT, data);
-                    ItemStack removedStack = player.getInventory().removeItem(stack).get(0);
-                    final int removedAmount = (BASE_AMOUNT - removedStack.getAmount());
-                    if (removedAmount > 0 || showExtended) {
-                        sender.sendMessage(tl("inventoryClearingStack", removedAmount, stack.getType().toString().toLowerCase(Locale.ENGLISH), player.getDisplayName()));
-                    }
-                } else {
-                    if (amount < 0) {
-                        amount = 1;
-                    }
-                    ItemStack stack = new ItemStack(mat, amount);
-                    if (player.getInventory().containsAtLeast(stack, amount)) {
-                        sender.sendMessage(tl("inventoryClearingStack", amount, stack.getType().toString().toLowerCase(Locale.ENGLISH), player.getDisplayName()));
-                        player.getInventory().removeItem(stack);
-                    } else {
-                        if (showExtended) {
-                            sender.sendMessage(tl("inventoryClearFail", player.getDisplayName(), amount, stack.getType().toString().toLowerCase(Locale.ENGLISH)));
-                        }
-                    }
-                }
-            }
         }
+
+        InventoryWorkaround.clearInventoryNoArmor(player.getInventory());
+        InventoryWorkaround.setItemInOffHand(player, null);
     }
 
     @Override
@@ -195,6 +220,12 @@ public class Commandclearinventory extends EssentialsCommand {
     }
 
     private String formatCommand(String commandLabel, String[] args) {
-        return "/" + commandLabel + " " + StringUtil.joinList(" ", (Object[]) args);
+        return "/" + commandLabel + " " + StringUtil.joinList(" ", args);
+    }
+
+    private enum ClearHandlerType {
+        ALL_EXCEPT_ARMOR,
+        ALL_INCLUDING_ARMOR,
+        SPECIFIC_ITEM
     }
 }

--- a/Essentials/src/com/earth2me/essentials/utils/ArrayUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/ArrayUtil.java
@@ -1,0 +1,19 @@
+package com.earth2me.essentials.utils;
+
+import java.util.Arrays;
+
+public class ArrayUtil {
+
+    public static <T> T[] removeFirst(T[] array, int amount) {
+        T[] newArray;
+
+        if (array.length <= amount) {
+            newArray = Arrays.copyOf(array, 0);
+        } else {
+            newArray = Arrays.copyOfRange(array, amount, array.length - 1);
+        }
+
+        return newArray;
+    }
+
+}

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -211,6 +211,7 @@ inventoryClearingAllArmor=\u00a76Cleared all inventory items and armor from {0}\
 inventoryClearingAllItems=\u00a76Cleared all inventory items from\u00a7c {0}\u00a76.
 inventoryClearingFromAll=\u00a76Clearing the inventory of all users...
 inventoryClearingStack=\u00a76Removed\u00a7c {0} \u00a76of\u00a7c {1} \u00a76from\u00a7c {2}\u00a76.
+inventoryClearingAllStack=\u00a76Removed all of\u00a7c {0} \u00a76from\u00a7c {1}\u00a76.
 is=is
 isIpBanned=\u00a76IP \u00a7c{0} \u00a76is banned.
 internalError=\u00a7cAn internal error occurred while attempting to perform this command.


### PR DESCRIPTION
This fixes clearing specific item types with /clear, which was broken on all versions by 79bc34047b86461e752491d08ee8a38a5c07d9dd (whose intended functionality never worked anyway).

The code has also been cleaned up a bit and you can now specify amounts to clear regardless of whether there's a data value or not.

Closes #3050 (which only restores full functionality on 1.13+) and fixes #2986. Any help testing on 1.8.8-1.12.2 and on 1.13+ would be appreciated.