### PR TITLE
Fix /lightning player not respecting essentials.lightning.others

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandlightning.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandlightning.java
@@ -19,8 +19,8 @@ public class Commandlightning extends EssentialsLoopCommand {
 
     @Override
     public void run(final Server server, final CommandSource sender, final String commandLabel, final String[] args) throws Exception {
-        if (args.length == 0) {
-            if (sender.isPlayer() || !sender.isAuthorized("essentials.lightning.others", ess)) {
+        if (args.length == 0 || !sender.isAuthorized("essentials.lightning.others", ess)) {
+            if (sender.isPlayer()) {
                 sender.getPlayer().getWorld().strikeLightning(sender.getPlayer().getTargetBlock(null, 600).getLocation());
                 return;
             }


### PR DESCRIPTION
Fixes #3667

Tested with the following:
With e.lightning, do not have e.lightning.others
/lightning => Just smites what I'm looking at
/lightning uegefw => same as above

With e.lightning AND e.lightning.others
/lightning => Just smites what I'm looking at
/lightning uitgire => player not found error