### PR TITLE
Add UserTeleportHomeEvent

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsConf.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsConf.java
@@ -337,7 +337,11 @@ public class EssentialsConf extends YamlConfiguration {
     }
 
     public Location getLocation(final String path, final Server server) throws InvalidWorldException {
-        return getLocationData(path, server).getLocation();
+        LocationData data = getLocationData(path, server);
+        if (data == null) {
+            return null;
+        }
+        return data.getLocation();
     }
     
     public LocationData getLocationData(final String path, final Server server) {

--- a/Essentials/src/com/earth2me/essentials/EssentialsConf.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsConf.java
@@ -2,6 +2,8 @@ package com.earth2me.essentials;
 
 import com.google.common.io.Files;
 import net.ess3.api.InvalidWorldException;
+import net.ess3.api.LocationData;
+
 import org.bukkit.OfflinePlayer;
 import org.bukkit.*;
 import org.bukkit.configuration.ConfigurationSection;
@@ -335,16 +337,16 @@ public class EssentialsConf extends YamlConfiguration {
     }
 
     public Location getLocation(final String path, final Server server) throws InvalidWorldException {
+        return getLocationData(path, server).getLocation();
+    }
+    
+    public LocationData getLocationData(final String path, final Server server) {
         final String worldString = (path == null ? "" : path + ".") + "world";
         final String worldName = getString(worldString);
         if (worldName == null || worldName.isEmpty()) {
             return null;
         }
-        final World world = server.getWorld(worldName);
-        if (world == null) {
-            throw new InvalidWorldException(worldName);
-        }
-        return new Location(world, getDouble((path == null ? "" : path + ".") + "x", 0), getDouble((path == null ? "" : path + ".") + "y", 0), getDouble((path == null ? "" : path + ".") + "z", 0), (float) getDouble((path == null ? "" : path + ".") + "yaw", 0), (float) getDouble((path == null ? "" : path + ".") + "pitch", 0));
+        return new LocationData(worldName, getDouble((path == null ? "" : path + ".") + "x", 0), getDouble((path == null ? "" : path + ".") + "y", 0), getDouble((path == null ? "" : path + ".") + "z", 0), (float) getDouble((path == null ? "" : path + ".") + "yaw", 0), (float) getDouble((path == null ? "" : path + ".") + "pitch", 0));
     }
 
     public void setProperty(final String path, final Location loc) {

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -5,6 +5,7 @@ import com.earth2me.essentials.utils.StringUtil;
 import com.google.common.collect.ImmutableMap;
 import net.ess3.api.IEssentials;
 import net.ess3.api.InvalidWorldException;
+import net.ess3.api.LocationData;
 import net.ess3.api.MaxMoneyException;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -165,6 +166,11 @@ public abstract class UserData extends PlayerExtension implements IConf {
     public Location getHome(String name) throws Exception {
         String search = getHomeName(name);
         return config.getLocation("homes." + search, this.getBase().getServer());
+    }
+    
+    public LocationData getHomeSafe(String name) throws Exception {
+        String search = getHomeName(name);
+        return config.getLocationData("homes." + search, this.getBase().getServer());
     }
 
     public Location getHome(final Location world) {

--- a/Essentials/src/net/ess3/api/LocationData.java
+++ b/Essentials/src/net/ess3/api/LocationData.java
@@ -1,0 +1,61 @@
+package net.ess3.api;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+
+public class LocationData {
+
+    private String worldName;
+    private double x;
+    private double y;
+    private double z;
+    private float pitch;
+    private float yaw;
+
+    public LocationData(String worldName, double x, double y, double z, float pitch, float yaw) {
+        this.worldName = worldName;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.pitch = pitch;
+        this.yaw = yaw;
+    }
+
+    public String getWorldName() {
+        return worldName;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public double getZ() {
+        return z;
+    }
+
+    public float getPitch() {
+        return pitch;
+    }
+
+    public float getYaw() {
+        return yaw;
+    }
+
+    public boolean exists() {
+        return Bukkit.getWorld(worldName) != null;
+    }
+
+    public Location getLocation() throws InvalidWorldException {
+        World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            throw new InvalidWorldException(worldName);
+        }
+        return new Location(world, x, y, z, yaw, pitch);
+    }
+
+}

--- a/Essentials/src/net/ess3/api/LocationData.java
+++ b/Essentials/src/net/ess3/api/LocationData.java
@@ -10,16 +10,16 @@ public class LocationData {
     private double x;
     private double y;
     private double z;
-    private float pitch;
     private float yaw;
+    private float pitch;
 
-    public LocationData(String worldName, double x, double y, double z, float pitch, float yaw) {
+    public LocationData(String worldName, double x, double y, double z, float yaw, float pitch) {
         this.worldName = worldName;
         this.x = x;
         this.y = y;
         this.z = z;
-        this.pitch = pitch;
         this.yaw = yaw;
+        this.pitch = pitch;
     }
 
     public String getWorldName() {
@@ -38,12 +38,12 @@ public class LocationData {
         return z;
     }
 
-    public float getPitch() {
-        return pitch;
-    }
-
     public float getYaw() {
         return yaw;
+    }
+    
+    public float getPitch() {
+        return pitch;
     }
 
     public boolean exists() {

--- a/Essentials/src/net/ess3/api/events/UserTeleportHomeEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserTeleportHomeEvent.java
@@ -1,0 +1,54 @@
+package net.ess3.api.events;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import net.ess3.api.IUser;
+import net.ess3.api.LocationData;
+
+/**
+ * Called when the player tries to teleport to their home before the
+ * location/world is resolved
+ */
+public class UserTeleportHomeEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private IUser user;
+    private LocationData target;
+    private boolean cancelled;
+
+    public UserTeleportHomeEvent(IUser user, LocationData target) {
+        this.user = user;
+        this.target = target;
+    }
+
+    public IUser getUser() {
+        return user;
+    }
+
+    public LocationData getLocationData() {
+        return target;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+}


### PR DESCRIPTION
This PR adds an event that gets called when a player teleports to their home but before the world is resolved (which immediately throws an InvalidWorldException if the world isn't current loaded).

This allows servers to intercept home teleports and load worlds that may be unloaded when a player tries to teleport to them