### PR TITLE
Disable random tp pre-cache by default

### DIFF
--- a/Essentials/src/com/earth2me/essentials/RandomTeleport.java
+++ b/Essentials/src/com/earth2me/essentials/RandomTeleport.java
@@ -97,7 +97,7 @@ public class RandomTeleport implements IConf {
     }
 
     public boolean getPreCache() {
-        return config.getBoolean("pre-cache", true);
+        return config.getBoolean("pre-cache", false);
     }
 
     public Queue<Location> getCachedLocations() {


### PR DESCRIPTION
This feature is catching some people by surprise, particularly in the fact that it may cause longer startup times and potentially generate several chunks in regions extremely far away from the spawn point.

Closes #3493.