### PR TITLE
Add command permissions, fix use-bukkit-permissions (Fixes #1782, #3438)

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -435,6 +435,35 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             }
         }
 
+        // Register command permissions and no-usage message
+        boolean useBukkitPerms = settings.useBukkitPermissions();
+        for (Plugin plugin : getServer().getPluginManager().getPlugins()) {
+            if (plugin.getDescription().getMain().startsWith("com.earth2me.essentials")) {
+                for (String commandName : plugin.getDescription().getCommands().keySet()) {
+                    Command command = getServer().getPluginCommand(plugin.getName() + ":" + commandName);
+                    if (command != null) {
+                        if (useBukkitPerms) {
+                            if (command.getPermission() == null) {
+                                String permission = "essentials." + (command.getName().equals("r") ? "msg" : command.getName());
+                                command.setPermission(permission);
+                                if (getServer().getPluginManager().getPermission(permission) == null) {
+                                    getServer().getPluginManager().addPermission(new Permission(permission, PermissionDefault.OP));
+                                }
+                            }
+                            command.setPermissionMessage(tl("noAccessCommand"));
+                        } else {
+                            command.setPermission(null);
+                            command.setPermissionMessage(null);
+                        }
+                    }
+                }
+            }
+        }
+        if (permissionsHandler != null) {
+            permissionsHandler.setUseSuperperms(useBukkitPerms);
+            permissionsHandler.checkPermissions();
+        }
+
         final PluginManager pm = getServer().getPluginManager();
         registerListeners(pm);
     }

--- a/Essentials/src/com/earth2me/essentials/perm/PermissionsHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/PermissionsHandler.java
@@ -109,35 +109,39 @@ public class PermissionsHandler implements IPermissionsHandler {
 
     public void checkPermissions() {
         // load and assign a handler
-        List<Class<? extends SuperpermsHandler>> providerClazz = Arrays.asList(
-                LuckPermsHandler.class,
-                ModernVaultHandler.class,
-                GenericVaultHandler.class,
-                SuperpermsHandler.class
-        );
-        for (Class<? extends IPermissionsHandler> providerClass : providerClazz) {
-            try {
-                IPermissionsHandler provider = providerClass.newInstance();
-                if (provider.tryProvider()) {
-                    if (provider.getClass().isInstance(this.handler)) {
-                        return;
+        if (useSuperperms) {
+            List<Class<? extends SuperpermsHandler>> providerClazz = Arrays.asList(
+                    LuckPermsHandler.class,
+                    ModernVaultHandler.class,
+                    GenericVaultHandler.class,
+                    SuperpermsHandler.class
+            );
+            for (Class<? extends IPermissionsHandler> providerClass : providerClazz) {
+                try {
+                    IPermissionsHandler provider = providerClass.newInstance();
+                    if (provider.tryProvider()) {
+                        if (provider.getClass().isInstance(this.handler)) {
+                            return;
+                        }
+                        if (this.handler != null) {
+                            unregisterContexts();
+                        }
+                        this.handler = provider;
+                        initContexts();
+                        break;
                     }
-                    if (this.handler != null) {
-                        unregisterContexts();
-                    }
-                    this.handler = provider;
-                    initContexts();
-                    break;
+                } catch (Throwable ignored) {
                 }
-            } catch (Throwable ignored) {
             }
-        }
-        if (handler == null) {
-            if (useSuperperms) {
+            if (handler == null) {
+                // How?
                 handler = new SuperpermsHandler();
-            } else {
-                handler = new ConfigPermissionsHandler(ess);
             }
+        } else {
+            if (this.handler != null) {
+                unregisterContexts();
+            }
+            handler = new ConfigPermissionsHandler(ess);
         }
 
         // don't spam logs


### PR DESCRIPTION
This adds permissions to all commands when `use-bukkit-permissions` is set to true in the config.

It also fixes that the config option `use-bukkit-permissions` was ignored when Vault/LuckPerms was installed and the bug that reloading the plugin did not switch the behavior of the permission when that config option was changed (a full reload/restart was required).