### PR TITLE
Display date diff correctly

### DIFF
--- a/Essentials/src/com/earth2me/essentials/utils/DateUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/DateUtil.java
@@ -131,11 +131,11 @@ public class DateUtil {
         if (toDate.equals(fromDate)) {
             return tl("now");
         }
-        // Temporary 50ms time buffer added to avoid display truncation due to code execution delays
-        toDate.add(Calendar.MILLISECOND, 50);
         if (toDate.after(fromDate)) {
             future = true;
         }
+        // Temporary 50ms time buffer added to avoid display truncation due to code execution delays
+        toDate.add(Calendar.MILLISECOND, future ? 50 : -50);
         StringBuilder sb = new StringBuilder();
         int[] types = new int[]{Calendar.YEAR, Calendar.MONTH, Calendar.DAY_OF_MONTH, Calendar.HOUR_OF_DAY, Calendar.MINUTE, Calendar.SECOND};
         String[] names = new String[]{tl("year"), tl("years"), tl("month"), tl("months"), tl("day"), tl("days"), tl("hour"), tl("hours"), tl("minute"), tl("minutes"), tl("second"), tl("seconds")};
@@ -151,7 +151,7 @@ public class DateUtil {
             }
         }
         // Preserve correctness in the original date object by removing the extra buffer time
-        toDate.add(Calendar.MILLISECOND, -50);
+        toDate.add(Calendar.MILLISECOND, future ? -50 : 50);
         if (sb.length() == 0) {
             return tl("now");
         }

--- a/Essentials/src/com/earth2me/essentials/utils/DateUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/DateUtil.java
@@ -131,6 +131,8 @@ public class DateUtil {
         if (toDate.equals(fromDate)) {
             return tl("now");
         }
+        // Temporary 50ms time buffer added to avoid display truncation due to code execution delays
+        toDate.add(Calendar.MILLISECOND, 50);
         if (toDate.after(fromDate)) {
             future = true;
         }
@@ -148,6 +150,8 @@ public class DateUtil {
                 sb.append(" ").append(diff).append(" ").append(names[i * 2 + (diff > 1 ? 1 : 0)]);
             }
         }
+        // Preserve correctness in the original date object by removing the extra buffer time
+        toDate.add(Calendar.MILLISECOND, -50);
         if (sb.length() == 0) {
             return tl("now");
         }


### PR DESCRIPTION
There is an age old issue in Essentials which causes date diffs (such as those displayed in teleportation delays, mutes, and temp bans) to display incorrectly to the user when the command is run. After looking into this a bit, it looks like the reason for this is that if there is even a 1 ms time difference between parsing the date diff and displaying it, the time displayed will be truncated by an entire second. This PR fixes this problem by adding 50 ms of buffer time to the date object *only* when it is calculating the date diff string. This is not significant enough to be noticed by users, and allows Essentials code to correctly generate the date diff string as long as it does so within 50 ms of parsing it.

As a theoretical example... lets say a user is muted for 1 year. If 1 ms passed (in code prior to this PR) between parsing and displaying the date diff, then the displayed time will be 11 months, 29 days, 23 hours. This is because 1 year - 1 ms is being truncated down and then Essentials lops off time accuracy beyond the 3 most significant terms. After this PR, the date diff will be parsed normally, but when the display string is being calculated, it will use 1 year + 50 ms (and if 1 ms passed, then that would be 1 year + 49 ms), which gets truncated to 1 year.

As a practical example:
![image](https://user-images.githubusercontent.com/17698576/82106444-d55c0700-96d5-11ea-8290-377442e4f9fe.png)
Quite often (I'd say about half of the time) before this PR, the date diff will display like this, when the example command `/mute <player> 1y` is run.

![image](https://user-images.githubusercontent.com/17698576/82106467-063c3c00-96d6-11ea-9da2-3dc1556add14.png)
After this PR, the date diff displays correctly every time.

Fixes #3349