### PR TITLE
Fix double command cost charge in teleport-related commands

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhome.java
@@ -64,7 +64,7 @@ public class Commandhome extends EssentialsCommand {
                         showError(user.getBase(), new Exception(tl("bedMissing")), commandLabel);
                     }
                 });
-                return;
+                throw new NoChargeException();
             }
             goHome(user, player, homeName.toLowerCase(Locale.ENGLISH), charge, getNewExceptionFuture(user.getSource(), commandLabel));
         } catch (NotEnoughArgumentsException e) {
@@ -108,6 +108,7 @@ public class Commandhome extends EssentialsCommand {
             }
             PaperLib.getBedSpawnLocationAsync(player.getBase(), true).thenAccept(message::complete);
         }
+        throw new NoChargeException();
     }
 
     private String getHomeLimit(final User player) {

--- a/Essentials/src/com/earth2me/essentials/commands/Commandjump.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandjump.java
@@ -47,6 +47,8 @@ public class Commandjump extends EssentialsCommand {
         final Trade charge = new Trade(this.getName(), ess);
         charge.isAffordableFor(user);
         user.getAsyncTeleport().teleport(loc, charge, TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
+
+        throw new NoChargeException();
     }
 
     @Override

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtp.java
@@ -44,7 +44,7 @@ public class Commandtp extends EssentialsCommand {
                 final Trade charge = new Trade(this.getName(), ess);
                 charge.isAffordableFor(user);
                 user.getAsyncTeleport().teleport(player.getBase(), charge, TeleportCause.COMMAND, future);
-                break;
+                throw new NoChargeException();
             case 3:
                 if (!user.isAuthorized("essentials.tp.position")) {
                     throw new Exception(tl("noPerm", "essentials.tp.position"));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpaccept.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpaccept.java
@@ -72,6 +72,7 @@ public class Commandtpaccept extends EssentialsCommand {
             teleport.teleport(user.getBase(), charge, TeleportCause.COMMAND, future);
         }
         user.requestTeleport(null, false);
+        throw new NoChargeException();
     }
 
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtphere.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtphere.java
@@ -26,6 +26,7 @@ public class Commandtphere extends EssentialsCommand {
             throw new Exception(tl("noPerm", "essentials.worlds." + user.getWorld().getName()));
         }
         user.getAsyncTeleport().teleportPlayer(player, user.getBase(), new Trade(this.getName(), ess), TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
+        throw new NoChargeException();
     }
 
     @Override

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtppos.java
@@ -56,6 +56,8 @@ public class Commandtppos extends EssentialsCommand {
         charge.isAffordableFor(user);
         user.sendMessage(tl("teleporting", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
         user.getAsyncTeleport().teleport(loc, charge, TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
+
+        throw new NoChargeException();
     }
 
     @Override

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtpr.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtpr.java
@@ -39,6 +39,7 @@ public class Commandtpr extends EssentialsCommand {
                 }
             });
         });
+        throw new NoChargeException();
     }
 
     @Override

--- a/Essentials/src/com/earth2me/essentials/commands/Commandwarp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandwarp.java
@@ -42,9 +42,10 @@ public class Commandwarp extends EssentialsCommand {
             if (args.length == 2 && (user.isAuthorized("essentials.warp.otherplayers") || user.isAuthorized("essentials.warp.others"))) {
                 otherUser = getPlayer(server, user, args, 1);
                 warpUser(user, otherUser, args[0], commandLabel);
-                return;
+                throw new NoChargeException();
             }
             warpUser(user, user, args[0], commandLabel);
+            throw new NoChargeException();
         }
     }
 
@@ -56,6 +57,7 @@ public class Commandwarp extends EssentialsCommand {
         }
         User otherUser = getPlayer(server, args, 1, true, false);
         otherUser.getAsyncTeleport().warp(otherUser, args[0], null, TeleportCause.COMMAND, getNewExceptionFuture(sender, commandLabel));
+        throw new NoChargeException();
     }
 
     //TODO: Use one of the new text classes, like /help ?

--- a/Essentials/src/com/earth2me/essentials/commands/Commandworld.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandworld.java
@@ -67,6 +67,8 @@ public class Commandworld extends EssentialsCommand {
         final Trade charge = new Trade(this.getName(), ess);
         charge.isAffordableFor(user);
         user.getAsyncTeleport().teleport(target, charge, TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
+
+        throw new NoChargeException();
     }
 
     @Override

--- a/EssentialsSpawn/src/com/earth2me/essentials/spawn/Commandspawn.java
+++ b/EssentialsSpawn/src/com/earth2me/essentials/spawn/Commandspawn.java
@@ -5,6 +5,7 @@ import com.earth2me.essentials.Console;
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.commands.EssentialsCommand;
+import com.earth2me.essentials.commands.NoChargeException;
 import com.earth2me.essentials.commands.NotEnoughArgumentsException;
 import org.bukkit.Location;
 import org.bukkit.Server;
@@ -40,6 +41,8 @@ public class Commandspawn extends EssentialsCommand {
         } else {
             respawn(user.getSource(), user, user, charge, commandLabel, new CompletableFuture<>());
         }
+        
+        throw new NoChargeException();
     }
 
     @Override


### PR DESCRIPTION
Closes #3518. Fixes a bug introduced in d9bf099 where some teleport-related command costs will charge the user twice.

Affected commands: home, jump, spawn, tp, tpaccept, tphere, tppos, tpr, warp, world.