### PR TITLE
Update old EssentialsX URLs in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/help.md
+++ b/.github/ISSUE_TEMPLATE/help.md
@@ -20,7 +20,7 @@ If you're happy to wait (or you were sent here from Discord), read on:
 
 2.  Check the Common Issues page.
       Read through the wiki page to see if you've encountered a regular issue:
-      https://essentialsx.github.io/#/Common-Issues
+      https://essentialsx.net/wiki/Common-Issues.html
 
 3.  Delete this line and all above lines before posting your issue!       -->
 

--- a/.github/ISSUE_TEMPLATE/request-a-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-a-feature.md
@@ -27,7 +27,7 @@ If you have a feature suggestion for EssentialsX, read the following tips:
 3.  Check whether it has already been asked or added.
       You can search the issue tracker to see if your feature has already been
       requested at https://github.com/EssentialsX/Essentials/issues. You can
-      also check the wiki at https://essentialsx.github.io/ to see if the
+      also check the wiki at https://essentialsx.net/ to see if the
       feature was recently added.
 
 4.  Ask yourself: "Does this belong in EssentialsX?"

--- a/.github/ISSUE_TEMPLATE/request-a-feature.md
+++ b/.github/ISSUE_TEMPLATE/request-a-feature.md
@@ -27,8 +27,8 @@ If you have a feature suggestion for EssentialsX, read the following tips:
 3.  Check whether it has already been asked or added.
       You can search the issue tracker to see if your feature has already been
       requested at https://github.com/EssentialsX/Essentials/issues. You can
-      also check the wiki at https://essentialsx.net/ to see if the
-      feature was recently added.
+      also check the changelogs at https://github.com/EssentialsX/Essentials/releases
+      to see if the feature was recently added.
 
 4.  Ask yourself: "Does this belong in EssentialsX?"
       There are lots of features that we reject because most servers won't


### PR DESCRIPTION
This updates the old https://essentialsx.github.io domains to the new https://essentialsx.net one.