### PR TITLE
Fix minor errors with YAML / Javadocs

### DIFF
--- a/Essentials/src/net/ess3/api/events/UserTeleportHomeEvent.java
+++ b/Essentials/src/net/ess3/api/events/UserTeleportHomeEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.event.HandlerList;
 /**
  * Called when a user is teleported home via the /home command.
  *
- * This is called before {@link net.ess3.api.events.UserTeleportEvent UserTeleportEvent}.
+ * This is called before {@link net.ess3.api.events.teleport.TeleportWarmupEvent TeleportWarmupEvent}.
  */
 public class UserTeleportHomeEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();

--- a/Essentials/src/plugin.yml
+++ b/Essentials/src/plugin.yml
@@ -571,9 +571,6 @@ permissions:
     description: Give players with op everything by default
     children:
       essentials.gamemode.*: true
-  essentials.sleepingignored:
-    default: false
-    description: If the player has this permission, they will not have to sleep for the night to be skipped
   # These permissions can't be assigned from player-commands for compatibility reasons
   essentials.teleport.cooldown.bypass.tpa:
     default: true

--- a/Essentials/src/worth.yml
+++ b/Essentials/src/worth.yml
@@ -31,7 +31,6 @@ worth:
   minecart: 23.0
   leatherchestplate: 85.0
   storageminecart: 30.0
-  leaves: 1.0
   feather: 3.0
   goldchestplate: 6.5
   mushroomsoup: 4.5


### PR DESCRIPTION
<details>
<summary>
This simply fixes 2 duplicate entries (one in plugin.yml, one in worth.yml) and fixes a Javadoc error when the UserTeleportEvent class got removed
</summary>
owo
</details>