### PR TITLE
Fix null check in Username->UUID ignore list converter

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsUpgrade.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsUpgrade.java
@@ -65,9 +65,9 @@ public class EssentialsUpgrade {
                         if (name == null) {
                             continue;
                         }
-                        OfflinePlayer user = ((OfflinePlayer) ess.getOfflineUser(name).getBase());
-                        if (user != null) {
-                            migratedIgnores.add(user.getUniqueId().toString());
+                        User user = ess.getOfflineUser(name);
+                        if (user != null && user.getBase() != null) {
+                            migratedIgnores.add(user.getBase().getUniqueId().toString());
                         }
                     }
                     config.removeProperty("ignore");


### PR DESCRIPTION
Didn't test with a username that didn't exist and didn't notice this. Null check(s) are now in their proper place.