### PR TITLE
Reformat trade log

### DIFF
--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -166,9 +166,9 @@ public interface ISettings extends IConf {
 
     boolean isEcoLogEnabled();
 
-		boolean isEcoLogUpdateEnabled();
-		
-		boolean isEcoLogPrettier();
+    boolean isEcoLogUpdateEnabled();
+
+    boolean isEcoLogPrettier();
 
     boolean realNamesOnList();
 

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -166,7 +166,9 @@ public interface ISettings extends IConf {
 
     boolean isEcoLogEnabled();
 
-    boolean isEcoLogUpdateEnabled();
+		boolean isEcoLogUpdateEnabled();
+		
+		boolean isEcoLogPrettier();
 
     boolean realNamesOnList();
 

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -59,7 +59,7 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean getRespawnAtHome() {
         return config.getBoolean("respawn-at-home", false);
-        }
+    }
         
     @Override
     public boolean getUpdateBedAtDaytime() {

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -60,7 +60,7 @@ public class Settings implements net.ess3.api.ISettings {
     public boolean getRespawnAtHome() {
         return config.getBoolean("respawn-at-home", false);
     }
-        
+
     @Override
     public boolean getUpdateBedAtDaytime() {
         return config.getBoolean("update-bed-at-daytime", true);

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -59,8 +59,8 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean getRespawnAtHome() {
         return config.getBoolean("respawn-at-home", false);
-    }
-
+        }
+        
     @Override
     public boolean getUpdateBedAtDaytime() {
         return config.getBoolean("update-bed-at-daytime", true);
@@ -808,6 +808,11 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean isEcoLogEnabled() {
         return economyLog;
+    }
+
+    @Override
+    public boolean isEcoLogPrettier() {
+        return config.getBoolean("prettier-economy-log", false);
     }
 
     public boolean _isEcoLogEnabled() {

--- a/Essentials/src/com/earth2me/essentials/Trade.java
+++ b/Essentials/src/com/earth2me/essentials/Trade.java
@@ -25,372 +25,352 @@ import java.util.logging.Logger;
 
 import static com.earth2me.essentials.I18n.tl;
 
-
 public class Trade {
-    private final transient String command;
-    private final transient Trade fallbackTrade;
-    private final transient BigDecimal money;
-    private final transient ItemStack itemStack;
-    private final transient Integer exp;
-    private final transient IEssentials ess;
+  private final transient String command;
+  private final transient Trade fallbackTrade;
+  private final transient BigDecimal money;
+  private final transient ItemStack itemStack;
+  private final transient Integer exp;
+  private final transient IEssentials ess;
 
+  public enum TradeType {
+    MONEY, EXP, ITEM
+  }
 
-    public enum TradeType {
-        MONEY,
-        EXP,
-        ITEM
+  public enum OverflowType {
+    ABORT, DROP, RETURN
+  }
+
+  public Trade(final String command, final IEssentials ess) {
+    this(command, null, null, null, null, ess);
+  }
+
+  public Trade(final String command, final Trade fallback, final IEssentials ess) {
+    this(command, fallback, null, null, null, ess);
+  }
+
+  @Deprecated
+  public Trade(final double money, final com.earth2me.essentials.IEssentials ess) {
+    this(null, null, BigDecimal.valueOf(money), null, null, (IEssentials) ess);
+  }
+
+  public Trade(final BigDecimal money, final IEssentials ess) {
+    this(null, null, money, null, null, ess);
+  }
+
+  public Trade(final ItemStack items, final IEssentials ess) {
+    this(null, null, null, items, null, ess);
+  }
+
+  public Trade(final int exp, final IEssentials ess) {
+    this(null, null, null, null, exp, ess);
+  }
+
+  private Trade(final String command, final Trade fallback, final BigDecimal money, final ItemStack item,
+      final Integer exp, final IEssentials ess) {
+    this.command = command;
+    this.fallbackTrade = fallback;
+    this.money = money;
+    this.itemStack = item;
+    this.exp = exp;
+    this.ess = ess;
+  }
+
+  public void isAffordableFor(final IUser user) throws ChargeException {
+    CompletableFuture<Boolean> future = new CompletableFuture<>();
+    isAffordableFor(user, future);
+    if (future.isCompletedExceptionally()) {
+      try {
+        future.get();
+      } catch (InterruptedException e) { // If this happens, we have bigger problems...
+        e.printStackTrace();
+      } catch (ExecutionException e) {
+        throw (ChargeException) e.getCause();
+      }
+    }
+  }
+
+  public void isAffordableFor(final IUser user, CompletableFuture<Boolean> future) {
+    if (ess.getSettings().isDebug()) {
+      ess.getLogger().log(Level.INFO, "checking if " + user.getName() + " can afford charge.");
     }
 
-
-    public enum OverflowType {
-        ABORT,
-        DROP,
-        RETURN
+    if (getMoney() != null && getMoney().signum() > 0 && !user.canAfford(getMoney())) {
+      future.completeExceptionally(
+          new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(getMoney(), ess))));
+      return;
     }
 
-    public Trade(final String command, final IEssentials ess) {
-        this(command, null, null, null, null, ess);
+    if (getItemStack() != null && !user.getBase().getInventory().containsAtLeast(itemStack, itemStack.getAmount())) {
+      future.completeExceptionally(
+          new ChargeException(tl("missingItems", getItemStack().getAmount(), ess.getItemDb().name(getItemStack()))));
+      return;
     }
 
-    public Trade(final String command, final Trade fallback, final IEssentials ess) {
-        this(command, fallback, null, null, null, ess);
+    BigDecimal money;
+    if (command != null && !command.isEmpty() && (money = getCommandCost(user)).signum() > 0
+        && !user.canAfford(money)) {
+      future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(money, ess))));
+      return;
     }
 
-    @Deprecated
-    public Trade(final double money, final com.earth2me.essentials.IEssentials ess) {
-        this(null, null, BigDecimal.valueOf(money), null, null, (IEssentials) ess);
+    if (exp != null && exp > 0 && SetExpFix.getTotalExperience(user.getBase()) < exp) {
+      future.completeExceptionally(new ChargeException(tl("notEnoughExperience")));
     }
+  }
 
-    public Trade(final BigDecimal money, final IEssentials ess) {
-        this(null, null, money, null, null, ess);
+  public boolean pay(final IUser user) throws MaxMoneyException {
+    return pay(user, OverflowType.ABORT) == null;
+  }
+
+  public Map<Integer, ItemStack> pay(final IUser user, final OverflowType type) throws MaxMoneyException {
+    if (getMoney() != null && getMoney().signum() > 0) {
+      if (ess.getSettings().isDebug()) {
+        ess.getLogger().log(Level.INFO, "paying user " + user.getName() + " via trade " + getMoney().toPlainString());
+      }
+      user.giveMoney(getMoney());
     }
+    if (getItemStack() != null) {
+      // This stores the would be overflow
+      Map<Integer, ItemStack> overFlow = InventoryWorkaround.addAllItems(user.getBase().getInventory(), getItemStack());
 
-    public Trade(final ItemStack items, final IEssentials ess) {
-        this(null, null, null, items, null, ess);
-    }
-
-    public Trade(final int exp, final IEssentials ess) {
-        this(null, null, null, null, exp, ess);
-    }
-
-    private Trade(final String command, final Trade fallback, final BigDecimal money, final ItemStack item, final Integer exp, final IEssentials ess) {
-        this.command = command;
-        this.fallbackTrade = fallback;
-        this.money = money;
-        this.itemStack = item;
-        this.exp = exp;
-        this.ess = ess;
-    }
-
-    public void isAffordableFor(final IUser user) throws ChargeException {
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        isAffordableFor(user, future);
-        if (future.isCompletedExceptionally()) {
-            try {
-                future.get();
-            } catch (InterruptedException e) { //If this happens, we have bigger problems...
-                e.printStackTrace();
-            } catch (ExecutionException e) {
-                throw (ChargeException) e.getCause();
-            }
-        }
-    }
-
-
-    public void isAffordableFor(final IUser user, CompletableFuture<Boolean> future) {
-        if (ess.getSettings().isDebug()) {
-            ess.getLogger().log(Level.INFO, "checking if " + user.getName() + " can afford charge.");
-        }
-
-        if (getMoney() != null && getMoney().signum() > 0 && !user.canAfford(getMoney())) {
-            future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(getMoney(), ess))));
-            return;
-        }
-
-        if (getItemStack() != null && !user.getBase().getInventory().containsAtLeast(itemStack, itemStack.getAmount())) {
-            future.completeExceptionally(new ChargeException(tl("missingItems", getItemStack().getAmount(), ess.getItemDb().name(getItemStack()))));
-            return;
-        }
-
-        BigDecimal money;
-        if (command != null && !command.isEmpty() && (money = getCommandCost(user)).signum() > 0 && !user.canAfford(money)) {
-            future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(money, ess))));
-            return;
-        }
-
-        if (exp != null && exp > 0 && SetExpFix.getTotalExperience(user.getBase()) < exp) {
-            future.completeExceptionally(new ChargeException(tl("notEnoughExperience")));
-        }
-    }
-
-    public boolean pay(final IUser user) throws MaxMoneyException {
-        return pay(user, OverflowType.ABORT) == null;
-    }
-
-    public Map<Integer, ItemStack> pay(final IUser user, final OverflowType type) throws MaxMoneyException {
-        if (getMoney() != null && getMoney().signum() > 0) {
+      if (overFlow != null) {
+        switch (type) {
+          case ABORT:
             if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO, "paying user " + user.getName() + " via trade " + getMoney().toPlainString());
+              ess.getLogger().log(Level.INFO, "abort paying " + user.getName() + " itemstack "
+                  + getItemStack().toString() + " due to lack of inventory space ");
             }
-            user.giveMoney(getMoney());
-        }
-        if (getItemStack() != null) {
-            // This stores the would be overflow
-            Map<Integer, ItemStack> overFlow = InventoryWorkaround.addAllItems(user.getBase().getInventory(), getItemStack());
 
-            if (overFlow != null) {
-                switch (type) {
-                    case ABORT:
-                        if (ess.getSettings().isDebug()) {
-                            ess.getLogger().log(Level.INFO, "abort paying " + user.getName() + " itemstack " + getItemStack().toString() + " due to lack of inventory space ");
-                        }
+            return overFlow;
 
-                        return overFlow;
-
-                    case RETURN:
-                        // Pay the user the items, and return overflow
-                        final Map<Integer, ItemStack> returnStack = InventoryWorkaround.addItems(user.getBase().getInventory(), getItemStack());
-                        user.getBase().updateInventory();
-
-                        if (ess.getSettings().isDebug()) {
-                            ess.getLogger().log(Level.INFO, "paying " + user.getName() + " partial itemstack " + getItemStack().toString() + " with overflow " + returnStack.get(0).toString());
-                        }
-
-                        return returnStack;
-
-                    case DROP:
-                        // Pay the users the items directly, and drop the rest, will always return no overflow.
-                        final Map<Integer, ItemStack> leftOver = InventoryWorkaround.addItems(user.getBase().getInventory(), getItemStack());
-                        final Location loc = user.getBase().getLocation();
-                        for (ItemStack loStack : leftOver.values()) {
-                            final int maxStackSize = loStack.getType().getMaxStackSize();
-                            final int stacks = loStack.getAmount() / maxStackSize;
-                            final int leftover = loStack.getAmount() % maxStackSize;
-                            final Item[] itemStacks = new Item[stacks + (leftover > 0 ? 1 : 0)];
-                            for (int i = 0; i < stacks; i++) {
-                                final ItemStack stack = loStack.clone();
-                                stack.setAmount(maxStackSize);
-                                itemStacks[i] = loc.getWorld().dropItem(loc, stack);
-                            }
-                            if (leftover > 0) {
-                                final ItemStack stack = loStack.clone();
-                                stack.setAmount(leftover);
-                                itemStacks[stacks] = loc.getWorld().dropItem(loc, stack);
-                            }
-                        }
-                        if (ess.getSettings().isDebug()) {
-                            ess.getLogger().log(Level.INFO, "paying " + user.getName() + " partial itemstack " + getItemStack().toString() + " and dropping overflow " + leftOver.get(0).toString());
-                        }
-                }
-            } else if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO, "paying " + user.getName() + " itemstack " + getItemStack().toString());
-            }
+          case RETURN:
+            // Pay the user the items, and return overflow
+            final Map<Integer, ItemStack> returnStack = InventoryWorkaround.addItems(user.getBase().getInventory(),
+                getItemStack());
             user.getBase().updateInventory();
-        }
-        if (getExperience() != null) {
-            SetExpFix.setTotalExperience(user.getBase(), SetExpFix.getTotalExperience(user.getBase()) + getExperience());
-        }
-        return null;
-    }
-
-    public void charge(final IUser user) throws ChargeException {
-        CompletableFuture<Boolean> future = new CompletableFuture<>();
-        charge(user, future);
-        if (future.isCompletedExceptionally()) {
-            try {
-                future.get();
-            } catch (InterruptedException e) { //If this happens, we have bigger problems...
-                e.printStackTrace();
-            } catch (ExecutionException e) {
-                throw (ChargeException) e.getCause();
-            }
-        }
-    }
-
-    public void charge(final IUser user, CompletableFuture<Boolean> future) {
-        if (ess.getSettings().isDebug()) {
-            ess.getLogger().log(Level.INFO, "attempting to charge user " + user.getName());
-        }
-        if (getMoney() != null) {
-            if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO, "charging user " + user.getName() + " money " + getMoney().toPlainString());
-            }
-            if (!user.canAfford(getMoney()) && getMoney().signum() > 0) {
-                future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(getMoney(), ess))));
-                return;
-            }
-            user.takeMoney(getMoney());
-        }
-        if (getItemStack() != null) {
-            if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO, "charging user " + user.getName() + " itemstack " + getItemStack().toString());
-            }
-            if (!user.getBase().getInventory().containsAtLeast(getItemStack(), getItemStack().getAmount())) {
-                future.completeExceptionally(new ChargeException(tl("missingItems", getItemStack().getAmount(), getItemStack().getType().toString().toLowerCase(Locale.ENGLISH).replace("_", " "))));
-                return;
-            }
-            user.getBase().getInventory().removeItem(getItemStack());
-            user.getBase().updateInventory();
-        }
-        if (command != null) {
-            final BigDecimal cost = getCommandCost(user);
-            if (!user.canAfford(cost) && cost.signum() > 0) {
-                future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(cost, ess))));
-                return;
-            }
-            user.takeMoney(cost);
-        }
-        if (getExperience() != null) {
-            if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO, "charging user " + user.getName() + " exp " + getExperience());
-            }
-            final int experience = SetExpFix.getTotalExperience(user.getBase());
-            if (experience < getExperience() && getExperience() > 0) {
-                future.completeExceptionally(new ChargeException(tl("notEnoughExperience")));
-                return;
-            }
-            SetExpFix.setTotalExperience(user.getBase(), experience - getExperience());
-        }
-        if (ess.getSettings().isDebug()) {
-            ess.getLogger().log(Level.INFO, "charge user " + user.getName() + " completed");
-        }
-    }
-
-    public BigDecimal getMoney() {
-        return money;
-    }
-
-    public ItemStack getItemStack() {
-        return itemStack;
-    }
-
-    public Integer getExperience() {
-        return exp;
-    }
-
-    public TradeType getType() {
-        if (getExperience() != null) {
-            return TradeType.EXP;
-        }
-
-        if (getItemStack() != null) {
-            return TradeType.ITEM;
-        }
-
-        return TradeType.MONEY;
-    }
-
-    public BigDecimal getCommandCost(final IUser user) {
-        BigDecimal cost = BigDecimal.ZERO;
-        if (command != null && !command.isEmpty()) {
-            cost = ess.getSettings().getCommandCost(command.charAt(0) == '/' ? command.substring(1) : command);
-            if (cost.signum() == 0 && fallbackTrade != null) {
-                cost = fallbackTrade.getCommandCost(user);
-            }
 
             if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO, "calculated command (" + command + ") cost for " + user.getName() + " as " + cost);
+              ess.getLogger().log(Level.INFO, "paying " + user.getName() + " partial itemstack "
+                  + getItemStack().toString() + " with overflow " + returnStack.get(0).toString());
+            }
+
+            return returnStack;
+
+          case DROP:
+            // Pay the users the items directly, and drop the rest, will always return no
+            // overflow.
+            final Map<Integer, ItemStack> leftOver = InventoryWorkaround.addItems(user.getBase().getInventory(),
+                getItemStack());
+            final Location loc = user.getBase().getLocation();
+            for (ItemStack loStack : leftOver.values()) {
+              final int maxStackSize = loStack.getType().getMaxStackSize();
+              final int stacks = loStack.getAmount() / maxStackSize;
+              final int leftover = loStack.getAmount() % maxStackSize;
+              final Item[] itemStacks = new Item[stacks + (leftover > 0 ? 1 : 0)];
+              for (int i = 0; i < stacks; i++) {
+                final ItemStack stack = loStack.clone();
+                stack.setAmount(maxStackSize);
+                itemStacks[i] = loc.getWorld().dropItem(loc, stack);
+              }
+              if (leftover > 0) {
+                final ItemStack stack = loStack.clone();
+                stack.setAmount(leftover);
+                itemStacks[stacks] = loc.getWorld().dropItem(loc, stack);
+              }
+            }
+            if (ess.getSettings().isDebug()) {
+              ess.getLogger().log(Level.INFO, "paying " + user.getName() + " partial itemstack "
+                  + getItemStack().toString() + " and dropping overflow " + leftOver.get(0).toString());
             }
         }
