### PR TITLE
Fix regression in /tpaccept

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpaccept.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpaccept.java
@@ -56,11 +56,6 @@ public class Commandtpaccept extends EssentialsCommand {
             user.sendMessage(tl("pendingTeleportCancelled"));
             return false;
         });
-        future.thenAccept(success -> {
-           if (success) {
-               user.requestTeleport(null, false);
-           }
-        });
         if (user.isTpRequestHere()) {
             final Location loc = user.getTpRequestLocation();
             AsyncTeleport teleport = (AsyncTeleport) requester.getAsyncTeleport();
@@ -76,6 +71,7 @@ public class Commandtpaccept extends EssentialsCommand {
             teleport.setTpType(AsyncTeleport.TeleportType.TPA);
             teleport.teleport(user.getBase(), charge, TeleportCause.COMMAND, future);
         }
+        user.requestTeleport(null, false);
     }
 
 }


### PR DESCRIPTION
Fixes #3563 which involves a regression introduced in d9bf099c3d411e5f493180de9c487a93e2fcfda7 where `/tpaccept` no longer unconditionally cancels the teleportation request when it is successfully accepted.