### PR TITLE
Block removing hats with curse of binding

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandhat.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhat.java
@@ -2,10 +2,12 @@ package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.InventoryWorkaround;
+import com.earth2me.essentials.utils.VersionUtil;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.Server;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.permissions.Permission;
@@ -55,6 +57,8 @@ public class Commandhat extends EssentialsCommand {
             final ItemStack head = inv.getHelmet();
             if (head == null || head.getType() == Material.AIR) {
                 user.sendMessage(tl("hatEmpty"));
+            } else if (VersionUtil.getServerBukkitVersion().isHigherThan(VersionUtil.v1_9_4_R01) && head.getEnchantments().containsKey(Enchantment.BINDING_CURSE) && !user.isAuthorized("essentials.hat.ignore-binding")) {
+                user.sendMessage(tl("hatCurse"));
             } else {
                 final ItemStack air = new ItemStack(Material.AIR);
                 inv.setHelmet(air);
@@ -71,6 +75,10 @@ public class Commandhat extends EssentialsCommand {
                 if (hand.getType().getMaxDurability() == 0) {
                     final PlayerInventory inv = user.getBase().getInventory();
                     final ItemStack head = inv.getHelmet();
+                    if (VersionUtil.getServerBukkitVersion().isHigherThan(VersionUtil.v1_9_4_R01) && head != null && head.getEnchantments().containsKey(Enchantment.BINDING_CURSE) && !user.isAuthorized("essentials.hat.ignore-binding")) {
+                        user.sendMessage(tl("hatCurse"));
+                        return;
+                    }
                     inv.setHelmet(hand);
                     inv.setItemInHand(head);
                     user.sendMessage(tl("hatPlaced"));

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -163,6 +163,7 @@ godMode=\u00a76God mode\u00a7c {0}\u00a76.
 groupDoesNotExist=\u00a74There''s no one online in this group\!
 groupNumber=\u00a7c{0}\u00a7f online, for the full list\:\u00a7c /{1} {2}
 hatArmor=\u00a74You cannot use this item as a hat\!
+hatCurse=\u00a74You cannot remove a hat with the curse of binding\!
 hatEmpty=\u00a74You are not wearing a hat.
 hatFail=\u00a74You must have something to wear in your hand.
 hatPlaced=\u00a76Enjoy your new hat\!


### PR DESCRIPTION
Makes it so you need the `essentials.hat.ignore-binding` permission to remove armor with the binding enchantment from your /hat
Closes #1638