### PR TITLE
Fix safelogin permission when disabled

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -342,6 +342,8 @@ public class EssentialsPlayerListener implements Listener {
                             user.getBase().sendMessage(tl("flyMode", tl("enabled"), user.getDisplayName()));
                         }
                     }
+                } else {
+                    resetUserFly(user);
                 }
 
                 if (!user.isAuthorized("essentials.speed")) {
@@ -602,13 +604,7 @@ public class EssentialsPlayerListener implements Listener {
         final User user = ess.getUser(event.getPlayer());
 
         if (ess.getSettings().isWorldChangeFlyResetEnabled()) {
-            if (user.getBase().getGameMode() != GameMode.CREATIVE
-                    // COMPAT: String compare for 1.7.10
-                    && !user.getBase().getGameMode().name().equals("SPECTATOR")
-                    && !user.isAuthorized("essentials.fly")) {
-                user.getBase().setFallDistance(0f);
-                user.getBase().setAllowFlight(false);
-            }
+            resetUserFly(user);
         }
 
         if (ess.getSettings().isWorldChangeSpeedResetEnabled()) {
@@ -626,6 +622,16 @@ public class EssentialsPlayerListener implements Listener {
                     user.getBase().setWalkSpeed((float) ess.getSettings().getMaxWalkSpeed());
                 }
             }
+        }
+    }
+
+    private void resetUserFly(User user) {
+        if (user.getBase().getGameMode() != GameMode.CREATIVE
+                // COMPAT: String compare for 1.7.10
+                && !user.getBase().getGameMode().name().equals("SPECTATOR")
+                && !user.isAuthorized("essentials.fly")) {
+            user.getBase().setFallDistance(0f);
+            user.getBase().setAllowFlight(false);
         }
     }
 


### PR DESCRIPTION
Properly disables a player's flight when they do not have permission for `essentials.fly.safelogin` on log-in. During testing I noticed that even when this permission was disabled, the player would still be flying when they logged in. Obviously, if the user does not have this permission, they are not supposed to be flying, so we need to disable their flight in this case for correct behaviour.

Fixes #1895.
