### PR TITLE
Add config option to hide join/quit messages above X players

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -187,7 +187,7 @@ public class EssentialsPlayerListener implements Listener {
     public void onPlayerQuit(final PlayerQuitEvent event) {
         final User user = ess.getUser(event.getPlayer());
 
-        if (ess.getSettings().allowSilentJoinQuit() && user.isAuthorized("essentials.silentquit")) {
+        if (hideJoinQuitMessages() || (ess.getSettings().allowSilentJoinQuit() && user.isAuthorized("essentials.silentquit"))) {
             event.setQuitMessage(null);
         } else if (ess.getSettings().isCustomQuitMessage() && event.getQuitMessage() != null) {
             final Player player = event.getPlayer();
@@ -235,9 +235,13 @@ public class EssentialsPlayerListener implements Listener {
         final String joinMessage = event.getJoinMessage();
         ess.runTaskAsynchronously(() -> delayedJoin(event.getPlayer(), joinMessage));
 
-        if (ess.getSettings().allowSilentJoinQuit() || ess.getSettings().isCustomJoinMessage()) {
+        if (hideJoinQuitMessages() || ess.getSettings().allowSilentJoinQuit() || ess.getSettings().isCustomJoinMessage()) {
             event.setJoinMessage(null);
         }
+    }
+
+    private boolean hideJoinQuitMessages() {
+        return ess.getSettings().hasJoinQuitMessagePlayerCount() && ess.getServer().getOnlinePlayers().size() > ess.getSettings().getJoinQuitMessagePlayerCount();
     }
 
     public void delayedJoin(final Player player, final String message) {
@@ -294,7 +298,7 @@ public class EssentialsPlayerListener implements Listener {
                     if (user.isAuthorized("essentials.silentjoin.vanish")) {
                         user.setVanished(true);
                     }
-                } else if (message == null) {
+                } else if (message == null || hideJoinQuitMessages()) {
                     //NOOP
                 } else if (ess.getSettings().isCustomJoinMessage()) {
                     String msg = ess.getSettings().getCustomJoinMessage()

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -210,6 +210,10 @@ public interface ISettings extends IConf {
 
     KeepInvPolicy getBindingItemsPolicy();
 
+    int getJoinQuitMessagePlayerCount();
+
+    boolean hasJoinQuitMessagePlayerCount();
+
     enum KeepInvPolicy {
         KEEP,
         DELETE,

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -570,7 +570,6 @@ public class Settings implements net.ess3.api.ISettings {
         isCustomJoinMessage = !customJoinMessage.equals("none");
         customQuitMessage = _getCustomQuitMessage();
         isCustomQuitMessage = !customQuitMessage.equals("none");
-        joinQuitMessagePlayerCount = _getJoinQuitMessagePlayerCount();
         muteCommands = _getMuteCommands();
         spawnOnJoinGroups = _getSpawnOnJoinGroups();
         commandCooldowns = _getCommandCooldowns();
@@ -1286,20 +1285,14 @@ public class Settings implements net.ess3.api.ISettings {
         return isCustomQuitMessage;
     }
 
-    private int joinQuitMessagePlayerCount;
-
-    public int _getJoinQuitMessagePlayerCount() {
+    @Override
+    public int getJoinQuitMessagePlayerCount() {
         return config.getInt("hide-join-quit-messages-above", -1);
     }
 
     @Override
-    public int getJoinQuitMessagePlayerCount() {
-        return joinQuitMessagePlayerCount;
-    }
-
-    @Override
     public boolean hasJoinQuitMessagePlayerCount() {
-        return joinQuitMessagePlayerCount >= 0;
+        return getJoinQuitMessagePlayerCount() >= 0;
     }
 
     @Override

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -570,6 +570,7 @@ public class Settings implements net.ess3.api.ISettings {
         isCustomJoinMessage = !customJoinMessage.equals("none");
         customQuitMessage = _getCustomQuitMessage();
         isCustomQuitMessage = !customQuitMessage.equals("none");
+        joinQuitMessagePlayerCount = _getJoinQuitMessagePlayerCount();
         muteCommands = _getMuteCommands();
         spawnOnJoinGroups = _getSpawnOnJoinGroups();
         commandCooldowns = _getCommandCooldowns();
@@ -1283,6 +1284,22 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean isCustomQuitMessage() {
         return isCustomQuitMessage;
+    }
+
+    private int joinQuitMessagePlayerCount;
+
+    public int _getJoinQuitMessagePlayerCount() {
+        return config.getInt("hide-join-quit-messages-above", -1);
+    }
+
+    @Override
+    public int getJoinQuitMessagePlayerCount() {
+        return joinQuitMessagePlayerCount;
+    }
+
+    @Override
+    public boolean hasJoinQuitMessagePlayerCount() {
+        return joinQuitMessagePlayerCount >= 0;
     }
 
     @Override

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -484,10 +484,16 @@ send-info-after-death: false
 # In addition, people with essentials.silentjoin.vanish will be vanished on join.
 allow-silent-join-quit: false
 
-# You can set custom join and quit messages here. Set to "none" to use the default message or "" to disable the message entirely.
+# You can set custom join and quit messages here. Set this to "none" to use the default Minecraft message,
+# or set this to "" to hide the message entirely.
 # You may use color codes, {USERNAME} for the player's name, and {PLAYER} for the player's displayname.
 custom-join-message: "none"
 custom-quit-message: "none"
+
+# You can disable join and quit messages when the player count reaches a certain limit.
+# When the player count is below this number, join/quit messages will always be shown.
+# Set this to -1 to always show join and quit messages regardless of player count.
+hide-join-quit-messages-above: -1
 
 # Add worlds to this list, if you want to automatically disable god mode there.
 no-god-in-worlds:


### PR DESCRIPTION
Add "hide-join-quit-messages-above" option, which will hide join and quit messages above a certain player count.

Closes #3347.
