### PR TITLE
fix: prevent mob spawner item duplication by cloning ItemStack

### DIFF
--- a/nms/UpdatedMetaProvider/src/net/ess3/nms/updatedmeta/BlockMetaSpawnerProvider.java
+++ b/nms/UpdatedMetaProvider/src/net/ess3/nms/updatedmeta/BlockMetaSpawnerProvider.java
@@ -20,7 +20,8 @@ public class BlockMetaSpawnerProvider extends SpawnerProvider {
 
     @Override
     public EntityType getEntityType(ItemStack is) {
-        BlockStateMeta bsm = (BlockStateMeta) is.getItemMeta();
+        ItemStack clonedItemStack = is.clone();
+        BlockStateMeta bsm = (BlockStateMeta) clonedItemStack.getItemMeta();
         CreatureSpawner bs = (CreatureSpawner) bsm.getBlockState();
         return bs.getSpawnedType();
     }


### PR DESCRIPTION
I've received reports about duplicated items when placing a mob spawner (https://github.com/timbru31/SilkSpawners/issues/226, https://www.youtube.com/watch?v=Jq6xWKr3UHQ&feature=emb_title) results in duplicated items.

This seems **not** connected to SilkSpawners but rather having an empty listener already produces the problem:

```java
    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
    public void onBlockPlace(BlockPlaceEvent event) {
    }
```

I'm not 100% sure if this is Vanilla MC or Bukkit bug where calling `.getItemMeta()` or `getBlockState()` inside the event causes this behavior, but a simply `.clone()` call prevents the issue.