### PR TITLE
Corrected player nickname event ordering

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandnick.java
@@ -114,7 +114,7 @@ public class Commandnick extends EssentialsLoopCommand {
 
     private void setNickname(final Server server, final CommandSource sender, final User target, final String nickname) {
         final User controller = sender.isPlayer() ? ess.getUser(sender.getPlayer()) : null;
-        final NickChangeEvent nickEvent = new NickChangeEvent(controller, target, nickname);
+        final NickChangeEvent nickEvent = new NickChangeEvent(target, controller, nickname);
         server.getPluginManager().callEvent(nickEvent);
         if (!nickEvent.isCancelled()) {
             target.setNickname(nickname);


### PR DESCRIPTION
It seems as though the event called when a nickname was changed has the incorrect ordering of inputs. I think the target (affected) should be first and the controller should be second.