### PR TITLE
Deny teleport requests to players lacking permission to accept request

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpa.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpa.java
@@ -28,6 +28,9 @@ public class Commandtpa extends EssentialsCommand {
         if (user.getName().equalsIgnoreCase(player.getName())) {
             throw new NotEnoughArgumentsException();
         }
+        if (!player.isAuthorized("essentials.tpaccept")) {
+            throw new Exception(tl("teleportNoAcceptPermission", player.getDisplayName()));
+        }
         if (!player.isTeleportEnabled()) {
             throw new Exception(tl("teleportDisabled", player.getDisplayName()));
         }

--- a/Essentials/src/messages.properties
+++ b/Essentials/src/messages.properties
@@ -538,6 +538,7 @@ teleportHome=\u00a76Teleporting to \u00a7c{0}\u00a76.
 teleporting=\u00a76Teleporting...
 teleportInvalidLocation=Value of coordinates cannot be over 30000000
 teleportNewPlayerError=\u00a74Failed to teleport new player\!
+teleportNoAcceptPermission=\u00a7c{0} \u00a74does not have permission to accept teleport requests.
 teleportRequest=\u00a7c{0}\u00a76 has requested to teleport to you.
 teleportRequestAllCancelled=\u00a76All outstanding teleport requests cancelled.
 teleportRequestCancelled=\u00a76Your teleport request to \u00a7c{0}\u00a76 was cancelled.


### PR DESCRIPTION
This PR will deny any teleport requests to players lacking permission to accept the request (`essentials.tpaccept`).

Closes #1259