### PR TITLE
Update bStats version + add new graphs

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/com/earth2me/essentials/Essentials.java
@@ -22,7 +22,7 @@ import com.earth2me.essentials.items.AbstractItemDb;
 import com.earth2me.essentials.items.CustomItemResolver;
 import com.earth2me.essentials.items.FlatItemDb;
 import com.earth2me.essentials.items.LegacyItemDb;
-import com.earth2me.essentials.metrics.Metrics;
+import com.earth2me.essentials.metrics.MetricsWrapper;
 import com.earth2me.essentials.perm.PermissionsHandler;
 import com.earth2me.essentials.register.payment.Methods;
 import com.earth2me.essentials.signs.SignBlockListener;
@@ -103,7 +103,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     private transient UserMap userMap;
     private transient ExecuteTimer execTimer;
     private transient I18n i18n;
-    private transient Metrics metrics;
+    private transient MetricsWrapper metrics;
     private transient EssentialsTimer timer;
     private final transient Set<String> vanishedPlayers = new LinkedHashSet<>();
     private transient Method oldGetOnlinePlayers;
@@ -305,12 +305,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             for (World w : Bukkit.getWorlds())
                 addDefaultBackPermissionsToWorld(w);
 
-            metrics = new Metrics(this);
-            if (metrics.isEnabled()) {
-                getLogger().info("Starting Metrics. Opt-out using the global bStats config.");
-            } else {
-                getLogger().info("Metrics disabled per bStats config.");
-            }
+            metrics = new MetricsWrapper(this, 858, true);
 
             final String timeroutput = execTimer.end();
             if (getSettings().isDebug()) {
@@ -518,6 +513,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
     @Override
     public boolean onCommand(final CommandSender sender, final Command command, final String commandLabel, final String[] args) {
+        metrics.markCommand(command.getName(), true);
         return onCommandEssentials(sender, command, commandLabel, args, Essentials.class.getClassLoader(), "com.earth2me.essentials.commands.Command", "essentials.", null);
     }
 
@@ -684,16 +680,6 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     @Override
     public Kits getKits() {
         return kits;
-    }
-
-    @Override
-    public Metrics getMetrics() {
-        return metrics;
-    }
-
-    @Override
-    public void setMetrics(Metrics metrics) {
-        this.metrics = metrics;
     }
 
     @Deprecated

--- a/Essentials/src/com/earth2me/essentials/IEssentials.java
+++ b/Essentials/src/com/earth2me/essentials/IEssentials.java
@@ -3,7 +3,6 @@ package com.earth2me.essentials;
 import com.earth2me.essentials.api.IItemDb;
 import com.earth2me.essentials.api.IJails;
 import com.earth2me.essentials.api.IWarps;
-import com.earth2me.essentials.metrics.Metrics;
 import com.earth2me.essentials.perm.PermissionsHandler;
 import com.earth2me.essentials.register.payment.Methods;
 import net.ess3.provider.ServerStateProvider;
@@ -92,10 +91,6 @@ public interface IEssentials extends Plugin {
     IItemDb getItemDb();
 
     UserMap getUserMap();
-
-    Metrics getMetrics();
-
-    void setMetrics(Metrics metrics);
 
     EssentialsTimer getTimer();
 

--- a/Essentials/src/com/earth2me/essentials/metrics/MetricsWrapper.java
+++ b/Essentials/src/com/earth2me/essentials/metrics/MetricsWrapper.java
@@ -1,0 +1,137 @@
+package com.earth2me.essentials.metrics;
+
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.register.payment.Methods;
+import com.google.common.collect.ImmutableList;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MetricsWrapper {
+
+    private final Essentials ess;
+    private final Metrics metrics;
+    private final Map<String, Boolean> commands = new HashMap<>();
+    private final Plugin plugin;
+
+    private static boolean hasWarned = false;
+    private static final List<String> KNOWN_FORCED_METRICS = ImmutableList.of("ChatControl");
+
+    public MetricsWrapper(Plugin plugin, int pluginId, boolean includeCommands) {
+        this.plugin = plugin;
+        this.ess = (Essentials) Bukkit.getPluginManager().getPlugin("Essentials");
+        this.metrics = new Metrics(plugin, pluginId);
+
+        if (metrics.isEnabled()) {
+            plugin.getLogger().info("Starting Metrics. Opt-out using the global bStats config.");
+        } else {
+            plugin.getLogger().info("Metrics disabled per bStats config.");
+        }
+
+        checkForcedMetrics();
+        addPermsChart();
+        addEconomyChart();
+
+        // bStats' backend currently doesn't support multi-line charts or advanced bar charts
+        // These are included for when bStats is ready to accept this data
+        addVersionHistoryChart();
+        if (includeCommands) addCommandsChart();
+    }
+
+    public void markCommand(String command, boolean state) {
+        commands.put(command, state);
+    }
+
+    public void addCustomChart(Metrics.CustomChart chart) {
+        metrics.addCustomChart(chart);
+    }
+
+    private void addPermsChart() {
+        metrics.addCustomChart(new Metrics.DrilldownPie("permsPlugin", () -> {
+            Map<String, Map<String, Integer>> result = new HashMap<>();
+            String handler = ess.getPermissionsHandler().getName();
+            Map<String, Integer> backend = new HashMap<>();
+            backend.put(ess.getPermissionsHandler().getBackendName(), 1);
+            result.put(handler, backend);
+            return result;
+        }));
+    }
+
+    private void addEconomyChart() {
+        metrics.addCustomChart(new Metrics.DrilldownPie("econPlugin", () -> {
+            Map<String, Map<String, Integer>> result = new HashMap<>();
+            Map<String, Integer> backend = new HashMap<>();
+            backend.put(Methods.getMethod().getPlugin().getName(), 1);
+            result.put(Methods.getMethod().getName(), backend);
+            return result;
+        }));
+    }
+
+    private void addVersionHistoryChart() {
+        metrics.addCustomChart(new Metrics.MultiLineChart("versionHistory", () -> {
+            HashMap<String, Integer> result = new HashMap<>();
+            result.put(plugin.getDescription().getVersion(), 1);
+            return result;
+        }));
+    }
+
+    private void addCommandsChart() {
+        for (String command : plugin.getDescription().getCommands().keySet()) {
+            markCommand(command, false);
+        }
+
+        metrics.addCustomChart(new Metrics.AdvancedBarChart("commands", () -> {
+            Map<String, int[]> result = new HashMap<>();
+            for (Map.Entry<String, Boolean> entry : commands.entrySet()) {
+                if (entry.getValue()) {
+                    result.put(entry.getKey(), new int[]{1,0});
+                } else {
+                    result.put(entry.getKey(), new int[]{0,1});
+                }
+            }
+            return result;
+        }));
+    }
+
+    private void checkForcedMetrics() {
+        if (hasWarned) return;
+        hasWarned = true;
+
+        Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+            for (Class<?> service : Bukkit.getServicesManager().getKnownServices()) {
+                try {
+                    service.getField("B_STATS_VERSION"); // Identifies bStats classes
+
+                    if (KNOWN_FORCED_METRICS.contains(JavaPlugin.getProvidingPlugin(service).getName())) {
+                        warnForcedMetrics(service);
+                    } else {
+                        try {
+                            service.getDeclaredField("pluginId"); // Only present in recent bStats classes, which should also have the enabled field unless modified
+                        } catch (NoSuchFieldException e) {
+                            // Old bStats class found so "enabled" field detection is unreliable.
+                            break;
+                        }
+
+                        try {
+                            service.getDeclaredField("enabled"); // In modified forced metrics classes, this will fail
+                        } catch (NoSuchFieldException e) {
+                            warnForcedMetrics(service);
+                        }
+                    }
+                } catch (NoSuchFieldException ignored) {}
+            }
+        });
+    }
+
+    private void warnForcedMetrics(Class<?> service) {
+        Plugin servicePlugin = JavaPlugin.getProvidingPlugin(service);
+        plugin.getLogger().severe("WARNING: Potential forced metrics collection by plugin '" + servicePlugin.getName() + "' v" + servicePlugin.getDescription().getVersion());
+        plugin.getLogger().severe("Your server is running a plugin that may not respect bStats' opt-out settings.");
+        plugin.getLogger().severe("This may cause data to be uploaded to bStats.org for plugins that use bStats, even if you've opted out in the bStats config.");
+        plugin.getLogger().severe("Please report this to bStats and to the authors of '" + servicePlugin.getName() + "'. (Offending class: " + service.getName() + ")");
+    }
+}

