### PR TITLE
Add UserKickEvent

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
@@ -4,7 +4,7 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Console;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
-import net.ess3.api.events.UserKickEvent;
+import net.essentialsx.api.v2.events.UserKickEvent;
 import org.bukkit.Server;
 
 import java.util.Collections;

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
@@ -43,14 +43,16 @@ public class Commandkick extends EssentialsCommand {
         UserKickEvent event = new UserKickEvent(user, target, kickReason);
         ess.getServer().getPluginManager().callEvent(event);
 
-        if (!event.isCancelled()) {
-            kickReason = event.getReason();
-            target.getBase().kickPlayer(kickReason);
-            final String senderDisplayName = sender.isPlayer() ? sender.getPlayer().getDisplayName() : Console.DISPLAY_NAME;
-
-            server.getLogger().log(Level.INFO, tl("playerKicked", senderDisplayName, target.getName(), kickReason));
-            ess.broadcastMessage("essentials.kick.notify", tl("playerKicked", senderDisplayName, target.getName(), kickReason));
+        if (event.isCancelled()) {
+            return;
         }
+
+        kickReason = event.getReason();
+        target.getBase().kickPlayer(kickReason);
+        final String senderDisplayName = sender.isPlayer() ? sender.getPlayer().getDisplayName() : Console.DISPLAY_NAME;
+
+        server.getLogger().log(Level.INFO, tl("playerKicked", senderDisplayName, target.getName(), kickReason));
+        ess.broadcastMessage("essentials.kick.notify", tl("playerKicked", senderDisplayName, target.getName(), kickReason));
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
@@ -4,6 +4,7 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Console;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
+import net.ess3.api.events.UserKickEvent;
 import org.bukkit.Server;
 
 import java.util.Collections;
@@ -24,8 +25,9 @@ public class Commandkick extends EssentialsCommand {
         }
 
         final User target = getPlayer(server, args, 0, true, false);
-        if (sender.isPlayer()) {
-            final User user = ess.getUser(sender.getPlayer());
+        final User user = sender.isPlayer() ? ess.getUser(sender.getPlayer()) : null;
+
+        if (user != null) {
             if (target.isHidden(sender.getPlayer()) && !user.canInteractVanished() && !sender.getPlayer().canSee(target.getBase())) {
                 throw new PlayerNotFoundException();
             }
@@ -38,11 +40,17 @@ public class Commandkick extends EssentialsCommand {
         String kickReason = args.length > 1 ? getFinalArg(args, 1) : tl("kickDefault");
         kickReason = FormatUtil.replaceFormat(kickReason.replace("\\n", "\n").replace("|", "\n"));
 
-        target.getBase().kickPlayer(kickReason);
-        final String senderDisplayName = sender.isPlayer() ? sender.getPlayer().getDisplayName() : Console.DISPLAY_NAME;
+        UserKickEvent event = new UserKickEvent(user, target, kickReason);
+        ess.getServer().getPluginManager().callEvent(event);
 
-        server.getLogger().log(Level.INFO, tl("playerKicked", senderDisplayName, target.getName(), kickReason));
-        ess.broadcastMessage("essentials.kick.notify", tl("playerKicked", senderDisplayName, target.getName(), kickReason));
+        if (!event.isCancelled()) {
+            kickReason = event.getReason();
+            target.getBase().kickPlayer(kickReason);
+            final String senderDisplayName = sender.isPlayer() ? sender.getPlayer().getDisplayName() : Console.DISPLAY_NAME;
+
+            server.getLogger().log(Level.INFO, tl("playerKicked", senderDisplayName, target.getName(), kickReason));
+            ess.broadcastMessage("essentials.kick.notify", tl("playerKicked", senderDisplayName, target.getName(), kickReason));
+        }
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
@@ -40,7 +40,7 @@ public class Commandkick extends EssentialsCommand {
         String kickReason = args.length > 1 ? getFinalArg(args, 1) : tl("kickDefault");
         kickReason = FormatUtil.replaceFormat(kickReason.replace("\\n", "\n").replace("|", "\n"));
 
-        UserKickEvent event = new UserKickEvent(user, target, kickReason);
+        final UserKickEvent event = new UserKickEvent(user, target, kickReason);
         ess.getServer().getPluginManager().callEvent(event);
 
         if (event.isCancelled()) {

--- a/Essentials/src/main/java/net/ess3/api/events/UserKickEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/UserKickEvent.java
@@ -41,8 +41,8 @@ public class UserKickEvent extends Event implements Cancellable {
     }
 
     @Override
-    public void setCancelled(boolean b) {
-        this.cancelled = b;
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 
     @Override

--- a/Essentials/src/main/java/net/ess3/api/events/UserKickEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/UserKickEvent.java
@@ -1,0 +1,58 @@
+package net.ess3.api.events;
+
+import com.earth2me.essentials.IUser;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class UserKickEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private IUser kicked;
+    private IUser kicker;
+    private String reason;
+    private boolean cancelled;
+
+    public UserKickEvent(IUser kicked, IUser kicker, String reason) {
+        super(!Bukkit.isPrimaryThread());
+        this.kicked = kicked;
+        this.kicker = kicker;
+        this.reason = reason;
+    }
+
+    public IUser getKicked() {
+        return kicked;
+    }
+
+    public IUser getKicker() {
+        return kicker;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = b;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/Essentials/src/main/java/net/ess3/api/events/UserKickEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/UserKickEvent.java
@@ -1,7 +1,6 @@
 package net.ess3.api.events;
 
 import com.earth2me.essentials.IUser;
-import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -15,7 +14,6 @@ public class UserKickEvent extends Event implements Cancellable {
     private boolean cancelled;
 
     public UserKickEvent(IUser kicked, IUser kicker, String reason) {
-        super(!Bukkit.isPrimaryThread());
         this.kicked = kicked;
         this.kicker = kicker;
         this.reason = reason;

--- a/Essentials/src/main/java/net/essentialsx/api/v2/events/UserKickEvent.java
+++ b/Essentials/src/main/java/net/essentialsx/api/v2/events/UserKickEvent.java
@@ -5,11 +5,14 @@ import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * Called when a user is kicked with the /kick command.
+ */
 public class UserKickEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
-    private IUser kicked;
-    private IUser kicker;
+    private final IUser kicked;
+    private final IUser kicker;
     private String reason;
     private boolean cancelled;
 

--- a/Essentials/src/main/java/net/essentialsx/api/v2/events/UserKickEvent.java
+++ b/Essentials/src/main/java/net/essentialsx/api/v2/events/UserKickEvent.java
@@ -1,4 +1,4 @@
-package net.ess3.api.events;
+package net.essentialsx.api.v2.events;
 
 import com.earth2me.essentials.IUser;
 import org.bukkit.event.Cancellable;


### PR DESCRIPTION
Pretty self-explanatory. Adds a `UserKickEvent` that is cancellable and which has the initiator (two things missing from spigot's PlayerKickEvent). 
Will most likely add a similar event for bans in another PR. 