### PR TITLE
Improve suicide and kill commands

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandkill.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandkill.java
@@ -32,18 +32,13 @@ public class Commandkill extends EssentialsLoopCommand {
         if (sender.isPlayer() && user.isAuthorized("essentials.kill.exempt") && !ess.getUser(sender.getPlayer()).isAuthorized("essentials.kill.force")) {
             throw new PlayerExemptException(tl("killExempt", matchPlayer.getDisplayName()));
         }
-        final EntityDamageEvent ede = new EntityDamageEvent(matchPlayer, sender.isPlayer() && sender.getPlayer().getName().equals(matchPlayer.getName()) ? EntityDamageEvent.DamageCause.SUICIDE : EntityDamageEvent.DamageCause.CUSTOM, Short.MAX_VALUE);
+        final EntityDamageEvent ede = new EntityDamageEvent(matchPlayer, sender.isPlayer() && sender.getPlayer().getName().equals(matchPlayer.getName()) ? EntityDamageEvent.DamageCause.SUICIDE : EntityDamageEvent.DamageCause.CUSTOM, Float.MAX_VALUE);
         server.getPluginManager().callEvent(ede);
         if (ede.isCancelled() && sender.isPlayer() && !ess.getUser(sender.getPlayer()).isAuthorized("essentials.kill.force")) {
             return;
         }
         ede.getEntity().setLastDamageCause(ede);
-        matchPlayer.damage(Short.MAX_VALUE);
-
-        if (matchPlayer.getHealth() > 0) {
-            matchPlayer.setHealth(0);
-        }
-
+        matchPlayer.setHealth(0);
         sender.sendMessage(tl("kill", matchPlayer.getDisplayName()));
     }
 

--- a/Essentials/src/com/earth2me/essentials/commands/Commandsuicide.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandsuicide.java
@@ -4,6 +4,9 @@ import com.earth2me.essentials.User;
 import org.bukkit.Server;
 import org.bukkit.event.entity.EntityDamageEvent;
 
+import java.util.Collections;
+import java.util.List;
+
 import static com.earth2me.essentials.I18n.tl;
 
 
@@ -14,15 +17,17 @@ public class Commandsuicide extends EssentialsCommand {
 
     @Override
     public void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
-        EntityDamageEvent ede = new EntityDamageEvent(user.getBase(), EntityDamageEvent.DamageCause.SUICIDE, Short.MAX_VALUE);
+        EntityDamageEvent ede = new EntityDamageEvent(user.getBase(), EntityDamageEvent.DamageCause.SUICIDE, Float.MAX_VALUE);
         server.getPluginManager().callEvent(ede);
         ede.getEntity().setLastDamageCause(ede);
-        user.getBase().damage(Short.MAX_VALUE);
-        if (user.getBase().getHealth() > 0) {
-            user.getBase().setHealth(0);
-        }
+        user.getBase().setHealth(0);
         user.sendMessage(tl("suicideMessage"));
         user.setDisplayNick();
         ess.broadcastMessage(user, tl("suicideSuccess", user.getDisplayName()));
+    }
+
+    @Override
+    protected List<String> getTabCompleteOptions(Server server, User user, String commandLabel, String[] args) {
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
Fixes #3189 

This PR makes improvements to the suicide and kill commands, namely:
1) Call `EntityDamageEvent` with damage equal to `Float.MAX_VALUE`, which is the amount that is inflicted by `/minecraft:kill`.
2) Removes the calls to `Damageable::damage` which ends up damaging the player with `DamageSource.GENERIC`, and later causing another `EntityDamageEvent` where as a result the last damage cause gets set to `EntityDamageEvent.DamageCause.CUSTOM`. Thus, the `EntityDamageEvent` that Essentials calls gets rendered useless when someone tries to get the damage cause of the player in `PlayerDeathEvent`. Setting health to zero forcibly kills the player without causing damage.
3) Add `getTabCompleteOptions` to the suicide command, as it currently incorrectly suggests players.