### PR TITLE
Option to not store IP Addresses in plain text

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -262,7 +262,7 @@ public interface ISettings extends IConf {
 
     int getMaxUserCacheCount();
     
-    boolean storeIPAddressPlainText();
+    boolean storeUserIPAddress();
     
     boolean allowSilentJoinQuit();
 

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -261,7 +261,9 @@ public interface ISettings extends IConf {
     boolean hideDisplayNameInVanish();
 
     int getMaxUserCacheCount();
-
+    
+    boolean storeIPAddressPlainText();
+    
     boolean allowSilentJoinQuit();
 
     boolean isCustomJoinMessage();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -828,7 +828,7 @@ public class Settings implements net.ess3.api.ISettings {
     }
     
     public boolean storeIPAddressPlainText() {
-        return config.getBoolean("store-users-ip-address", true);
+        return config.getBoolean("store-ip-address", true);
     }
     
     private boolean changePlayerListName = false;

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -815,7 +815,11 @@ public class Settings implements net.ess3.api.ISettings {
     public boolean removeGodOnDisconnect() {
         return config.getBoolean("remove-god-on-disconnect", false);
     }
-
+    
+    public boolean isstoreIPAddressPlainText() {
+        return config.getBoolean("store-users-ip-address", true);
+    }
+    
     private boolean changeDisplayName = true;
 
     private boolean _changeDisplayName() {
@@ -826,7 +830,11 @@ public class Settings implements net.ess3.api.ISettings {
     public boolean changeDisplayName() {
         return changeDisplayName;
     }
-
+    
+    public boolean storeIPAddressPlainText() {
+        return config.getBoolean("store-users-ip-address", true);
+    }
+    
     private boolean changePlayerListName = false;
 
     private boolean _changePlayerListName() {

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -815,11 +815,7 @@ public class Settings implements net.ess3.api.ISettings {
     public boolean removeGodOnDisconnect() {
         return config.getBoolean("remove-god-on-disconnect", false);
     }
-    
-    public boolean isstoreIPAddressPlainText() {
-        return config.getBoolean("store-users-ip-address", true);
-    }
-    
+
     private boolean changeDisplayName = true;
 
     private boolean _changeDisplayName() {

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -827,7 +827,7 @@ public class Settings implements net.ess3.api.ISettings {
         return changeDisplayName;
     }
     
-    public boolean storeIPAddressPlainText() {
+    public boolean storeUserIPAddress() {
         return config.getBoolean("store-ip-address", true);
     }
     

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -698,9 +698,15 @@ public abstract class UserData extends PlayerExtension implements IConf {
         return lastLoginAddress;
     }
 
+    // Gives the user an option to store the Player's ip
+    // address in the Player's UUID file
     private void _setLastLoginAddress(String address) {
         lastLoginAddress = address;
-        config.setProperty("ipAddress", address);
+        if (ess.getSettings().storeIPAddressPlainText()) {
+            config.setProperty("ipAddress", address);
+        } else {
+        	config.setProperty("ipAddress", "hidden");
+        }
     }
 
     private boolean afk;

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -700,7 +700,7 @@ public abstract class UserData extends PlayerExtension implements IConf {
 
     private void _setLastLoginAddress(String address) {
         lastLoginAddress = address;
-        if (ess.getSettings().storeIPAddressPlainText()) {
+        if (ess.getSettings().storeUserIPAddress()) {
             config.setProperty("ipAddress", address);
         } else {
         	config.setProperty("ipAddress", "hidden");

--- a/Essentials/src/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/com/earth2me/essentials/UserData.java
@@ -698,8 +698,6 @@ public abstract class UserData extends PlayerExtension implements IConf {
         return lastLoginAddress;
     }
 
-    // Gives the user an option to store the Player's ip
-    // address in the Player's UUID file
     private void _setLastLoginAddress(String address) {
         lastLoginAddress = address;
         if (ess.getSettings().storeIPAddressPlainText()) {

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -410,6 +410,9 @@ debug: false
 # Turn off god mode when people leave the server.
 remove-god-on-disconnect: false
 
+# Turn this off if you wish to not store the users IP address within the UUID file.
+store-users-ip-address: true
+
 # Auto-AFK
 # After this timeout in seconds, the user will be set as AFK.
 # This feature requires the player to have essentials.afk.auto node.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -410,7 +410,7 @@ debug: false
 # Turn off god mode when people leave the server.
 remove-god-on-disconnect: false
 
-# Set to false if essentials should not store user's ip addresses in their player data
+# Set this to false if essentials should not store user's ip addresses in their player data
 store-ip-address: true
 
 # Auto-AFK

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -410,8 +410,8 @@ debug: false
 # Turn off god mode when people leave the server.
 remove-god-on-disconnect: false
 
-# Turn this off if you wish to not store the users IP address within the UUID file.
-store-users-ip-address: true
+# Set to false if essentials should not store user's ip addresses in their player data
+store-ip-address: true
 
 # Auto-AFK
 # After this timeout in seconds, the user will be set as AFK.


### PR DESCRIPTION
Added an option in the config file to not store the users IP Addresses within the UserData/UUID.yml file. I believe this is a risk to security, and if say players were to get DDoSed by someone due to a leak of IP Addresses, the server owner can be personally Liable.

Although, that is the extreme, it can still reduce the itergrity of a server running this if word got out there was a leak, or even there is an extremely easy way to get a list of player IP Addresses.