### PR TITLE
Add UTF8 support for .properties files

### DIFF
--- a/Essentials/src/com/earth2me/essentials/I18n.java
+++ b/Essentials/src/com/earth2me/essentials/I18n.java
@@ -2,12 +2,11 @@ package com.earth2me.essentials;
 
 import net.ess3.api.IEssentials;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.logging.Level;
@@ -38,7 +37,7 @@ public class I18n implements net.ess3.api.II18n {
 
     public I18n(final IEssentials ess) {
         this.ess = ess;
-        defaultBundle = ResourceBundle.getBundle(MESSAGES, Locale.ENGLISH);
+        defaultBundle = ResourceBundle.getBundle(MESSAGES, Locale.ENGLISH, new UTF8PropertiesControl());
         localeBundle = defaultBundle;
         customBundle = NULL_BUNDLE;
     }
@@ -114,13 +113,13 @@ public class I18n implements net.ess3.api.II18n {
         Logger.getLogger("Essentials").log(Level.INFO, String.format("Using locale %s", currentLocale.toString()));
 
         try {
-            localeBundle = ResourceBundle.getBundle(MESSAGES, currentLocale);
+            localeBundle = ResourceBundle.getBundle(MESSAGES, currentLocale, new UTF8PropertiesControl());
         } catch (MissingResourceException ex) {
             localeBundle = NULL_BUNDLE;
         }
 
         try {
-            customBundle = ResourceBundle.getBundle(MESSAGES, currentLocale, new FileResClassLoader(I18n.class.getClassLoader(), ess));
+            customBundle = ResourceBundle.getBundle(MESSAGES, currentLocale, new FileResClassLoader(I18n.class.getClassLoader(), ess), new UTF8PropertiesControl());
         } catch (MissingResourceException ex) {
             customBundle = NULL_BUNDLE;
         }
@@ -130,7 +129,9 @@ public class I18n implements net.ess3.api.II18n {
         return input == null || input.length() == 0 ? input : input.toUpperCase(Locale.ENGLISH).charAt(0) + input.toLowerCase(Locale.ENGLISH).substring(1);
     }
 
-
+    /**
+     * Attempts to load properties files from the plugin directory before falling back to the jar.
+     */
     private static class FileResClassLoader extends ClassLoader {
         private final transient File dataFolder;
 
@@ -145,8 +146,7 @@ public class I18n implements net.ess3.api.II18n {
             if (file.exists()) {
                 try {
                     return file.toURI().toURL();
-                } catch (MalformedURLException ignored) {
-                }
+                } catch (MalformedURLException ignored) {}
             }
             return null;
         }
@@ -157,10 +157,43 @@ public class I18n implements net.ess3.api.II18n {
             if (file.exists()) {
                 try {
                     return new FileInputStream(file);
-                } catch (FileNotFoundException ignored) {
-                }
+                } catch (FileNotFoundException ignored) {}
             }
             return null;
+        }
+    }
+
+    /**
+     * Reads .properties files as UTF-8 instead of ISO-8859-1, which is the default on Java 8/below.
+     * Java 9 fixes this by defaulting to UTF-8 for .properties files.
+     */
+    private static class UTF8PropertiesControl extends ResourceBundle.Control {
+        public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload) throws IOException {
+            String bundleName = toBundleName(baseName, locale);
+            String resourceName = toResourceName(bundleName, "properties");
+            ResourceBundle bundle = null;
+            InputStream stream = null;
+            if (reload) {
+                URL url = loader.getResource(resourceName);
+                if (url != null) {
+                    URLConnection connection = url.openConnection();
+                    if (connection != null) {
+                        connection.setUseCaches(false);
+                        stream = connection.getInputStream();
+                    }
+                }
+            } else {
+                stream = loader.getResourceAsStream(resourceName);
+            }
+            if (stream != null) {
+                try {
+                    // use UTF-8 here, this is the important bit
+                    bundle = new PropertyResourceBundle(new InputStreamReader(stream, StandardCharsets.UTF_8));
+                } finally {
+                    stream.close();
+                }
+            }
+            return bundle;
         }
     }
 }

--- a/Essentials/src/com/earth2me/essentials/I18n.java
+++ b/Essentials/src/com/earth2me/essentials/I18n.java
@@ -169,8 +169,7 @@ public class I18n implements net.ess3.api.II18n {
      */
     private static class UTF8PropertiesControl extends ResourceBundle.Control {
         public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload) throws IOException {
-            String bundleName = toBundleName(baseName, locale);
-            String resourceName = toResourceName(bundleName, "properties");
+            String resourceName = toResourceName(toBundleName(baseName, locale), "properties");
             ResourceBundle bundle = null;
             InputStream stream = null;
             if (reload) {

--- a/pom.xml
+++ b/pom.xml
@@ -251,28 +251,6 @@
                         <tags>true</tags>
                     </gitDescribe>
                 </configuration>
-
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>native2ascii-maven-plugin</artifactId>
-                <version>2.0.1</version>
-                <executions>
-                    <execution>
-                        <id>utf8-to-latin1</id>
-                        <goals>
-                            <goal>inplace</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                        <configuration>
-                            <dir>${project.build.outputDirectory}</dir>
-                            <encoding>${project.build.sourceEncoding}</encoding>
-                            <includes>
-                                <include>**/*.properties</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
         <resources>


### PR DESCRIPTION
Based on edaa4f6, this allows messages files to be read in UTF8 without the need for native2ascii conversion. This also removes the `native2ascii-maven-plugin`, previously used to convert Crowdin translations to a compatible format. I've tested this briefly and it appears to work correctly with both internal translations and custom messages.