--- a/Essentials/src/com/earth2me/essentials/perm/IPermissionsHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/IPermissionsHandler.java
@@ -29,5 +29,7 @@ public interface IPermissionsHandler {
 
     void unregisterContexts();
 
+    String getBackendName();
+
     boolean tryProvider();
 }

--- a/Essentials/src/com/earth2me/essentials/perm/PermissionsHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/PermissionsHandler.java
@@ -103,6 +103,11 @@ public class PermissionsHandler implements IPermissionsHandler {
     }
 
     @Override
+    public String getBackendName() {
+        return handler.getBackendName();
+    }
+
+    @Override
     public boolean tryProvider() {
         return true;
     }

--- a/Essentials/src/com/earth2me/essentials/perm/impl/AbstractVaultHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/impl/AbstractVaultHandler.java
@@ -5,6 +5,7 @@ import net.milkbowl.vault.permission.Permission;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
+import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Arrays;
 import java.util.List;
@@ -71,6 +72,11 @@ public abstract class AbstractVaultHandler extends SuperpermsHandler {
         }
 
         return null;
+    }
+
+    @Override
+    public String getBackendName() {
+        return JavaPlugin.getProvidingPlugin(perms.getClass()).getName();
     }
 
     boolean canLoad() {

--- a/Essentials/src/com/earth2me/essentials/perm/impl/ConfigPermissionsHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/impl/ConfigPermissionsHandler.java
@@ -24,6 +24,11 @@ public class ConfigPermissionsHandler extends SuperpermsHandler {
     }
 
     @Override
+    public String getBackendName() {
+        return "Essentials";
+    }
+
+    @Override
     public boolean tryProvider() {
         return true;
     }

--- a/Essentials/src/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
+++ b/Essentials/src/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
@@ -83,6 +83,11 @@ public class SuperpermsHandler implements IPermissionsHandler {
     }
 
     @Override
+    public String getBackendName() {
+        return getEnabledPermsPlugin();
+    }
+
+    @Override
     public boolean tryProvider() {
         return getEnabledPermsPlugin() != null;
     }

--- a/Essentials/src/com/earth2me/essentials/register/payment/Method.java
+++ b/Essentials/src/com/earth2me/essentials/register/payment/Method.java
@@ -24,7 +24,7 @@ public interface Method {
      * @see #getName()
      * @see #getVersion()
      */
-    Object getPlugin();
+    Plugin getPlugin();
 
     /**
      * Returns the actual name of this method.

--- a/EssentialsAntiBuild/src/com/earth2me/essentials/antibuild/EssentialsAntiBuild.java
+++ b/EssentialsAntiBuild/src/com/earth2me/essentials/antibuild/EssentialsAntiBuild.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.antibuild;
 
 import com.earth2me.essentials.metrics.Metrics;
+import com.earth2me.essentials.metrics.MetricsWrapper;
 import org.bukkit.Material;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -15,7 +16,7 @@ public class EssentialsAntiBuild extends JavaPlugin implements IAntiBuild {
     private final transient Map<AntiBuildConfig, Boolean> settingsBoolean = new EnumMap<>(AntiBuildConfig.class);
     private final transient Map<AntiBuildConfig, List<Material>> settingsList = new EnumMap<>(AntiBuildConfig.class);
     private transient EssentialsConnect ess = null;
-    private transient Metrics metrics = null;
+    private transient MetricsWrapper metrics = null;
 
     @Override
     public void onEnable() {
@@ -30,7 +31,7 @@ public class EssentialsAntiBuild extends JavaPlugin implements IAntiBuild {
         pm.registerEvents(blockListener, this);
 
         if (metrics == null) {
-            metrics = new Metrics(this);
+            metrics = new MetricsWrapper(this, 3813, false);
         }
     }
 

--- a/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChat.java
+++ b/EssentialsChat/src/com/earth2me/essentials/chat/EssentialsChat.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.chat;
 
 import com.earth2me.essentials.metrics.Metrics;
+import com.earth2me.essentials.metrics.MetricsWrapper;
 import net.ess3.api.IEssentials;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.plugin.PluginManager;
@@ -16,7 +17,7 @@ import static com.earth2me.essentials.I18n.tl;
 
 public class EssentialsChat extends JavaPlugin {
 
-    private transient Metrics metrics = null;
+    private transient MetricsWrapper metrics = null;
 
     @Override
     public void onEnable() {
@@ -40,7 +41,7 @@ public class EssentialsChat extends JavaPlugin {
         pluginManager.registerEvents(playerListenerHighest, this);
 
         if (metrics == null) {
-            metrics = new Metrics(this);
+            metrics = new MetricsWrapper(this, 3814, false);
         }
     }
 

--- a/EssentialsGeoIP/src/com/earth2me/essentials/geoip/EssentialsGeoIP.java
+++ b/EssentialsGeoIP/src/com/earth2me/essentials/geoip/EssentialsGeoIP.java
@@ -5,6 +5,8 @@ import static com.earth2me.essentials.I18n.tl;
 import com.earth2me.essentials.metrics.Metrics;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.earth2me.essentials.metrics.MetricsWrapper;
 import net.ess3.api.IEssentials;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -12,7 +14,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class EssentialsGeoIP extends JavaPlugin {
   
-    private transient Metrics metrics = null;
+    private transient MetricsWrapper metrics = null;
 
     @Override
     public void onEnable() {
@@ -35,7 +37,7 @@ public class EssentialsGeoIP extends JavaPlugin {
         getLogger().log(Level.INFO, "This product includes GeoLite2 data created by MaxMind, available from http://www.maxmind.com/.");
 
         if (metrics == null) {
-            metrics = new Metrics(this);
+            metrics = new MetricsWrapper(this, 3815, false);
         }
     }
 

--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtect.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtect.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.protect;
 
 import com.earth2me.essentials.metrics.Metrics;
+import com.earth2me.essentials.metrics.MetricsWrapper;
 import com.earth2me.essentials.utils.VersionUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -20,7 +21,7 @@ public class EssentialsProtect extends JavaPlugin implements IProtect {
     private final Map<ProtectConfig, String> settingsString = new EnumMap<>(ProtectConfig.class);
     private final Map<ProtectConfig, List<Material>> settingsList = new EnumMap<>(ProtectConfig.class);
     private EssentialsConnect ess = null;
-    private transient Metrics metrics = null;
+    private transient MetricsWrapper metrics = null;
 
     private final EmergencyListener emListener = new EmergencyListener(this);
 
@@ -36,7 +37,7 @@ public class EssentialsProtect extends JavaPlugin implements IProtect {
         initialize(pm, essPlugin);
 
         if (metrics == null) {
-            metrics = new Metrics(this);
+            metrics = new MetricsWrapper(this, 3816, false);
         }
     }
 

--- a/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawn.java
+++ b/EssentialsSpawn/src/com/earth2me/essentials/spawn/EssentialsSpawn.java
@@ -1,6 +1,6 @@
 package com.earth2me.essentials.spawn;
 
-import com.earth2me.essentials.metrics.Metrics;
+import com.earth2me.essentials.metrics.MetricsWrapper;
 import net.ess3.api.IEssentials;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
@@ -19,7 +19,7 @@ import static com.earth2me.essentials.I18n.tl;
 public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn {
     private transient IEssentials ess;
     private transient SpawnStorage spawns;
-    private transient Metrics metrics = null;
+    private transient MetricsWrapper metrics = null;
 
     @Override
     public void onEnable() {
@@ -51,7 +51,7 @@ public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn {
         }
 
         if (metrics == null) {
-            metrics = new Metrics(this);
+            metrics = new MetricsWrapper(this, 3817, true);
         }
     }
 
@@ -61,6 +61,7 @@ public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn {
 
     @Override
     public boolean onCommand(final CommandSender sender, final Command command, final String commandLabel, final String[] args) {
+        metrics.markCommand(command.getName(), true);
         return ess.onCommandEssentials(sender, command, commandLabel, args, EssentialsSpawn.class.getClassLoader(), "com.earth2me.essentials.spawn.Command", "essentials.", spawns);
     }
 

--- a/EssentialsXMPP/src/com/earth2me/essentials/xmpp/EssentialsXMPP.java
+++ b/EssentialsXMPP/src/com/earth2me/essentials/xmpp/EssentialsXMPP.java
@@ -2,6 +2,7 @@ package com.earth2me.essentials.xmpp;
 
 import com.earth2me.essentials.IEssentials;
 import com.earth2me.essentials.metrics.Metrics;
+import com.earth2me.essentials.metrics.MetricsWrapper;
 import net.ess3.api.IUser;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -21,7 +22,7 @@ public class EssentialsXMPP extends JavaPlugin implements IEssentialsXMPP {
     private transient UserManager users;
     private transient XMPPManager xmpp;
     private transient IEssentials ess;
-    private transient Metrics metrics = null;
+    private transient MetricsWrapper metrics = null;
 
     static IEssentialsXMPP getInstance() {
         return instance;
@@ -51,7 +52,7 @@ public class EssentialsXMPP extends JavaPlugin implements IEssentialsXMPP {
         ess.addReloadListener(xmpp);
 
         if (metrics == null) {
-            metrics = new Metrics(this);
+            metrics = new MetricsWrapper(this, 3818, true);
             metrics.addCustomChart(new Metrics.SimplePie("config-valid", () -> xmpp.isConfigValid() ? "yes" : "no"));
         }
     }
@@ -66,6 +67,7 @@ public class EssentialsXMPP extends JavaPlugin implements IEssentialsXMPP {
 
     @Override
     public boolean onCommand(final CommandSender sender, final Command command, final String commandLabel, final String[] args) {
+        metrics.markCommand(command.getName(), true);
         return ess.onCommandEssentials(sender, command, commandLabel, args, EssentialsXMPP.class.getClassLoader(), "com.earth2me.essentials.xmpp.Command", "essentials.", null);
     }
 


### PR DESCRIPTION
This PR updates the version of the bStats Metrics class to the latest version, supporting plugin IDs in place of just plugin names. It also adds the following graphs:
- Active permissions backend
- Active economy backend
- Whether or not a command has been used as a bar chart (pending bStats backend implementation)
- Version history graph as a multiline graph (also pending bStats impl)

It also removes the weird `getMetrics` and `setMetrics` APIs which should never have been API in the first place.