### PR TITLE
Fix creeper player damage being cancelled incorrectly

### DIFF
--- a/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
+++ b/EssentialsProtect/src/com/earth2me/essentials/protect/EssentialsProtectEntityListener.java
@@ -86,7 +86,7 @@ public class EssentialsProtectEntityListener implements Listener {
             }
 
             //Creeper explode prevention
-            if (eAttack instanceof Creeper && (prot.getSettingBool(ProtectConfig.prevent_creeper_explosion) || prot.getSettingBool(ProtectConfig.prevent_creeper_playerdmg)) && !(target instanceof Player && shouldBeDamaged(user, "creeper"))) {
+            if (eAttack instanceof Creeper && prot.getSettingBool(ProtectConfig.prevent_creeper_playerdmg) && !(target instanceof Player && shouldBeDamaged(user, "creeper"))) {
                 event.setCancelled(true);
                 return;
             }


### PR DESCRIPTION
Fixes issue #3603 

Basicly there was a mistake which also asked for creeper-explosion to be disabled, and all other checkers just ask for playerdm