### PR TITLE
Add config option to block /pay from ignored users

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -280,6 +280,8 @@ public interface ISettings extends IConf {
 
     BigDecimal getMinimumPayAmount();
 
+    boolean isPayExcludesIgnoreList();
+
     long getLastMessageReplyRecipientTimeout();
 
     boolean isMilkBucketEasterEggEnabled();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1258,6 +1258,11 @@ public class Settings implements net.ess3.api.ISettings {
         return new BigDecimal(config.getString("minimum-pay-amount", "0.001"));
     }
 
+    @Override
+    public boolean isPayExcludesIgnoreList() {
+        return config.getBoolean("pay-excludes-ignore-list", true);
+    }
+
     @Override public long getLastMessageReplyRecipientTimeout() {
         return config.getLong("last-message-reply-recipient-timeout", 180);
     }

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -1260,7 +1260,7 @@ public class Settings implements net.ess3.api.ISettings {
 
     @Override
     public boolean isPayExcludesIgnoreList() {
-        return config.getBoolean("pay-excludes-ignore-list", true);
+        return config.getBoolean("pay-excludes-ignore-list", false);
     }
 
     @Override public long getLastMessageReplyRecipientTimeout() {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpay.java
@@ -59,7 +59,7 @@ public class Commandpay extends EssentialsLoopCommand {
     protected void updatePlayer(final Server server, final CommandSource sender, final User player, final String[] args) throws ChargeException {
         User user = ess.getUser(sender.getPlayer());
         try {
-            if (!player.isAcceptingPay()) {
+            if (!player.isAcceptingPay() || (ess.getSettings().isPayExcludesIgnoreList() && player.isIgnoredPlayer(user))) {
                 sender.sendMessage(tl("notAcceptingPay", player.getDisplayName()));
                 return;
             }

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -702,6 +702,9 @@ economy-log-update-enabled: false
 # Minimum acceptable amount to be used in /pay.
 minimum-pay-amount: 0.001
 
+# When set to true, this will block users who try to /pay another user which ignore them.
+pay-excludes-ignore-list: true
+
 # The format of currency, excluding symbols. See currency-symbol-format-locale for symbol configuration.
 #
 # "#,##0.00" is how the majority of countries display currency.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -702,8 +702,8 @@ economy-log-update-enabled: false
 # Minimum acceptable amount to be used in /pay.
 minimum-pay-amount: 0.001
 
-# When set to true, this will block users who try to /pay another user which ignore them.
-pay-excludes-ignore-list: true
+# Enable this to block users who try to /pay another user which ignore them.
+pay-excludes-ignore-list: false
 
 # The format of currency, excluding symbols. See currency-symbol-format-locale for symbol configuration.
 #


### PR DESCRIPTION
Adds `pay-excludes-ignore-list` config option which when true, will block ignored users from /pay'ing

