### PR TITLE
[keep-inv] Quick fix for servers who use wildcard perms

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsEntityListener.java
@@ -166,7 +166,8 @@ public class EssentialsEntityListener implements Listener {
     @EventHandler(priority = EventPriority.LOW)
     public void onPlayerDeathInvEvent(final PlayerDeathEvent event) {
         final User user = ess.getUser(event.getEntity());
-        if (user.isAuthorized("essentials.keepinv")) {
+        //Added a configuration boolean to aid those who use wildcard permissions.
+        if (user.isAuthorized("essentials.keepinv") && ess.getSettings().keepInventoryPermission()) {
             event.setKeepInventory(true);
             event.getDrops().clear();
         }

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -356,4 +356,6 @@ public interface ISettings extends IConf {
 
     boolean isSpawnIfNoHome();
 
+    boolean keepInventoryPermission();
+
 }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1679,4 +1679,9 @@ public class Settings implements net.ess3.api.ISettings {
     public boolean isSpawnIfNoHome() {
         return config.getBoolean("spawn-if-no-home", true);
     }
+
+    @Override
+    public boolean keepInventoryPermission() {
+        return config.getBoolean("keep-inventory-permisison", true);
+    }
 }

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -612,6 +612,12 @@ log-command-block-commands: true
 # Set the maximum speed for projectiles spawned with /fireball.
 max-projectile-speed: 8
 
+# Should essentials keep player inventories if they
+# have permissions?
+#
+# Requires the permission: essentials.keepinv
+keep-inventory-permisison: false
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                        Homes                         | #


### PR DESCRIPTION
During work I see a common complaint where users with op or wildcard perms (* / essentials.*) have keep-inv enabled by default without a way to toggle it off.

This PR just makes it an always default off feature, that they can turn on if they want keep-inv perms enabled.

Could make it a /keepinv (player) command similar to /god but not sure if people would like that.