-        if (cost.signum() != 0 && (user.isAuthorized("essentials.nocommandcost.all") || user.isAuthorized("essentials.nocommandcost." + command))) {
-            return BigDecimal.ZERO;
-        }
-        return cost;
+      } else if (ess.getSettings().isDebug()) {
+        ess.getLogger().log(Level.INFO, "paying " + user.getName() + " itemstack " + getItemStack().toString());
+      }
+      user.getBase().updateInventory();
+    }
+    if (getExperience() != null) {
+      SetExpFix.setTotalExperience(user.getBase(), SetExpFix.getTotalExperience(user.getBase()) + getExperience());
+    }
+    return null;
+  }
+
+  public void charge(final IUser user) throws ChargeException {
+    CompletableFuture<Boolean> future = new CompletableFuture<>();
+    charge(user, future);
+    if (future.isCompletedExceptionally()) {
+      try {
+        future.get();
+      } catch (InterruptedException e) { // If this happens, we have bigger problems...
+        e.printStackTrace();
+      } catch (ExecutionException e) {
+        throw (ChargeException) e.getCause();
+      }
+    }
+  }
+
+  public void charge(final IUser user, CompletableFuture<Boolean> future) {
+    if (ess.getSettings().isDebug()) {
+      ess.getLogger().log(Level.INFO, "attempting to charge user " + user.getName());
+    }
+    if (getMoney() != null) {
+      if (ess.getSettings().isDebug()) {
+        ess.getLogger().log(Level.INFO, "charging user " + user.getName() + " money " + getMoney().toPlainString());
+      }
+      if (!user.canAfford(getMoney()) && getMoney().signum() > 0) {
+        future.completeExceptionally(
+            new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(getMoney(), ess))));
+        return;
+      }
+      user.takeMoney(getMoney());
+    }
+    if (getItemStack() != null) {
+      if (ess.getSettings().isDebug()) {
+        ess.getLogger().log(Level.INFO, "charging user " + user.getName() + " itemstack " + getItemStack().toString());
+      }
+      if (!user.getBase().getInventory().containsAtLeast(getItemStack(), getItemStack().getAmount())) {
+        future.completeExceptionally(new ChargeException(tl("missingItems", getItemStack().getAmount(),
+            getItemStack().getType().toString().toLowerCase(Locale.ENGLISH).replace("_", " "))));
+        return;
+      }
+      user.getBase().getInventory().removeItem(getItemStack());
+      user.getBase().updateInventory();
+    }
+    if (command != null) {
+      final BigDecimal cost = getCommandCost(user);
+      if (!user.canAfford(cost) && cost.signum() > 0) {
+        future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(cost, ess))));
+        return;
+      }
+      user.takeMoney(cost);
+    }
+    if (getExperience() != null) {
+      if (ess.getSettings().isDebug()) {
+        ess.getLogger().log(Level.INFO, "charging user " + user.getName() + " exp " + getExperience());
+      }
+      final int experience = SetExpFix.getTotalExperience(user.getBase());
+      if (experience < getExperience() && getExperience() > 0) {
+        future.completeExceptionally(new ChargeException(tl("notEnoughExperience")));
+        return;
+      }
+      SetExpFix.setTotalExperience(user.getBase(), experience - getExperience());
+    }
+    if (ess.getSettings().isDebug()) {
+      ess.getLogger().log(Level.INFO, "charge user " + user.getName() + " completed");
+    }
+  }
+
+  public BigDecimal getMoney() {
+    return money;
+  }
+
+  public ItemStack getItemStack() {
+    return itemStack;
+  }
+
+  public Integer getExperience() {
+    return exp;
+  }
+
+  public TradeType getType() {
+    if (getExperience() != null) {
+      return TradeType.EXP;
     }
 
-    private static FileWriter fw = null;
-
-    public static void log(String type, String subtype, String event, String sender, Trade charge, String receiver, Trade pay, Location loc, IEssentials ess) {
-        //isEcoLogUpdateEnabled() - This refers to log entries with no location, ie API updates #EasterEgg
-        //isEcoLogEnabled() - This refers to log entries with with location, ie /pay /sell and eco signs.
-
-        if ((loc == null && !ess.getSettings().isEcoLogUpdateEnabled()) || (loc != null && !ess.getSettings().isEcoLogEnabled())) {
-            return;
-        }
-        if (fw == null) {
-            try {
-                fw = new FileWriter(new File(ess.getDataFolder(), "trade.log"), true);
-            } catch (IOException ex) {
-                Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
-            }
-        }
-        StringBuilder sb = new StringBuilder();
-        sb.append(type).append(",").append(subtype).append(",").append(event).append(",\"");
-        sb.append(DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL).format(new Date()));
-        sb.append("\",\"");
-        if (sender != null) {
-            sb.append(sender);
-        }
-        sb.append("\",");
-        if (charge == null) {
-            sb.append("\"\",\"\",\"\"");
-        } else {
-            if (charge.getItemStack() != null) {
-                sb.append(charge.getItemStack().getAmount()).append(",");
-                sb.append(charge.getItemStack().getType().toString()).append(",");
-                sb.append(charge.getItemStack().getDurability());
-            }
-            if (charge.getMoney() != null) {
-                sb.append(charge.getMoney()).append(",");
-                sb.append("money").append(",");
-                sb.append(ess.getSettings().getCurrencySymbol());
-            }
-            if (charge.getExperience() != null) {
-                sb.append(charge.getExperience()).append(",");
-                sb.append("exp").append(",");
-                sb.append("\"\"");
-            }
-        }
-        sb.append(",\"");
-        if (receiver != null) {
-            sb.append(receiver);
-        }
-        sb.append("\",");
-        if (pay == null) {
-            sb.append("\"\",\"\",\"\"");
-        } else {
-            if (pay.getItemStack() != null) {
-                sb.append(pay.getItemStack().getAmount()).append(",");
-                sb.append(pay.getItemStack().getType().toString()).append(",");
-                sb.append(pay.getItemStack().getDurability());
-            }
-            if (pay.getMoney() != null) {
-                sb.append(pay.getMoney()).append(",");
-                sb.append("money").append(",");
-                sb.append(ess.getSettings().getCurrencySymbol());
-            }
-            if (pay.getExperience() != null) {
-                sb.append(pay.getExperience()).append(",");
-                sb.append("exp").append(",");
-                sb.append("\"\"");
-            }
-        }
-        if (loc == null) {
-            sb.append(",\"\",\"\",\"\",\"\"");
-        } else {
-            sb.append(",\"");
-            sb.append(loc.getWorld().getName()).append("\",");
-            sb.append(loc.getBlockX()).append(",");
-            sb.append(loc.getBlockY()).append(",");
-            sb.append(loc.getBlockZ()).append(",");
-        }
-        sb.append("\n");
-        try {
-            fw.write(sb.toString());
-            fw.flush();
-        } catch (IOException ex) {
-            Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
-        }
+    if (getItemStack() != null) {
+      return TradeType.ITEM;
     }
 
-    public static void closeLog() {
-        if (fw != null) {
-            try {
-                fw.close();
-            } catch (IOException ex) {
-                Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
-            }
-            fw = null;
-        }
+    return TradeType.MONEY;
+  }
+
+  public BigDecimal getCommandCost(final IUser user) {
+    BigDecimal cost = BigDecimal.ZERO;
+    if (command != null && !command.isEmpty()) {
+      cost = ess.getSettings().getCommandCost(command.charAt(0) == '/' ? command.substring(1) : command);
+      if (cost.signum() == 0 && fallbackTrade != null) {
+        cost = fallbackTrade.getCommandCost(user);
+      }
+
+      if (ess.getSettings().isDebug()) {
+        ess.getLogger().log(Level.INFO,
+            "calculated command (" + command + ") cost for " + user.getName() + " as " + cost);
+      }
     }
+    if (cost.signum() != 0 && (user.isAuthorized("essentials.nocommandcost.all")
+        || user.isAuthorized("essentials.nocommandcost." + command))) {
+      return BigDecimal.ZERO;
+    }
+    return cost;
+  }
+
+  private static FileWriter fw = null;
+
+  public static void log(String type, String subtype, String event, String sender, Trade charge, String receiver,
+      Trade pay, Location loc, IEssentials ess) {
+
+    // isEcoLogUpdateEnabled() - This refers to log entries with no location, ie API
+    // updates #EasterEgg
+    // isEcoLogEnabled() - This refers to log entries with with location, ie /pay
+    // /sell and eco signs.
+    // Check if logging is enabled
+    if ((loc == null && !ess.getSettings().isEcoLogUpdateEnabled())
+        || (loc != null && !ess.getSettings().isEcoLogEnabled()))
+      return;
+
+    // Init the file writer
+    if (fw == null) {
+      try {
+        fw = new FileWriter(new File(ess.getDataFolder(), "trade.log"), true);
+      } catch (IOException ex) {
+        Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
+      }
+    }
+
+    // [Time] [Type:Subtype:Event]
+    String logFormat = "[%s] %s:%s:%s send:%s/rec:%s/pay:%s/charge:%s/loc:%s \n";
+
+    String time = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL).format(new Date());
+
+    String safeSender = sender != null ? sender : "??";
+    String safeReceiver = receiver != null ? receiver : "??";
+
+    String locationString = loc != null
+        ? String.format("%s:%d,%d,%d", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ())
+        : "??";
+
+    String log = String.format(logFormat, time, type, subtype, event, safeSender, safeReceiver, formatTrade(pay, ess),
+        formatTrade(charge, ess), locationString);
+
+    try {
+      fw.write(log);
+      fw.flush();
+    } catch (IOException ex) {
+      Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
+    }
+  }
+
+  private static String formatTrade(Trade trade, IEssentials ess) {
+    if (trade == null)
+      return "??";
+    else if (trade.getItemStack() != null)
+      return String.format("(amt:%d,type:%s)", trade.getItemStack().getAmount(), trade.getItemStack().getType().name());
+    else if (trade.getMoney() != null)
+      return String.format("(amt:%f,money,cur:%s)", trade.getMoney(), ess.getSettings().getCurrencySymbol());
+    else if (trade.getExperience() != null)
+      return String.format("(amt:%d, exp)", trade.getExperience());
+    else
+      return "??";
+  }
+
+  public static void closeLog() {
+    if (fw != null) {
+      try {
+        fw.close();
+      } catch (IOException ex) {
+        Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
+      }
+      fw = null;
+    }
+  }
 }

