### PR TITLE
Fix home tab completions

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
@@ -104,29 +104,31 @@ public class Commandhome extends EssentialsCommand {
     @Override
     protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
         boolean canVisitOthers = user.isAuthorized("essentials.home.others");
-
+        boolean canVisitBed = user.isAuthorized("essentials.home.bed");
         if (args.length == 1) {
+            List<String> homes = user.getHomes();
+            if (canVisitBed) {
+                homes.add("bed");
+            }
             if (canVisitOthers) {
-                return getPlayers(server, user);
-            } else {
-                List<String> homes = user.getHomes();
-                if (user.isAuthorized("essentials.home.bed")) {
-                    homes.add("bed");
+                int sepIndex = args[0].indexOf(':');
+                if (sepIndex < 0) {
+                    getPlayers(server, user).forEach(player -> homes.add(player + ":"));
+                } else {
+                    String namePart = args[0].substring(0, sepIndex);
+                    User otherUser;
+                    try {
+                        otherUser = getPlayer(server, new String[]{namePart}, 0, true, true);
+                    } catch (Exception ex) {
+                        return homes;
+                    }
+                    otherUser.getHomes().forEach(home -> homes.add(namePart + ":" + home));
+                    if (canVisitBed) {
+                        homes.add(namePart + ":bed");
+                    }
                 }
-                return homes;
             }
-        } else if (args.length == 2 && canVisitOthers) {
-            try {
-                User otherUser = getPlayer(server, args, 0, true, true);
-                List<String> homes = otherUser.getHomes();
-                if (user.isAuthorized("essentials.home.bed")) {
-                    homes.add("bed");
-                }
-                return homes;
-            } catch (Exception ex) {
-                // No such user
-                return Collections.emptyList();
-            }
+            return homes;
         } else {
             return Collections.emptyList();
         }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandsethome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandsethome.java
@@ -1,11 +1,14 @@
 package com.earth2me.essentials.commands;
 
+import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.LocationUtil;
 import com.earth2me.essentials.utils.NumberUtil;
 import org.bukkit.Location;
 import org.bukkit.Server;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import static com.earth2me.essentials.I18n.tl;
@@ -69,5 +72,10 @@ public class Commandsethome extends EssentialsCommand {
             return limit == 1;
         }
         return false;
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
Fixes #1337 😎 

This PR fixes tab completions for all of the home commands in Essentials. Prior to this PR, the behavior is approximately as follows:

- `/sethome` has no implementation for completions, and so it provides player names, which isn't very useful, and in my opinion can cause more harm than good by confusing users.
- `/home` and `/delhome` fail to provide valid completions when a user has the `essentials.home.others` permission. The argument syntax is `[player:]<name>` but it tries to complete it as `<player> <name>`. Not only does it not show you suggestions for your own homes, but it proceeds to show you invalid suggestions!

This PR provides completions that accurately reflect the syntax and real behavior of the command, including suggesting homes for player names that are partially matched. It will provide suggestions for all of your own homes, as well as providing suggestions based on how far along you are in the command (players if you haven't specified `:` yet, otherwise a specific player's homes).

Below are some tests to show the new suggestions working.

User without the `others` and `bed` permissions:

![image](https://user-images.githubusercontent.com/17698576/80548045-b7b93e80-896e-11ea-992c-77605556be92.png)
![image](https://user-images.githubusercontent.com/17698576/80548047-bbe55c00-896e-11ea-85d4-1af1b371c0a5.png)
![image](https://user-images.githubusercontent.com/17698576/80548054-c0117980-896e-11ea-900e-518700eb5e9b.png)

User with both mentioned permissions:

![image](https://user-images.githubusercontent.com/17698576/80548072-d15a8600-896e-11ea-919c-dbd804cac59a.png)
![image](https://user-images.githubusercontent.com/17698576/80548084-dcadb180-896e-11ea-8c6d-2a339d0cb159.png)
![image](https://user-images.githubusercontent.com/17698576/80548086-dfa8a200-896e-11ea-89c9-91e76d7fd6a6.png)
![image](https://user-images.githubusercontent.com/17698576/80548090-e2a39280-896e-11ea-8903-5665d12e8beb.png)
![image](https://user-images.githubusercontent.com/17698576/80548096-e59e8300-896e-11ea-991a-d8525933e2e7.png)
![image](https://user-images.githubusercontent.com/17698576/80548103-e8997380-896e-11ea-9fae-4d5f89912743.png)
