### PR TITLE
Add a more helpful error message for xmpp module

### DIFF
--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -653,3 +653,4 @@ year=year
 years=years
 youAreHealed=\u00a76You have been healed.
 youHaveNewMail=\u00a76You have\u00a7c {0} \u00a76messages\! Type \u00a7c/mail read\u00a76 to view your mail.
+xmppNotConfigured=XMPP is not configured properly. If you do not know what XMPP is, you may wish to remove the EssentialsXXMPP plugin from your server.

--- a/EssentialsXMPP/src/com/earth2me/essentials/xmpp/XMPPManager.java
+++ b/EssentialsXMPP/src/com/earth2me/essentials/xmpp/XMPPManager.java
@@ -16,6 +16,8 @@ import java.io.File;
 import java.util.*;
 import java.util.logging.*;
 
+import static com.earth2me.essentials.I18n.tl;
+
 
 public class XMPPManager extends Handler implements MessageListener, ChatManagerListener, IConf {
     private static final Logger logger = Logger.getLogger("EssentialsXMPP");
@@ -86,7 +88,7 @@ public class XMPPManager extends Handler implements MessageListener, ChatManager
     private boolean connect() {
         final String server = config.getString("xmpp.server");
         if (server == null || server.equals("example.com")) {
-            logger.log(Level.WARNING, "config broken for xmpp");
+            logger.log(Level.WARNING, tl("xmppNotConfigured"));
             return false;
         }
         final int port = config.getInt("xmpp.port", 5222);
@@ -128,10 +130,14 @@ public class XMPPManager extends Handler implements MessageListener, ChatManager
         if (connection != null) {
             connection.disconnect(new Presence(Presence.Type.unavailable));
         }
-
     }
 
     final void updatePresence() {
+        if (connection == null) {
+            parent.getEss().getLogger().warning(tl("xmppNotConfigured"));
+            return;
+        }
+
         final int usercount;
         final StringBuilder stringBuilder = new StringBuilder();
 


### PR DESCRIPTION
Rather than spitting out a stacktrace, this gives users some instructions on what to do.

It's a bit spammy so the error messages get noticed, that could be toned down a bit if we just want to be silent on login. Unfortunately a lot of plugins haven't discovered the `debug` and `trace` log levels, so a lot of startup warnings (like this one) will get lost in the spam if there aren't other issues.

Hopefully this can reduce some of the people coming in for support?