### PR TITLE
Use playerNeverOnServer message where appropriate

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandmail.java
@@ -56,8 +56,10 @@ public class Commandmail extends EssentialsCommand {
                 throw new Exception(user.hasMuteReason() ? tl("voiceSilencedReasonTime", dateDiff, user.getMuteReason()) : tl("voiceSilencedTime", dateDiff));
             }
 
-            User u = getPlayer(server, args[1], true, true);
-            if (u == null) {
+            User u;
+            try {
+                u = getPlayer(server, args[1], true, true);
+            } catch (PlayerNotFoundException e) {
                 throw new Exception(tl("playerNeverOnServer", args[1]));
             }
 
@@ -111,8 +113,10 @@ public class Commandmail extends EssentialsCommand {
         } else if (args.length >= 1 && "clear".equalsIgnoreCase(args[0])) {
             throw new Exception(tl("onlyPlayers", commandLabel + " clear"));
         } else if (args.length >= 3 && "send".equalsIgnoreCase(args[0])) {
-            User u = getPlayer(server, args[1], true, true);
-            if (u == null) {
+            User u;
+            try {
+                u = getPlayer(server, args[1], true, true);
+            } catch (PlayerNotFoundException e) {
                 throw new Exception(tl("playerNeverOnServer", args[1]));
             }
             u.addMail(tl("mailFormat", "Server", FormatUtil.replaceFormat(getFinalArg(args, 2))));
@@ -124,8 +128,10 @@ public class Commandmail extends EssentialsCommand {
             return;
         } else if (args.length >= 2) {
             //allow sending from console without "send" argument, since it's the only thing the console can do
-            User u = getPlayer(server, args[0], true, true);
-            if (u == null) {
+            User u;
+            try {
+                u = getPlayer(server, args[0], true, true);
+            } catch (PlayerNotFoundException e) {
                 throw new Exception(tl("playerNeverOnServer", args[0]));
             }
             u.addMail(tl("mailFormat", "Server", FormatUtil.replaceFormat(getFinalArg(args, 1))));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandseen.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandseen.java
@@ -69,7 +69,11 @@ public class Commandseen extends EssentialsCommand {
                         if (userFromBukkit != null) {
                             showUserSeen(userFromBukkit);
                         } else {
-                            showUserSeen(getPlayer(server, sender, args, 0));
+                            try {
+                                showUserSeen(getPlayer(server, sender, args, 0));
+                            } catch (PlayerNotFoundException e) {
+                                throw new Exception(tl("playerNeverOnServer", args[0]));
+                            }
                         }
                     } catch (Exception e) {
                         ess.showError(sender, e, commandLabel);
@@ -77,9 +81,6 @@ public class Commandseen extends EssentialsCommand {
                 }
 
                 private void showUserSeen(User user) throws Exception {
-                    if (user == null) {
-                        throw new PlayerNotFoundException();
-                    }
                     showSeenMessage(server, sender, user, showBan, showIp, showLocation);
                 }
             });

--- a/Essentials/src/com/earth2me/essentials/commands/Commandunban.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandunban.java
@@ -22,16 +22,17 @@ public class Commandunban extends EssentialsCommand {
         if (args.length < 1) {
             throw new NotEnoughArgumentsException();
         }
+
         String name;
         try {
             final User user = getPlayer(server, args, 0, true, true);
             name = user.getName();
             ess.getServer().getBanList(BanList.Type.NAME).pardon(name);
-        } catch (NoSuchFieldException e) {
+        } catch (PlayerNotFoundException e) {
             final OfflinePlayer player = server.getOfflinePlayer(args[0]);
             name = player.getName();
             if (!player.isBanned()) {
-                throw new Exception(tl("playerNotFound"), e);
+                throw new Exception(tl("playerNeverOnServer", args[0]));
             }
             ess.getServer().getBanList(BanList.Type.NAME).pardon(name);
         }


### PR DESCRIPTION
### Use `playerNeverOnServer` message where it should be used:

### https://github.com/EssentialsX/Essentials/pull/3489/commits/309e1c470d4bcfe2a2186f9720ce33f26441b802 
`playerNeverOnServer=\u00a74Player\u00a7c {0} \u00a74was never on this server.` is currently used in the **Commandmail** class at [Line 61](https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/commands/Commandmail.java#L61), [Line 116](https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/commands/Commandmail.java#L116) and [Line 129](https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/commands/Commandmail.java#L129) however is **not called** as PlayerNotFoundException is thrown by `#getPlayer` breaking current execution (below).
```
Commandmail#run() throws Exception {
...
    User u = getPlayer(server, args[1], true, true); // throws PlayerNotFoundException
        if (u == null) {
            throw new Exception(tl("playerNeverOnServer", args[1]));
    } 
...
}
```

Before changes:
![bm](https://user-images.githubusercontent.com/24858857/87236993-6b679180-c3e8-11ea-83a7-002194f5c467.png)
After changes:
![mailafter](https://user-images.githubusercontent.com/24858857/87237060-3576dd00-c3e9-11ea-8020-d5a80a958ca0.png)

--------------------------

**Commandseen** currently throws the default PlayerNotFoundException `playerNotFound` message for players that have not logged on to the server where it would be more appropriate to use the `playerNeverOnServer` message.

```
Commandseen#run throws Exception {
...
    AsyncRunnable#run() {
        User userFromBukkit = ess.getUserMap().getUserFromBukkit(args[0]);  <-- ***
        try {
            if (userFromBukkit != null) {                             <--- ***
                showUserSeen(userFromBukkit);
            } else {
                showUserSeen(getPlayer(server, sender, args, 0)); <--- ***
            }
        } catch (Exception e) {
            ess.showError(sender, e, commandLabel);
        }
    }
    private void showUserSeen(User user) throws Exception {
        if (user == null) {                                    <--- ***
            throw new PlayerNotFoundException();
        }
        showSeenMessage(server, sender, user, showBan, showIp, showLocation);
    }
...
}
```

**`<-- ***`:**
`usersFromBukkit` null check is performed before `#showUserSeen` so there is no need for another null check.
`EssentialsCommand#getPlayer` throws **NotEnoughArguementsException** or **PlayerNotFoundException** after [arg checks](https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java#L88) and [player checks](https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java#L103). https://github.com/EssentialsX/Essentials/pull/3489#issuecomment-657138524

Before changes:
![sb](https://user-images.githubusercontent.com/24858857/87237038-e9c43380-c3e8-11ea-8294-8f91e8b6f25d.png)
After changes:
![seenafter](https://user-images.githubusercontent.com/24858857/87237067-53444200-c3e9-11ea-92c5-1784b4dcd739.png)

----------------

### 725128e
Catch more specfic exception `PlayerNotFoundException`.

Before changes:
![banbefore](https://user-images.githubusercontent.com/24858857/87237021-c1d4d000-c3e8-11ea-99e4-eb97b5a5ba6d.png)
After changes:
![afterunban](https://user-images.githubusercontent.com/24858857/87237081-8d154880-c3e9-11ea-9d35-a25b8c105969.png)
