### PR TITLE
Add permission for storing user's last location on teleportation

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -458,7 +458,7 @@ public class EssentialsPlayerListener implements Listener {
         	}
             final User user = ess.getUser(player);
             //There is TeleportCause.COMMMAND but plugins have to actively pass the cause in on their teleports.
-            if (backListener && (event.getCause() == TeleportCause.PLUGIN || event.getCause() == TeleportCause.COMMAND)) {
+            if (user.isAuthorized("essentials.back.onteleport") && backListener && (event.getCause() == TeleportCause.PLUGIN || event.getCause() == TeleportCause.COMMAND)) {
                 user.setLastLocation();
             }
             if (teleportInvulnerability && (event.getCause() == TeleportCause.PLUGIN || event.getCause() == TeleportCause.COMMAND)) {

--- a/Essentials/src/com/earth2me/essentials/Teleport.java
+++ b/Essentials/src/com/earth2me/essentials/Teleport.java
@@ -129,7 +129,9 @@ public class Teleport implements ITeleport {
             return;
         }
 
-        teleportee.setLastLocation();
+        if (teleportee.isAuthorized("essentials.back.onteleport")) {
+            teleportee.setLastLocation();
+        }
 
         if (!teleportee.getBase().isEmpty()) {
             if (!ess.getSettings().isTeleportPassengerDismount()) {

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -632,6 +632,12 @@ permissions:
   essentials.balancetop.exclude:
     default: false
     description: Players with this permission are excluded from the balancetop
+  essentials.back.onteleport:
+    default: true
+    description: Players with this permission will have back location stored during any teleportation
+  essentials.back.ondeath:
+    default: false
+    description: Players with this permission will have back location stored during death
   essentials.exempt:
     default: false
     description: Parent permission to be exempt from many moderator actions


### PR DESCRIPTION
Adds a `essentials.back.onteleport` permission (defaults to true) which will decide if teleports set the user's last location (their /back location). This allows for only a user's death locations to be stored if the `essentials.back.ondeath` permission granted and the `essentials.back.onteleport` permission is negated.

Closes #1839