### PR TITLE
Update to 1.16.2

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Mob.java
+++ b/Essentials/src/com/earth2me/essentials/Mob.java
@@ -97,6 +97,7 @@ public enum Mob {
     PIGLIN("Piglin", Enemies.ADULT_ENEMY, "PIGLIN"),
     STRIDER("Strider", Enemies.FRIENDLY, "STRIDER"),
     ZOGLIN("Zoglin", Enemies.ENEMY, "ZOGLIN"),
+    PIGLIN_BRUTE("PiglinBrute", Enemies.ADULT_ENEMY, "PIGLIN_BRUTE"),
     ;
 
     public static final Logger logger = Logger.getLogger("Essentials");

--- a/Essentials/src/com/earth2me/essentials/utils/VersionUtil.java
+++ b/Essentials/src/com/earth2me/essentials/utils/VersionUtil.java
@@ -27,8 +27,9 @@ public class VersionUtil {
     public static final BukkitVersion v1_15_R01 = BukkitVersion.fromString("1.15-R0.1-SNAPSHOT");
     public static final BukkitVersion v1_15_2_R01 = BukkitVersion.fromString("1.15.2-R0.1-SNAPSHOT");
     public static final BukkitVersion v1_16_1_R01 = BukkitVersion.fromString("1.16.1-R0.1-SNAPSHOT");
+    public static final BukkitVersion v1_16_2_R01 = BukkitVersion.fromString("1.16.2-R0.1-SNAPSHOT");
 
-    private static final Set<BukkitVersion> supportedVersions = ImmutableSet.of(v1_8_8_R01, v1_9_4_R01, v1_10_2_R01, v1_11_2_R01, v1_12_2_R01, v1_13_2_R01, v1_14_4_R01, v1_15_2_R01, v1_16_1_R01);
+    private static final Set<BukkitVersion> supportedVersions = ImmutableSet.of(v1_8_8_R01, v1_9_4_R01, v1_10_2_R01, v1_11_2_R01, v1_12_2_R01, v1_13_2_R01, v1_14_4_R01, v1_15_2_R01, v1_16_2_R01);
 
     private static BukkitVersion serverVersion = null;
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a fork of Essentials called EssentialsX.
 
 If you are using this, do **NOT** ask Essentials for support.
 
-The official upstream repository is at https://github.com/Essentials/Essentials.
+The official upstream repository for the original Essentials project is at https://github.com/Essentials/Essentials.
 
 
 Why use EssentialsX?
@@ -26,7 +26,7 @@ EssentialsX is almost a completely drop-in replacement for Essentials. However, 
 
 * **EssentialsX requires Java 8 or higher.** On older versions, the plugin may not work properly.
 
-* **EssentialsX supports Minecraft versions 1.8.8, 1.9.4, 1.10.2, 1.11.2, 1.12.2, 1.13.2, 1.14.4, 1.15.2, and 1.16.1.**
+* **EssentialsX supports Minecraft versions 1.8.8, 1.9.4, 1.10.2, 1.11.2, 1.12.2, 1.13.2, 1.14.4, 1.15.2, and 1.16.2.**
 
 
 Support
@@ -50,7 +50,7 @@ Each module's jar can be found in `target/` inside each module's directory.
 Using EssentialsX in your plugin
 --------------------------------
 
-Do you want to integrate with EssentialsX in your plugin? EssentialsX is available on the **ender.zone Maven repository** at https://ci.ender.zone/plugin/repository/everything/, and the EssentialsX artifact is `net.ess3:EssentialsX:2.17.2`.
+Do you want to integrate with EssentialsX in your plugin? EssentialsX is available on the **ender.zone Maven repository** at https://ci.ender.zone/plugin/repository/everything/, and the EssentialsX artifact is `net.ess3:EssentialsX:2.18.1`.
 More information at the [wiki](https://github.com/EssentialsX/Essentials/wiki/Common-Issues#how-do-i-add-essentialsx-as-a-dependency).
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.16.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- [x] Compile against 1.16.2
- [x] Add piglin brute to spawnable mobs
- [x] Bump officially supported 1.16.x version to 1.16.2
- ~~Add piglin brute spawner and spawn egg *(pending 1.16.2 API release)*~~ see 18ccea320ae0d14350204fa9a9bd8b8606166c38

