### PR TITLE
Fix clearing specific items in clearinventory

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
@@ -98,17 +98,21 @@ public class Commandclearinventory extends EssentialsCommand {
         }
     }
 
+    private enum ClearHandlerType {
+        ALL_EXCEPT_ARMOR, ALL_INCLUDING_ARMOR, SPECIFIC_ITEM
+    }
+
     protected void clearHandler(CommandSource sender, Player player, String[] args, int offset, boolean showExtended) {
-        int type = -1;
-        int amount = -1;
+        ClearHandlerType type = ClearHandlerType.ALL_EXCEPT_ARMOR;
         final Set<Item> items = new HashSet<>();
+        int amount = -1;
 
         if (args.length > (offset + 1) && NumberUtil.isInt(args[(offset + 1)])) {
             amount = Integer.parseInt(args[(offset + 1)]);
         }
         if (args.length > offset) {
             if (args[offset].equalsIgnoreCase("**")) {
-                type = -2;
+                type = ClearHandlerType.ALL_INCLUDING_ARMOR;
             } else if (!args[offset].equalsIgnoreCase("*")) {
                 final String[] split = args[offset].split(",");
                 for (String item : split) {
@@ -123,18 +127,18 @@ public class Commandclearinventory extends EssentialsCommand {
                         items.add(new Item(ess.getItemDb().get(itemParts[0]).getType(), data));
                     } catch (Exception ignored) {}
                 }
-                type = 1;
+                type = ClearHandlerType.SPECIFIC_ITEM;
             }
         }
 
-        if (type == -1) // type -1 represents wildcard or all items
+        if (type == ClearHandlerType.ALL_EXCEPT_ARMOR) // type -1 represents wildcard or all items
         {
             if (showExtended) {
                 sender.sendMessage(tl("inventoryClearingAllItems", player.getDisplayName()));
             }
             InventoryWorkaround.clearInventoryNoArmor(player.getInventory());
             InventoryWorkaround.setItemInOffHand(player, null);
-        } else if (type == -2) // type -2 represents double wildcard or all items and armor
+        } else if (type == ClearHandlerType.ALL_INCLUDING_ARMOR) // type -2 represents double wildcard or all items and armor
         {
             if (showExtended) {
                 sender.sendMessage(tl("inventoryClearingAllArmor", player.getDisplayName()));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
@@ -131,14 +131,14 @@ public class Commandclearinventory extends EssentialsCommand {
             }
         }
 
-        if (type == ClearHandlerType.ALL_EXCEPT_ARMOR) // type -1 represents wildcard or all items
+        if (type == ClearHandlerType.ALL_EXCEPT_ARMOR)
         {
             if (showExtended) {
                 sender.sendMessage(tl("inventoryClearingAllItems", player.getDisplayName()));
             }
             InventoryWorkaround.clearInventoryNoArmor(player.getInventory());
             InventoryWorkaround.setItemInOffHand(player, null);
-        } else if (type == ClearHandlerType.ALL_INCLUDING_ARMOR) // type -2 represents double wildcard or all items and armor
+        } else if (type == ClearHandlerType.ALL_INCLUDING_ARMOR)
         {
             if (showExtended) {
                 sender.sendMessage(tl("inventoryClearingAllArmor", player.getDisplayName()));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandclearinventory.java
@@ -96,13 +96,16 @@ public class Commandclearinventory extends EssentialsCommand {
                 final String[] split = args[offset].split(",");
                 for (String item : split) {
                     final String[] itemParts = item.split(":");
+                    boolean added = false;
                     try {
-                        mats.add(ess.getItemDb().get(itemParts[0]).getType());
+                        added = mats.add(ess.getItemDb().get(itemParts[0]).getType());
                     } catch (Exception ignored) {}
-                    try {
-                        dats.add(Short.parseShort(itemParts[1]));
-                    } catch (Exception e) {
-                        dats.add((short) 0);
+                    if (added) {
+                        try {
+                            dats.add(Short.parseShort(itemParts[1]));
+                        } catch (Exception e) {
+                            dats.add((short) 0);
+                        }
                     }
                 }
                 type = 1;


### PR DESCRIPTION
Fixes #2986
Closes #3050
Closes #3191

Refactors the clearinventory command code in such a way that fixes the problem of not being able to clear all of a specific item on newer server versions. Also re-adds data value support for older server versions that support it, which seemed to have been inadvertently removed in 79bc34047b86461e752491d08ee8a38a5c07d9dd.

Checked against 1.8.8, 1.12.2, 1.13.2, 1.15.2.