--- a/Essentials/src/com/earth2me/essentials/Trade.java
+++ b/Essentials/src/com/earth2me/essentials/Trade.java
@@ -420,7 +420,7 @@ public class Trade {
             return "??";
         else if (trade.getItemStack() != null)
             return String.format("(amt:%d,type:%s)", trade.getItemStack().getAmount(),
-                    trade.getItemStack().getType().name());
+                trade.getItemStack().getType().name());
         else if (trade.getMoney() != null)
             return String.format("(amt:%f,money,cur:%s)", trade.getMoney(), ess.getSettings().getCurrencySymbol());
         else if (trade.getExperience() != null)

--- a/Essentials/src/com/earth2me/essentials/Trade.java
+++ b/Essentials/src/com/earth2me/essentials/Trade.java
@@ -300,17 +300,13 @@ public class Trade {
 
     private static FileWriter fw = null;
 
-    public static void log(String type, String subtype, String event, String sender, Trade charge, String receiver,
-            Trade pay, Location loc, IEssentials ess) {
+    public static void log(String type, String subtype, String event, String sender, Trade charge, String receiver, Trade pay, Location loc, IEssentials ess) {
+        //isEcoLogUpdateEnabled() - This refers to log entries with no location, ie API updates #EasterEgg
+        //isEcoLogEnabled() - This refers to log entries with with location, ie /pay /sell and eco signs.
 
-        // isEcoLogUpdateEnabled() - This refers to log entries with no location, ie API
-        // updates #EasterEgg
-        // isEcoLogEnabled() - This refers to log entries with with location, ie /pay
-        // /sell and eco signs.
-        // Check if logging is enabled
-        if ((loc == null && !ess.getSettings().isEcoLogUpdateEnabled())
-                || (loc != null && !ess.getSettings().isEcoLogEnabled()))
+        if ((loc == null && !ess.getSettings().isEcoLogUpdateEnabled()) || (loc != null && !ess.getSettings().isEcoLogEnabled())) {
             return;
+        }
 
         // Init the file writer
         if (fw == null) {

--- a/Essentials/src/com/earth2me/essentials/Trade.java
+++ b/Essentials/src/com/earth2me/essentials/Trade.java
@@ -369,7 +369,7 @@ public class Trade {
         else if (trade.getMoney() != null)
             return String.format("(amt:%f,money,cur:%s)", trade.getMoney(), ess.getSettings().getCurrencySymbol());
         else if (trade.getExperience() != null)
-            return String.format("(amt:%d, exp)", trade.getExperience());
+            return String.format("(amt:%d,exp)", trade.getExperience());
         else
             return "??";
     }

--- a/Essentials/src/com/earth2me/essentials/Trade.java
+++ b/Essentials/src/com/earth2me/essentials/Trade.java
@@ -321,28 +321,98 @@ public class Trade {
             }
         }
 
-        // [Time] [Type:Subtype:Event]
-        String logFormat = "[%s] %s:%s:%s send:%s/rec:%s/pay:%s/charge:%s/loc:%s \n";
+        if (ess.getSettings().isEcoLogPrettier()) {
+            String logFormat = "[%s] %s:%s:%s send:%s/rec:%s/pay:%s/charge:%s/loc:%s \n";
 
-        String time = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL).format(new Date());
+            String time = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL).format(new Date());
 
-        String safeSender = sender != null ? sender : "??";
-        String safeReceiver = receiver != null ? receiver : "??";
+            String safeSender = sender != null ? sender : "??";
+            String safeReceiver = receiver != null ? receiver : "??";
 
-        String locationString = loc != null
+            String locationString = loc != null
                 ? String.format("%s:%d,%d,%d", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(),
                         loc.getBlockZ())
                 : "??";
 
-        String log = String.format(logFormat, time, type, subtype, event, safeSender, safeReceiver,
+            String log = String.format(logFormat, time, type, subtype, event, safeSender, safeReceiver,
                 formatTrade(pay, ess), formatTrade(charge, ess), locationString);
 
-        try {
-            fw.write(log);
-            fw.flush();
-        } catch (IOException ex) {
-            Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
+            try {
+                fw.write(log);
+                fw.flush();
+            } catch (IOException ex) {
+                Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
+            }
+        } else { // Use legacy eco log formatting
+            StringBuilder sb = new StringBuilder();
+            sb.append(type).append(",").append(subtype).append(",").append(event).append(",\"");
+            sb.append(DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL).format(new Date()));
+            sb.append("\",\"");
+            if (sender != null) {
+                sb.append(sender);
+            }
+            sb.append("\",");
+            if (charge == null) {
+                sb.append("\"\",\"\",\"\"");
+            } else {
+                if (charge.getItemStack() != null) {
+                    sb.append(charge.getItemStack().getAmount()).append(",");
+                    sb.append(charge.getItemStack().getType().toString()).append(",");
+                    sb.append(charge.getItemStack().getDurability());
+                }
+                if (charge.getMoney() != null) {
+                    sb.append(charge.getMoney()).append(",");
+                    sb.append("money").append(",");
+                    sb.append(ess.getSettings().getCurrencySymbol());
+                }
+                if (charge.getExperience() != null) {
+                    sb.append(charge.getExperience()).append(",");
+                    sb.append("exp").append(",");
+                    sb.append("\"\"");
+                }
+            }
+            sb.append(",\"");
+            if (receiver != null) {
+                sb.append(receiver);
+            }
+            sb.append("\",");
+            if (pay == null) {
+                sb.append("\"\",\"\",\"\"");
+            } else {
+                if (pay.getItemStack() != null) {
+                    sb.append(pay.getItemStack().getAmount()).append(",");
+                    sb.append(pay.getItemStack().getType().toString()).append(",");
+                    sb.append(pay.getItemStack().getDurability());
+                }
+                if (pay.getMoney() != null) {
+                    sb.append(pay.getMoney()).append(",");
+                    sb.append("money").append(",");
+                    sb.append(ess.getSettings().getCurrencySymbol());
+                }
+                if (pay.getExperience() != null) {
+                    sb.append(pay.getExperience()).append(",");
+                    sb.append("exp").append(",");
+                    sb.append("\"\"");
+                }
+            }
+            if (loc == null) {
+                sb.append(",\"\",\"\",\"\",\"\"");
+            } else {
+                sb.append(",\"");
+                sb.append(loc.getWorld().getName()).append("\",");
+                sb.append(loc.getBlockX()).append(",");
+                sb.append(loc.getBlockY()).append(",");
+                sb.append(loc.getBlockZ()).append(",");
+            }
+            sb.append("\n");
+            try {
+                fw.write(sb.toString());
+                fw.flush();
+            } catch (IOException ex) {
+                Logger.getLogger("Essentials").log(Level.SEVERE, null, ex);
+            }
         }
+
     }
 
     private static String formatTrade(Trade trade, IEssentials ess) {

--- a/Essentials/src/com/earth2me/essentials/Trade.java
+++ b/Essentials/src/com/earth2me/essentials/Trade.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 
 import static com.earth2me.essentials.I18n.tl;
 
+
 public class Trade {
     private final transient String command;
     private final transient Trade fallbackTrade;
@@ -33,12 +34,18 @@ public class Trade {
     private final transient Integer exp;
     private final transient IEssentials ess;
 
+
     public enum TradeType {
-        MONEY, EXP, ITEM
+        MONEY,
+        EXP,
+        ITEM
     }
 
+
     public enum OverflowType {
-        ABORT, DROP, RETURN
+        ABORT,
+        DROP,
+        RETURN
     }
 
     public Trade(final String command, final IEssentials ess) {
@@ -66,8 +73,7 @@ public class Trade {
         this(null, null, null, null, exp, ess);
     }
 
-    private Trade(final String command, final Trade fallback, final BigDecimal money, final ItemStack item,
-            final Integer exp, final IEssentials ess) {
+    private Trade(final String command, final Trade fallback, final BigDecimal money, final ItemStack item, final Integer exp, final IEssentials ess) {
         this.command = command;
         this.fallbackTrade = fallback;
         this.money = money;
@@ -82,7 +88,7 @@ public class Trade {
         if (future.isCompletedExceptionally()) {
             try {
                 future.get();
-            } catch (InterruptedException e) { // If this happens, we have bigger problems...
+            } catch (InterruptedException e) { //If this happens, we have bigger problems...
                 e.printStackTrace();
             } catch (ExecutionException e) {
                 throw (ChargeException) e.getCause();
@@ -90,29 +96,25 @@ public class Trade {
         }
     }
 
+
     public void isAffordableFor(final IUser user, CompletableFuture<Boolean> future) {
         if (ess.getSettings().isDebug()) {
             ess.getLogger().log(Level.INFO, "checking if " + user.getName() + " can afford charge.");
         }
 
         if (getMoney() != null && getMoney().signum() > 0 && !user.canAfford(getMoney())) {
-            future.completeExceptionally(
-                    new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(getMoney(), ess))));
+            future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(getMoney(), ess))));
             return;
         }
 
-        if (getItemStack() != null
-                && !user.getBase().getInventory().containsAtLeast(itemStack, itemStack.getAmount())) {
-            future.completeExceptionally(new ChargeException(
-                    tl("missingItems", getItemStack().getAmount(), ess.getItemDb().name(getItemStack()))));
+        if (getItemStack() != null && !user.getBase().getInventory().containsAtLeast(itemStack, itemStack.getAmount())) {
+            future.completeExceptionally(new ChargeException(tl("missingItems", getItemStack().getAmount(), ess.getItemDb().name(getItemStack()))));
             return;
         }
 
         BigDecimal money;
-        if (command != null && !command.isEmpty() && (money = getCommandCost(user)).signum() > 0
-                && !user.canAfford(money)) {
-            future.completeExceptionally(
-                    new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(money, ess))));
+        if (command != null && !command.isEmpty() && (money = getCommandCost(user)).signum() > 0 && !user.canAfford(money)) {
+            future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(money, ess))));
             return;
         }
 
@@ -128,44 +130,37 @@ public class Trade {
     public Map<Integer, ItemStack> pay(final IUser user, final OverflowType type) throws MaxMoneyException {
         if (getMoney() != null && getMoney().signum() > 0) {
             if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO,
-                        "paying user " + user.getName() + " via trade " + getMoney().toPlainString());
+                ess.getLogger().log(Level.INFO, "paying user " + user.getName() + " via trade " + getMoney().toPlainString());
             }
             user.giveMoney(getMoney());
         }
         if (getItemStack() != null) {
             // This stores the would be overflow
-            Map<Integer, ItemStack> overFlow = InventoryWorkaround.addAllItems(user.getBase().getInventory(),
-                    getItemStack());
+            Map<Integer, ItemStack> overFlow = InventoryWorkaround.addAllItems(user.getBase().getInventory(), getItemStack());
 
             if (overFlow != null) {
                 switch (type) {
                     case ABORT:
                         if (ess.getSettings().isDebug()) {
-                            ess.getLogger().log(Level.INFO, "abort paying " + user.getName() + " itemstack "
-                                    + getItemStack().toString() + " due to lack of inventory space ");
+                            ess.getLogger().log(Level.INFO, "abort paying " + user.getName() + " itemstack " + getItemStack().toString() + " due to lack of inventory space ");
                         }
 
                         return overFlow;
 
                     case RETURN:
                         // Pay the user the items, and return overflow
-                        final Map<Integer, ItemStack> returnStack = InventoryWorkaround
-                                .addItems(user.getBase().getInventory(), getItemStack());
+                        final Map<Integer, ItemStack> returnStack = InventoryWorkaround.addItems(user.getBase().getInventory(), getItemStack());
                         user.getBase().updateInventory();
 
                         if (ess.getSettings().isDebug()) {
-                            ess.getLogger().log(Level.INFO, "paying " + user.getName() + " partial itemstack "
-                                    + getItemStack().toString() + " with overflow " + returnStack.get(0).toString());
+                            ess.getLogger().log(Level.INFO, "paying " + user.getName() + " partial itemstack " + getItemStack().toString() + " with overflow " + returnStack.get(0).toString());
                         }
 
                         return returnStack;
 
                     case DROP:
-                        // Pay the users the items directly, and drop the rest, will always return no
-                        // overflow.
-                        final Map<Integer, ItemStack> leftOver = InventoryWorkaround
-                                .addItems(user.getBase().getInventory(), getItemStack());
+                        // Pay the users the items directly, and drop the rest, will always return no overflow.
+                        final Map<Integer, ItemStack> leftOver = InventoryWorkaround.addItems(user.getBase().getInventory(), getItemStack());
                         final Location loc = user.getBase().getLocation();
                         for (ItemStack loStack : leftOver.values()) {
                             final int maxStackSize = loStack.getType().getMaxStackSize();
@@ -184,9 +179,7 @@ public class Trade {
                             }
                         }
                         if (ess.getSettings().isDebug()) {
-                            ess.getLogger().log(Level.INFO,
-                                    "paying " + user.getName() + " partial itemstack " + getItemStack().toString()
-                                            + " and dropping overflow " + leftOver.get(0).toString());
+                            ess.getLogger().log(Level.INFO, "paying " + user.getName() + " partial itemstack " + getItemStack().toString() + " and dropping overflow " + leftOver.get(0).toString());
                         }
                 }
             } else if (ess.getSettings().isDebug()) {
@@ -195,8 +188,7 @@ public class Trade {
             user.getBase().updateInventory();
         }
         if (getExperience() != null) {
-            SetExpFix.setTotalExperience(user.getBase(),
-                    SetExpFix.getTotalExperience(user.getBase()) + getExperience());
+            SetExpFix.setTotalExperience(user.getBase(), SetExpFix.getTotalExperience(user.getBase()) + getExperience());
         }
         return null;
     }
@@ -207,7 +199,7 @@ public class Trade {
         if (future.isCompletedExceptionally()) {
             try {
                 future.get();
-            } catch (InterruptedException e) { // If this happens, we have bigger problems...
+            } catch (InterruptedException e) { //If this happens, we have bigger problems...
                 e.printStackTrace();
             } catch (ExecutionException e) {
                 throw (ChargeException) e.getCause();
@@ -221,24 +213,20 @@ public class Trade {
         }
         if (getMoney() != null) {
             if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO,
-                        "charging user " + user.getName() + " money " + getMoney().toPlainString());
+                ess.getLogger().log(Level.INFO, "charging user " + user.getName() + " money " + getMoney().toPlainString());
             }
             if (!user.canAfford(getMoney()) && getMoney().signum() > 0) {
-                future.completeExceptionally(
-                        new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(getMoney(), ess))));
+                future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(getMoney(), ess))));
                 return;
             }
             user.takeMoney(getMoney());
         }
         if (getItemStack() != null) {
             if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO,
-                        "charging user " + user.getName() + " itemstack " + getItemStack().toString());
+                ess.getLogger().log(Level.INFO, "charging user " + user.getName() + " itemstack " + getItemStack().toString());
             }
             if (!user.getBase().getInventory().containsAtLeast(getItemStack(), getItemStack().getAmount())) {
-                future.completeExceptionally(new ChargeException(tl("missingItems", getItemStack().getAmount(),
-                        getItemStack().getType().toString().toLowerCase(Locale.ENGLISH).replace("_", " "))));
+                future.completeExceptionally(new ChargeException(tl("missingItems", getItemStack().getAmount(), getItemStack().getType().toString().toLowerCase(Locale.ENGLISH).replace("_", " "))));
                 return;
             }
             user.getBase().getInventory().removeItem(getItemStack());
