### PR TITLE
Fix /bigtree command on versions 1.12 and prior

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandbigtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbigtree.java
@@ -34,6 +34,9 @@ public class Commandbigtree extends EssentialsCommand {
         }
 
         final Location loc = LocationUtil.getTarget(user.getBase()).add(0, 1, 0);
+        if (loc.getBlock().getType().isSolid()) {
+            throw new Exception(tl("bigTreeFailure"));
+        }
         final boolean success = user.getWorld().generateTree(loc, tree);
         if (success) {
             user.sendMessage(tl("bigTreeSuccess"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbigtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbigtree.java
@@ -34,9 +34,6 @@ public class Commandbigtree extends EssentialsCommand {
         }
 
         final Location loc = LocationUtil.getTarget(user.getBase()).add(0, 1, 0);
-        if (!user.getWorld().getBlockAt(loc).isPassable()) {
-            throw new Exception(tl("bigTreeFailure"));
-        }
         final boolean success = user.getWorld().generateTree(loc, tree);
         if (success) {
             user.sendMessage(tl("bigTreeSuccess"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
@@ -43,7 +43,7 @@ public class Commandtree extends EssentialsCommand {
         }
 
         final Location loc = LocationUtil.getTarget(user.getBase()).add(0, 1, 0);
-        if (!user.getWorld().getBlockAt(loc).isPassable()) {
+        if (loc.getBlock().getType().isSolid()) {
             throw new Exception(tl("treeFailure"));
         }
         final boolean success = user.getWorld().generateTree(loc, tree);


### PR DESCRIPTION
Fixes #3549.

Removed the isPassable check entirely, as it is not compatible with 1.12 and prior, nor does it seem to have any meaningful impact on the command to begin with (it was added to replace a getSafeDestination call which didn't make much sense to begin with).