### PR TITLE
Convert ignore list storage to UUID-based

### DIFF
--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -486,8 +486,13 @@ public abstract class UserData extends PlayerExtension implements IConf {
     public void setIgnoredPlayers(List<String> players) {
         List<UUID> uuids = new ArrayList<>();
         for (String player : players) {
-            uuids.add(ess.getOfflineUser(player).getBase().getUniqueId());
+            User user = ess.getOfflineUser(player);
+            if (user == null) {
+                return;
+            }
+            uuids.add(user.getBase().getUniqueId());
         }
+        setIgnoredPlayerUUIDs(uuids);
     }
 
     public void setIgnoredPlayerUUIDs(List<UUID> players) {

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -496,26 +496,17 @@ public abstract class UserData extends PlayerExtension implements IConf {
         return isIgnoredPlayer(user);
     }
 
-    public boolean deleteIgnoredLegacy(String name) {
-        return ignoredPlayers.remove(name.toLowerCase(Locale.ENGLISH));
-    }
-
     public boolean isIgnoredPlayer(IUser user) {
-        return (ignoredPlayers.contains(user.getBase().getUniqueId().toString()) || ignoredPlayers.contains(user.getName().toLowerCase(Locale.ENGLISH))) && !user.isIgnoreExempt();
+        return ignoredPlayers.contains(user.getBase().getUniqueId().toString()) && !user.isIgnoreExempt();
     }
 
     public void setIgnoredPlayer(IUser user, boolean set) {
-        String name = user.getName().toLowerCase(Locale.ENGLISH);
         String uuid = user.getBase().getUniqueId().toString();
         if (set) {
-            if (ignoredPlayers.contains(name)) { // Convert legacy name -> uuid
-                ignoredPlayers.remove(name);
-                ignoredPlayers.add(uuid);
-            } else if (!ignoredPlayers.contains(uuid)) {
+            if (!ignoredPlayers.contains(uuid)) {
                 ignoredPlayers.add(uuid);
             }
         } else {
-            ignoredPlayers.remove(name);
             ignoredPlayers.remove(uuid);
         }
         setIgnoredPlayers(ignoredPlayers);

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -496,16 +496,27 @@ public abstract class UserData extends PlayerExtension implements IConf {
         return isIgnoredPlayer(user);
     }
 
+    public boolean deleteIgnoredLegacy(String name) {
+        return ignoredPlayers.remove(name.toLowerCase(Locale.ENGLISH));
+    }
+
     public boolean isIgnoredPlayer(IUser user) {
-        return (ignoredPlayers.contains(user.getName().toLowerCase(Locale.ENGLISH)) && !user.isIgnoreExempt());
+        return (ignoredPlayers.contains(user.getBase().getUniqueId().toString()) || ignoredPlayers.contains(user.getName().toLowerCase(Locale.ENGLISH))) && !user.isIgnoreExempt();
     }
 
     public void setIgnoredPlayer(IUser user, boolean set) {
-        final String entry = user.getName().toLowerCase(Locale.ENGLISH);
+        String name = user.getName().toLowerCase(Locale.ENGLISH);
+        String uuid = user.getBase().getUniqueId().toString();
         if (set) {
-            if (!ignoredPlayers.contains(entry)) ignoredPlayers.add(entry);
+            if (ignoredPlayers.contains(name)) { // Convert legacy name -> uuid
+                ignoredPlayers.remove(name);
+                ignoredPlayers.add(uuid);
+            } else if (!ignoredPlayers.contains(uuid)) {
+                ignoredPlayers.add(uuid);
+            }
         } else {
-            ignoredPlayers.remove(entry);
+            ignoredPlayers.remove(name);
+            ignoredPlayers.remove(uuid);
         }
         setIgnoredPlayers(ignoredPlayers);
     }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandignore.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandignore.java
@@ -5,6 +5,7 @@ import org.bukkit.Server;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -18,8 +19,8 @@ public class Commandignore extends EssentialsCommand {
     protected void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
         if (args.length < 1) {
             StringBuilder sb = new StringBuilder();
-            for (String s : user._getIgnoredPlayers()) {
-                sb.append(s).append(" ");
+            for (UUID uuid : user._getIgnoredPlayers()) {
+                sb.append(ess.getUser(uuid).getName()).append(" ");
             }
             String ignoredList = sb.toString().trim();
             user.sendMessage(ignoredList.length() > 0 ? tl("ignoredList", ignoredList) : tl("noIgnored"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandignore.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandignore.java
@@ -31,6 +31,12 @@ public class Commandignore extends EssentialsCommand {
                 player = ess.getOfflineUser(args[0]);
             }
             if (player == null) {
+                //Needed for edge cases where a username was ignored and they changed their name.
+                //Will no longer occur for newly ignored players due to the new uuid based system.
+                if (user.deleteIgnoredLegacy(args[0])) {
+                    user.sendMessage(tl("unignorePlayer", args[0]));
+                    return;
+                }
                 throw new PlayerNotFoundException();
             }
             if (player.isIgnoreExempt()) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandignore.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandignore.java
@@ -31,12 +31,6 @@ public class Commandignore extends EssentialsCommand {
                 player = ess.getOfflineUser(args[0]);
             }
             if (player == null) {
-                //Needed for edge cases where a username was ignored and they changed their name.
-                //Will no longer occur for newly ignored players due to the new uuid based system.
-                if (user.deleteIgnoredLegacy(args[0])) {
-                    user.sendMessage(tl("unignorePlayer", args[0]));
-                    return;
-                }
                 throw new PlayerNotFoundException();
             }
             if (player.isIgnoreExempt()) {


### PR DESCRIPTION
As the title describes, this PR converts the ignore list storage from username-based to UUID-based. 

The reason I went against using `EssentialsUpgrade` to convert all names to UUIDS in the on startup incase the ignore list contains a username of a player who changed their name. So my solution keeps the logic in once class.

Fixes #239 