### PR TITLE
Add UserTeleportHomeEvent

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
@@ -42,7 +42,7 @@ public class Commandhome extends EssentialsCommand {
             if ("bed".equalsIgnoreCase(homeName) && user.isAuthorized("essentials.home.bed")) {
                 final Location bed = player.getBase().getBedSpawnLocation();
                 if (bed != null) {
-                    UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, bed, UserTeleportHomeEvent.HomeType.BED);
+                    UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, "bed", bed, UserTeleportHomeEvent.HomeType.BED);
                     server.getPluginManager().callEvent(event);
                     if (!event.isCancelled()) {
                         user.getTeleport().teleport(bed, charge, TeleportCause.COMMAND);
@@ -58,7 +58,7 @@ public class Commandhome extends EssentialsCommand {
             final List<String> homes = player.getHomes();
             if (homes.isEmpty() && player.equals(user)) {
                 if (ess.getSettings().isSpawnIfNoHome()) {
-                    UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, bed != null ? bed : player.getWorld().getSpawnLocation(), UserTeleportHomeEvent.HomeType.RESPAWN);
+                    UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, null, bed != null ? bed : player.getWorld().getSpawnLocation(), bed != null ? UserTeleportHomeEvent.HomeType.BED : UserTeleportHomeEvent.HomeType.SPAWN);
                     server.getPluginManager().callEvent(event);
                     if (!event.isCancelled()) {
                         user.getTeleport().respawn(charge, TeleportCause.COMMAND);
@@ -106,7 +106,7 @@ public class Commandhome extends EssentialsCommand {
         if (user.getWorld() != loc.getWorld() && ess.getSettings().isWorldHomePermissions() && !user.isAuthorized("essentials.worlds." + loc.getWorld().getName())) {
             throw new Exception(tl("noPerm", "essentials.worlds." + loc.getWorld().getName()));
         }
-        UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, loc, UserTeleportHomeEvent.HomeType.HOME);
+        UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, home, loc, UserTeleportHomeEvent.HomeType.HOME);
         user.getServer().getPluginManager().callEvent(event);
         if (!event.isCancelled()) {
             user.getTeleport().teleport(loc, charge, TeleportCause.COMMAND);

--- a/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
@@ -3,6 +3,8 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.StringUtil;
+import net.ess3.api.events.UserTeleportHomeEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -41,7 +43,11 @@ public class Commandhome extends EssentialsCommand {
             if ("bed".equalsIgnoreCase(homeName) && user.isAuthorized("essentials.home.bed")) {
                 final Location bed = player.getBase().getBedSpawnLocation();
                 if (bed != null) {
-                    user.getTeleport().teleport(bed, charge, TeleportCause.COMMAND);
+                    UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, bed, UserTeleportHomeEvent.HomeType.BED);
+                    Bukkit.getServer().getPluginManager().callEvent(event);
+                    if (!event.isCancelled()) {
+                        user.getTeleport().teleport(bed, charge, TeleportCause.COMMAND);
+                    }
                     throw new NoChargeException();
                 } else {
                     throw new Exception(tl("bedMissing"));
@@ -53,7 +59,11 @@ public class Commandhome extends EssentialsCommand {
             final List<String> homes = player.getHomes();
             if (homes.isEmpty() && player.equals(user)) {
                 if (ess.getSettings().isSpawnIfNoHome()) {
-                    user.getTeleport().respawn(charge, TeleportCause.COMMAND);
+                    UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, bed != null ? bed : player.getWorld().getSpawnLocation(), UserTeleportHomeEvent.HomeType.RESPAWN);
+                    Bukkit.getServer().getPluginManager().callEvent(event);
+                    if (!event.isCancelled()) {
+                        user.getTeleport().respawn(charge, TeleportCause.COMMAND);
+                    }
                 } else {
                     throw new Exception(tl("noHomeSetPlayer"));
                 }
@@ -97,8 +107,12 @@ public class Commandhome extends EssentialsCommand {
         if (user.getWorld() != loc.getWorld() && ess.getSettings().isWorldHomePermissions() && !user.isAuthorized("essentials.worlds." + loc.getWorld().getName())) {
             throw new Exception(tl("noPerm", "essentials.worlds." + loc.getWorld().getName()));
         }
-        user.getTeleport().teleport(loc, charge, TeleportCause.COMMAND);
-        user.sendMessage(tl("teleportHome", home));
+        UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, loc, UserTeleportHomeEvent.HomeType.HOME);
+        Bukkit.getServer().getPluginManager().callEvent(event);
+        if (!event.isCancelled()) {
+            user.getTeleport().teleport(loc, charge, TeleportCause.COMMAND);
+            user.sendMessage(tl("teleportHome", home));
+        }
     }
 
     @Override

--- a/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
@@ -4,7 +4,6 @@ import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.StringUtil;
 import net.ess3.api.events.UserTeleportHomeEvent;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -44,7 +43,7 @@ public class Commandhome extends EssentialsCommand {
                 final Location bed = player.getBase().getBedSpawnLocation();
                 if (bed != null) {
                     UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, bed, UserTeleportHomeEvent.HomeType.BED);
-                    Bukkit.getServer().getPluginManager().callEvent(event);
+                    server.getPluginManager().callEvent(event);
                     if (!event.isCancelled()) {
                         user.getTeleport().teleport(bed, charge, TeleportCause.COMMAND);
                     }
@@ -60,7 +59,7 @@ public class Commandhome extends EssentialsCommand {
             if (homes.isEmpty() && player.equals(user)) {
                 if (ess.getSettings().isSpawnIfNoHome()) {
                     UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, bed != null ? bed : player.getWorld().getSpawnLocation(), UserTeleportHomeEvent.HomeType.RESPAWN);
-                    Bukkit.getServer().getPluginManager().callEvent(event);
+                    server.getPluginManager().callEvent(event);
                     if (!event.isCancelled()) {
                         user.getTeleport().respawn(charge, TeleportCause.COMMAND);
                     }
@@ -108,7 +107,7 @@ public class Commandhome extends EssentialsCommand {
             throw new Exception(tl("noPerm", "essentials.worlds." + loc.getWorld().getName()));
         }
         UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, loc, UserTeleportHomeEvent.HomeType.HOME);
-        Bukkit.getServer().getPluginManager().callEvent(event);
+        user.getServer().getPluginManager().callEvent(event);
         if (!event.isCancelled()) {
             user.getTeleport().teleport(loc, charge, TeleportCause.COMMAND);
             user.sendMessage(tl("teleportHome", home));

--- a/Essentials/src/net/ess3/api/events/UserTeleportHomeEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserTeleportHomeEvent.java
@@ -1,0 +1,83 @@
+package net.ess3.api.events;
+
+import net.ess3.api.IUser;
+import org.bukkit.Location;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a user is teleported home via the /home command.
+ *
+ * This is called before {@link net.ess3.api.events.UserTeleportEvent UserTeleportEvent}.
+ */
+public class UserTeleportHomeEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final IUser user;
+    private final Location target;
+    private final HomeType homeType;
+    private boolean cancelled = false;
+
+    public UserTeleportHomeEvent(IUser user, Location target, HomeType homeType) {
+        this.user = user;
+        this.target = target;
+        this.homeType = homeType;
+    }
+
+    /**
+     * Returns the user who is being teleported
+     *
+     * @return The teleportee.
+     */
+    public IUser getUser() {
+        return user;
+    }
+
+    /**
+     * Returns the location the user is teleporting to.
+     *
+     * @return Teleportation destination location.
+     */
+    public Location getHomeLocation() {
+        return target;
+    }
+
+    /**
+     * Returns the home location type.
+     *
+     * {@link HomeType#HOME}    - A user-set home location.
+     * {@link HomeType#BED}     - A user's bed location.
+     * {@link HomeType#RESPAWN} - A user's bed location, if set. Otherwise, the world spawn.
+     *
+     * @return Home location type.
+     */
+    public HomeType getHomeType() {
+        return homeType;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public enum HomeType {
+        HOME,
+        BED,
+        RESPAWN
+    }
+}

--- a/Essentials/src/net/ess3/api/events/UserTeleportHomeEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserTeleportHomeEvent.java
@@ -15,12 +15,14 @@ public class UserTeleportHomeEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     private final IUser user;
+    private final String homeName;
     private final Location target;
     private final HomeType homeType;
     private boolean cancelled = false;
 
-    public UserTeleportHomeEvent(IUser user, Location target, HomeType homeType) {
+    public UserTeleportHomeEvent(IUser user, String homeName, Location target, HomeType homeType) {
         this.user = user;
+        this.homeName = homeName;
         this.target = target;
         this.homeType = homeType;
     }
@@ -35,6 +37,20 @@ public class UserTeleportHomeEvent extends Event implements Cancellable {
     }
 
     /**
+     * Returns the name of the home being teleported to.
+     *
+     * The behavior of this method varies based on the {@link HomeType} as follows;
+     * {@link HomeType#HOME}  - Returns name of home being teleported to.
+     * {@link HomeType#BED}   - Returns "bed".
+     * {@link HomeType#SPAWN} - Returns null.
+     *
+     * @return Name of home being teleported to, or null if the user had no homes set.
+     */
+    public String getHomeName() {
+        return homeName;
+    }
+
+    /**
      * Returns the location the user is teleporting to.
      *
      * @return Teleportation destination location.
@@ -46,9 +62,9 @@ public class UserTeleportHomeEvent extends Event implements Cancellable {
     /**
      * Returns the home location type.
      *
-     * {@link HomeType#HOME}    - A user-set home location.
-     * {@link HomeType#BED}     - A user's bed location.
-     * {@link HomeType#RESPAWN} - A user's bed location, if set. Otherwise, the world spawn.
+     * {@link HomeType#HOME}  - A user-set home location.
+     * {@link HomeType#BED}   - A user's bed location.
+     * {@link HomeType#SPAWN} - The user's current world spawn.
      *
      * @return Home location type.
      */
@@ -78,6 +94,6 @@ public class UserTeleportHomeEvent extends Event implements Cancellable {
     public enum HomeType {
         HOME,
         BED,
-        RESPAWN
+        SPAWN
     }
 }


### PR DESCRIPTION
Adds an event which allows developers to see & cancel when users attempt to teleport home. This event is needed over `UserTeleportEvent` due to the fact that it would be extremely difficult to accurately filter it by the /home command.

Closes #3401