### PR TITLE
Match kit name in delkit

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Kits.java
+++ b/Essentials/src/com/earth2me/essentials/Kits.java
@@ -70,6 +70,21 @@ public class Kits implements IConf {
         return null;
     }
 
+    // Tries to find an existing kit name that matches the given name, ignoring case. Returns null if no match.
+    public String matchKit(String name) {
+        if (config.isConfigurationSection("kits")) {
+            final ConfigurationSection section = config.getConfigurationSection("kits");
+            if (section != null) {
+                for (String kitName : section.getKeys(false)) {
+                    if (kitName.equalsIgnoreCase(name)) {
+                        return kitName;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     public void addKit(String name, List<String> lines, long delay) {
         // Will overwrite but w/e
         config.set("kits." + name + ".delay", delay);

--- a/Essentials/src/com/earth2me/essentials/commands/Commanddelkit.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddelkit.java
@@ -23,7 +23,7 @@ public class Commanddelkit extends EssentialsCommand {
             sender.sendMessage(kitList.length() > 0 ? tl("kits", kitList) : tl("noKits"));
             throw new NoChargeException();
         } else {
-            final String kitName = args[0];
+            final String kitName = ess.getKits().matchKit(args[0]);
             final Kit kit = new Kit(kitName, ess);
 
             if (sender.getPlayer() != null) {


### PR DESCRIPTION
I don't know if this is the ideal fix, but everything else for kits seems to nuke the letter casing. Not really sure why in `Kits.java`, the keys needs to get lowercased in a new mock `ConfigurationSection`. It just seems like this would purely make it harder to access the same section again in the real config. Instead, I just added a different method that matches the real config name of the kit (as set in `/createkit`, which currently allows uppercase). This allows deleting kits ignoring case; fixes #3370