### PR TITLE
Fix bug with eco reset requiring 3 arguments when it shouldn't

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandeco.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandeco.java
@@ -36,7 +36,7 @@ public class Commandeco extends EssentialsLoopCommand {
 
         try {
             cmd = Commandeco.EcoCommands.valueOf(args[0].toUpperCase(Locale.ENGLISH));
-            isPercent = args[2].endsWith("%");
+            isPercent = cmd != EcoCommands.RESET && args[2].endsWith("%");
             amount = (cmd == Commandeco.EcoCommands.RESET) ? startingBalance : new BigDecimal(args[2].replaceAll("[^0-9\\.]", ""));
         } catch (Exception ex) {
             throw new NotEnoughArgumentsException(ex);


### PR DESCRIPTION
It turns out the bug was introduced in 4b967a749b450cf9c967f8d3530f0076b1162527 due to line 39 throwing an IOOB exception when there are not three arguments present.

Fixes #3251
Closes #3300
