### PR TITLE
Fix improper target block handing in /tree & /bigtree

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandbigtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbigtree.java
@@ -33,9 +33,11 @@ public class Commandbigtree extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
 
-        final Location loc = LocationUtil.getTarget(user.getBase());
-        final Location safeLocation = LocationUtil.getSafeDestination(loc);
-        final boolean success = user.getWorld().generateTree(safeLocation, tree);
+        final Location loc = LocationUtil.getTarget(user.getBase()).add(0, 1, 0);
+        if (!user.getWorld().getBlockAt(loc).isPassable()) {
+            throw new Exception(tl("bigTreeFailure"));
+        }
+        final boolean success = user.getWorld().generateTree(loc, tree);
         if (success) {
             user.sendMessage(tl("bigTreeSuccess"));
         } else {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
@@ -42,9 +42,11 @@ public class Commandtree extends EssentialsCommand {
             }
         }
 
-        final Location loc = LocationUtil.getTarget(user.getBase());
-        final Location safeLocation = LocationUtil.getSafeDestination(loc);
-        final boolean success = user.getWorld().generateTree(safeLocation, tree);
+        final Location loc = LocationUtil.getTarget(user.getBase()).add(0, 1, 0);
+        if (!user.getWorld().getBlockAt(loc).isPassable()) {
+            throw new Exception(tl("treeFailure"));
+        }
+        final boolean success = user.getWorld().generateTree(loc, tree);
         if (success) {
             user.sendMessage(tl("treeSpawned"));
         } else {

--- a/EssentialsAntiBuild/src/com/earth2me/essentials/antibuild/EssentialsAntiBuildListener.java
+++ b/EssentialsAntiBuild/src/com/earth2me/essentials/antibuild/EssentialsAntiBuildListener.java
@@ -1,11 +1,7 @@
 package com.earth2me.essentials.antibuild;
 
-import static com.earth2me.essentials.I18n.tl;
-
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.VersionUtil;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import net.ess3.api.IEssentials;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -16,11 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockDispenseEvent;
-import org.bukkit.event.block.BlockPistonExtendEvent;
-import org.bukkit.event.block.BlockPistonRetractEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.block.*;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
@@ -28,6 +20,11 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.earth2me.essentials.I18n.tl;
 
 
 public class EssentialsAntiBuildListener implements Listener {

--- a/EssentialsAntiBuild/src/com/earth2me/essentials/antibuild/EssentialsAntiBuildListener.java
+++ b/EssentialsAntiBuild/src/com/earth2me/essentials/antibuild/EssentialsAntiBuildListener.java
@@ -1,7 +1,11 @@
 package com.earth2me.essentials.antibuild;
 
+import static com.earth2me.essentials.I18n.tl;
+
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.VersionUtil;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.ess3.api.IEssentials;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -12,7 +16,11 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.*;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockDispenseEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
@@ -20,11 +28,6 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static com.earth2me.essentials.I18n.tl;
 
 
 public class EssentialsAntiBuildListener implements Listener {


### PR DESCRIPTION
Removes `LocationUtil#getSafeDestination`, which isn't made for this use case, and replace it with manual location manipulation and `Block#isPassable`

Fixes #2306 