### PR TITLE
Add PrivateMessageSentEvent and fix PrivateMessagePreSendEvent

### DIFF
--- a/Essentials/src/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
+++ b/Essentials/src/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
@@ -64,7 +64,7 @@ public class SimpleMessageRecipient implements IMessageRecipient {
     }
 
     @Override public MessageResponse sendMessage(IMessageRecipient recipient, String message) {
-        final PrivateMessagePreSendEvent preSendEvent = new PrivateMessagePreSendEvent(this, recipient, message);
+        final PrivateMessagePreSendEvent preSendEvent = new PrivateMessagePreSendEvent(parent, recipient, message);
         ess.getServer().getPluginManager().callEvent(preSendEvent);
         if (preSendEvent.isCancelled()) {
             return MessageResponse.EVENT_CANCELLED;

--- a/Essentials/src/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
+++ b/Essentials/src/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
@@ -4,6 +4,7 @@ import com.earth2me.essentials.IEssentials;
 import com.earth2me.essentials.IUser;
 import com.earth2me.essentials.User;
 import net.ess3.api.events.PrivateMessagePreSendEvent;
+import net.ess3.api.events.PrivateMessageSentEvent;
 
 import java.lang.ref.WeakReference;
 
@@ -63,13 +64,13 @@ public class SimpleMessageRecipient implements IMessageRecipient {
     }
 
     @Override public MessageResponse sendMessage(IMessageRecipient recipient, String message) {
-        final PrivateMessagePreSendEvent event = new PrivateMessagePreSendEvent(this, recipient, message);
-        ess.getServer().getPluginManager().callEvent(event);
-        if (event.isCancelled()) {
+        final PrivateMessagePreSendEvent preSendEvent = new PrivateMessagePreSendEvent(this, recipient, message);
+        ess.getServer().getPluginManager().callEvent(preSendEvent);
+        if (preSendEvent.isCancelled()) {
             return MessageResponse.EVENT_CANCELLED;
         }
 
-        message = event.getMessage();
+        message = preSendEvent.getMessage();
         MessageResponse messageResponse = recipient.onReceiveMessage(this.parent, message);
         switch (messageResponse) {
             case UNREACHABLE:
@@ -116,6 +117,10 @@ public class SimpleMessageRecipient implements IMessageRecipient {
         if (messageResponse.isSuccess()) {
             setReplyRecipient(recipient);
         }
+
+        final PrivateMessageSentEvent sentEvent = new PrivateMessageSentEvent(parent, recipient, message, messageResponse);
+        ess.getServer().getPluginManager().callEvent(sentEvent);
+
         return messageResponse;
     }
 

--- a/Essentials/src/net/ess3/api/events/PrivateMessageSentEvent.java
+++ b/Essentials/src/net/ess3/api/events/PrivateMessageSentEvent.java
@@ -1,0 +1,53 @@
+package net.ess3.api.events;
+
+import com.earth2me.essentials.messaging.IMessageRecipient;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called after a private message has been sent to its recipient.
+ *
+ * The related private message may not have been successfully received by the recipient,
+ * check the MessageResponse with getResponse() to determine the outcome of the delivery attempt.
+ */
+public class PrivateMessageSentEvent extends Event {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private IMessageRecipient sender;
+    private IMessageRecipient recipient;
+    private String message;
+    private IMessageRecipient.MessageResponse response;
+
+    public PrivateMessageSentEvent(IMessageRecipient sender, IMessageRecipient recipient, String message, IMessageRecipient.MessageResponse response) {
+        this.sender = sender;
+        this.recipient = recipient;
+        this.message = message;
+        this.response = response;
+    }
+
+    public IMessageRecipient getSender() {
+        return sender;
+    }
+
+    public IMessageRecipient getRecipient() {
+        return recipient;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public IMessageRecipient.MessageResponse getResponse() {
+        return response;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
This PR introduces a new private messaging related event `PrivateMessageSentEvent` and fixes a mistake made on my part during the implementation of `PrivateMessagePreSendEvent`.

Recently when attempting to use the pre-send event in order to play a sound to the recipient of a message, I found that the event was not completely adequate for my use case. Between the firing of the pre-send event and the end of the delivery attempt, the message delivery could fail for a number of reasons (e.g. messages toggled off, sender ignored, unreachable recipient) with no straightforward way of determining this using the existing event.

I believe that a second event fired after the message sending attempt has been fully processed will provide a simple method of determining whether or not a message was successfully delivered by including the [`MessageResponse`](https://github.com/EssentialsX/Essentials/blob/60f54ee37d9472848e28d2e64adc2735e10975c1/Essentials/src/com/earth2me/essentials/messaging/IMessageRecipient.java#L84) in the event.

Additionally, I found that when implementing the pre-send event, I mistakenly passed an incorrect reference for the `sender` meaning that currently there's no clean or reliable way to determine if `sender` is the `Console` or a `User` (`instanceof` doesn't work, which leaves checking by name or using reflection).