### PR TITLE
Remove 1.8 NMS spawner providers from pom

### DIFF
--- a/Essentials/pom.xml
+++ b/Essentials/pom.xml
@@ -74,30 +74,6 @@
         </dependency>
         <dependency>
             <groupId>net.ess3</groupId>
-            <artifactId>1_8_R1Provider</artifactId>
-            <version>2.17.2</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bukkit</groupId>
-                    <artifactId>craftbukkit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>net.ess3</groupId>
-            <artifactId>1_8_R2Provider</artifactId>
-            <version>2.17.2</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bukkit</groupId>
-                    <artifactId>craftbukkit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>net.ess3</groupId>
             <artifactId>LegacyProvider</artifactId>
             <version>2.17.2</version>
             <scope>compile</scope>


### PR DESCRIPTION
This got forgotten, should have been a part of the first PR but I was tired.