### PR TITLE
Option to disable Player IP Addresses shown in plain text..

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -259,7 +259,9 @@ public interface ISettings extends IConf {
     boolean ignoreColorsInMaxLength();
 
     boolean hideDisplayNameInVanish();
-
+    
+    boolean storeIPAddressPlainText();
+    
     int getMaxUserCacheCount();
 
     boolean allowSilentJoinQuit();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -817,7 +817,11 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     private boolean changeDisplayName = true;
-
+    
+    public boolean storeIPAddressPlainText() {
+        return config.getBoolean("store-users-ip-address", true);
+    }
+    
     private boolean _changeDisplayName() {
         return config.getBoolean("change-displayname", true);
     }

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -704,9 +704,15 @@ public abstract class UserData extends PlayerExtension implements IConf {
         }
     }
 
+    // Gives the user an option to store the Player's ip
+    // address in the Player's UUID file
     private void _setLastLoginAddress(String address) {
         lastLoginAddress = address;
-        config.setProperty("ipAddress", address);
+        if (ess.getSettings().storeIPAddressPlainText()) {
+            config.setProperty("ipAddress", address);
+        } else {
+        	config.setProperty("ipAddress", "hidden");
+        }
     }
 
     private boolean afk;

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -658,12 +658,7 @@ public abstract class UserData extends PlayerExtension implements IConf {
     public long getLastLogin() {
         return lastLogin;
     }
-
-    private void _setLastLogin(long time) {
-        lastLogin = time;
-        config.setProperty("timestamps.login", time);
-    }
-
+    
     public void setLastLogin(long time) {
         _setLastLogin(time);
         if (base.getAddress() != null && base.getAddress().getAddress() != null) {

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -697,6 +697,17 @@ public abstract class UserData extends PlayerExtension implements IConf {
     public String getLastLoginAddress() {
         return lastLoginAddress;
     }
+    
+    // Gives the user an option to store the Player's ip
+    // address in the Player's UUID file
+    private void _setLastLoginAddress(String address) {
+        lastLoginAddress = address;
+        if (ess.getSettings().storeIPAddressPlainText()) {
+            config.setProperty("ipAddress", address);
+        } else {
+        	config.setProperty("ipAddress", "hidden");
+        }
+    }
 
     private void _setLastLoginAddress(String address) {
         lastLoginAddress = address;

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -410,6 +410,9 @@ debug: false
 # Turn off god mode when people leave the server.
 remove-god-on-disconnect: false
 
+# Turn this to false if you wish to not store the user IP address within the UserData UUID files.
+store-users-ip-address: true
+
 # Auto-AFK
 # After this timeout in seconds, the user will be set as AFK.
 # This feature requires the player to have essentials.afk.auto node.


### PR DESCRIPTION
Added an option in the config file to not store the users IP Addresses within the UserData/UUID.yml file. I believe this is a risk to security, and if say players were to get DDoSed by someone due to a leak of IP Addresses, the server owner can be personally Liable. 

Although, that is the extreme, it can still reduce the itergrity of a server running this if word got out there was a leak, or even there is an extremely easy way to get a list of player IP Addresses.