### PR TITLE
Don't show hidden players in /balance unless exact name entered

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandbalance.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbalance.java
@@ -23,7 +23,7 @@ public class Commandbalance extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
 
-        User target = getPlayer(server, args, 0, true, true);
+        User target = getPlayer(server, args, 0, false, true);
         sender.sendMessage(tl("balanceOther", target.isHidden() ? target.getName() : target.getDisplayName(), NumberUtil.displayCurrency(target.getMoney(), ess)));
     }
 

--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -124,6 +124,10 @@ public abstract class EssentialsCommand implements IEssentialsCommand {
 
             if (getHidden || canInteractWith(sourceUser, user)) {
                 return user;
+            } else { // not looking for hidden and cannot interact (i.e is hidden)
+                if (getOffline && user.getName().equalsIgnoreCase(searchTerm)) { // if looking for offline and got an exact match
+                    return user;
+                }
             }
             throw new PlayerNotFoundException();
         }


### PR DESCRIPTION
Fixes #2305

Not looking for hidden players within the command, yet looking for offline players.
Only matching a hidden player if the name match was exact (i.e not matching nicknames).