### PR TITLE
Add "amplifier" potion meta attribute

### DIFF
--- a/Essentials/src/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/com/earth2me/essentials/MetaItemStack.java
@@ -367,6 +367,13 @@ public class MetaItemStack {
                 } else {
                     throw new Exception(tl("invalidPotionMeta", split[1]));
                 }
+            } else if (split[0].equalsIgnoreCase("amplifier") || (allowShortName && split[0].equalsIgnoreCase("a"))) {
+                if (NumberUtil.isInt(split[1])) {
+                    validPotionPower = true;
+                    power = Integer.parseInt(split[1]);
+                } else {
+                    throw new Exception(tl("invalidPotionMeta", split[1]));
+                }
             } else if (split[0].equalsIgnoreCase("duration") || (allowShortName && split[0].equalsIgnoreCase("d"))) {
                 if (NumberUtil.isInt(split[1])) {
                     validPotionDuration = true;

--- a/Essentials/src/com/earth2me/essentials/commands/Commandpotion.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandpotion.java
@@ -87,7 +87,7 @@ public class Commandpotion extends EssentialsCommand {
             }
             return options;
         } else if (args.length == 2 && args[0].startsWith("effect:")) {
-            return Lists.newArrayList("power:1", "power:2", "power:3", "power:4");
+            return Lists.newArrayList("power:1", "power:2", "power:3", "power:4", "amplifier:0", "amplifier:1", "amplifier:2", "amplifier:3");
         } else if (args.length == 3 && args[0].startsWith("effect:")) {
             List<String> options = Lists.newArrayList();
             for (String duration : COMMON_DURATIONS) {


### PR DESCRIPTION
Adds an `amplifier:<value>` potion meta attribute to MetaItemStack that applies a raw amplifier value, instead of translating inputs between 1 and 3 to match their vanilla names like `power:<value>` does. This matches the Mojang `/effect` command, which doesn't translate any potion effect amplifiers, and allows for creation of level IV potions (using `amplifier:3` instead of a `power` value) through EssentialsX without breaking existing usages of `power:<value>`.

More context for this PR can be found on [#3592 (comment)](https://github.com/EssentialsX/Essentials/pull/3592#issuecomment-678656107).

Closes #3592 and fixes #3589.