### PR TITLE
Fix issue with /remove skeletonhorse

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandremove.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandremove.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Mob;
 import com.earth2me.essentials.User;
 import org.bukkit.Chunk;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.entity.*;
@@ -126,8 +127,8 @@ public class Commandremove extends EssentialsCommand {
 
                 for (ToRemove toRemove : removeTypes) {
 
-                    // We should skip any TAMED animals unless we are specifially targetting them.
-                    if (e instanceof Tameable && ((Tameable) e).isTamed() && !removeTypes.contains(ToRemove.TAMED)) {
+                    // We should skip any animals tamed by players unless we are specifially targetting them.
+                    if (e instanceof Tameable && ((Tameable) e).isTamed() && (((Tameable) e).getOwner() instanceof Player || ((Tameable) e).getOwner() instanceof OfflinePlayer) && !removeTypes.contains(ToRemove.TAMED)) {
                         continue;
                     }
 


### PR DESCRIPTION
Fixes a problem where skeleton trapped horses cannot be killed in commands such as `/remove skeletonhorse` (or even `/remove all`) because they are tamed by non-player entities. There is a separate command for killing tamed entities, however this kills other player-owned entities which is undesirable.

This can be replicated easily by spawning some skeleton traps like so:
`/summon skeleton_horse ~ ~ ~ {SkeletonTrap:1}`
and then attempting to run `/killall skeletonhorse`.

After this small change, any tamed skeleton horses will be retained, but non-player-owned skeleton horses will be removed as appropriate.

Closes #3475.