@@ -247,8 +235,7 @@ public class Trade {
         if (command != null) {
             final BigDecimal cost = getCommandCost(user);
             if (!user.canAfford(cost) && cost.signum() > 0) {
-                future.completeExceptionally(
-                        new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(cost, ess))));
+                future.completeExceptionally(new ChargeException(tl("notEnoughMoney", NumberUtil.displayCurrency(cost, ess))));
                 return;
             }
             user.takeMoney(cost);
@@ -302,12 +289,10 @@ public class Trade {
             }
 
             if (ess.getSettings().isDebug()) {
-                ess.getLogger().log(Level.INFO,
-                        "calculated command (" + command + ") cost for " + user.getName() + " as " + cost);
+                ess.getLogger().log(Level.INFO, "calculated command (" + command + ") cost for " + user.getName() + " as " + cost);
             }
         }
-        if (cost.signum() != 0 && (user.isAuthorized("essentials.nocommandcost.all")
-                || user.isAuthorized("essentials.nocommandcost." + command))) {
+        if (cost.signum() != 0 && (user.isAuthorized("essentials.nocommandcost.all") || user.isAuthorized("essentials.nocommandcost." + command))) {
             return BigDecimal.ZERO;
         }
         return cost;

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -726,7 +726,7 @@ min-money: -10000
 # Enable this to log all interactions with trade/buy/sell signs and sell command.
 economy-log-enabled: false
 
-# Enable this to make the econmy log favor human readable messages instead of parseable ones.
+# Enable this to make the economy log favor human readable messages instead of parseable ones.
 # Requires economy-log-enabled to be set to true.
 prettier-economy-log: false
 

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -726,7 +726,8 @@ min-money: -10000
 # Enable this to log all interactions with trade/buy/sell signs and sell command.
 economy-log-enabled: false
 
-# Enable this for more readable economy logs (option above must be true)
+# Enable this to make the econmy log favor human readable messages instead of parseable ones.
+# Requires economy-log-enabled to be set to true.
 prettier-economy-log: false
 
 # Enable this to also log all transactions from other plugins through Vault.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -726,6 +726,9 @@ min-money: -10000
 # Enable this to log all interactions with trade/buy/sell signs and sell command.
 economy-log-enabled: false
 
+# Enable this for more readable economy logs (option above must be true)
+prettier-economy-log: false
+
 # Enable this to also log all transactions from other plugins through Vault.
 # This can cause the economy log to fill up quickly so should only be enabled for testing purposes!
 economy-log-update-enabled: false


### PR DESCRIPTION
This PR makes trade logs (`trade.log`) easier to understand. It doesn't change the arguments for the Trade#log method.

It also makes it much easier to read the code for trade logs and update the log format in the future.