### PR TITLE
Player should not be able to send empty shout/question messages

### DIFF
--- a/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayer.java
+++ b/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChatPlayer.java
@@ -38,9 +38,9 @@ public abstract class EssentialsChatPlayer implements Listener {
 
         final char prefix = message.charAt(0);
         if (prefix == ess.getSettings().getChatShout()) {
-            return "shout";
+            return message.length() > 1 ? "shout" : "";
         } else if (prefix == ess.getSettings().getChatQuestion()) {
-            return "question";
+            return message.length() > 1 ? "question" : "";
         } else {
             return "";
         }


### PR DESCRIPTION
This is nonsense behavior, especially as the function that handles this doesn't allow empty messages for normal chat, so empty shout/question messages are also invalid.

Fixes #3317
