### PR TITLE
Remove sign color codes from trade.log

### DIFF
--- a/Essentials/src/com/earth2me/essentials/signs/EssentialsSign.java
+++ b/Essentials/src/com/earth2me/essentials/signs/EssentialsSign.java
@@ -94,6 +94,7 @@ public class EssentialsSign {
     }
 
     public String getUsername(final User user) {
+        // Truncate username to ensure it can fit on a sign
         return user.getName().substring(0, Math.min(user.getName().length(), 13));
     }
 

--- a/Essentials/src/com/earth2me/essentials/signs/SignTrade.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignTrade.java
@@ -73,7 +73,7 @@ public class SignTrade extends EssentialsSign {
                 throw new ChargeException("Full inventory");
             }
             charge.charge(player);
-            Trade.log("Sign", "Trade", "Interact", sign.getLine(3), charge, username, trade, sign.getBlock().getLocation(), ess);
+            Trade.log("Sign", "Trade", "Interact", sign.getLine(3).substring(2), charge, username, trade, sign.getBlock().getLocation(), ess);
         }
         sign.updateSign();
         return true;
@@ -110,7 +110,7 @@ public class SignTrade extends EssentialsSign {
                 final Trade stored2 = getTrade(sign, 2, AmountType.TOTAL, false, true, ess);
 
                 if (!canCollect) {
-                    Trade.log("Sign", "Trade", "Destroy", signOwner, stored2, username, stored1, sign.getBlock().getLocation(), ess);
+                    Trade.log("Sign", "Trade", "Destroy", signOwner.substring(2), stored2, username, stored1, sign.getBlock().getLocation(), ess);
                     return true;
                 }
 
@@ -118,15 +118,15 @@ public class SignTrade extends EssentialsSign {
                 final Map<Integer, ItemStack> withdraw2 = stored2.pay(player, OverflowType.RETURN);
 
                 if (withdraw1 == null && withdraw2 == null) {
-                    Trade.log("Sign", "Trade", "Break", signOwner, stored2, username, stored1, sign.getBlock().getLocation(), ess);
+                    Trade.log("Sign", "Trade", "Break", signOwner.substring(2), stored2, username, stored1, sign.getBlock().getLocation(), ess);
                     return true;
                 }
 
                 setAmount(sign, 1, BigDecimal.valueOf(withdraw1 == null ? 0L : withdraw1.get(0).getAmount()), ess);
-                Trade.log("Sign", "Trade", "Withdraw", signOwner, stored1, username, withdraw1 == null ? null : new Trade(withdraw1.get(0), ess), sign.getBlock().getLocation(), ess);
+                Trade.log("Sign", "Trade", "Withdraw", signOwner.substring(2), stored1, username, withdraw1 == null ? null : new Trade(withdraw1.get(0), ess), sign.getBlock().getLocation(), ess);
 
                 setAmount(sign, 2, BigDecimal.valueOf(withdraw2 == null ? 0L : withdraw2.get(0).getAmount()), ess);
-                Trade.log("Sign", "Trade", "Withdraw", signOwner, stored2, username, withdraw2 == null ? null : new Trade(withdraw2.get(0), ess), sign.getBlock().getLocation(), ess);
+                Trade.log("Sign", "Trade", "Withdraw", signOwner.substring(2), stored2, username, withdraw2 == null ? null : new Trade(withdraw2.get(0), ess), sign.getBlock().getLocation(), ess);
 
                 sign.updateSign();
             } catch (SignException e) {


### PR DESCRIPTION
Started looking into #3116 but noticed this issue and wanted to fix it first.

Also added a comment as to why the username is truncated as this took me a long time to figure out and seemed arbitrary. Probably could truncate the username later for trade signs only as other signs don't require any username to be present on the sign. However, for now I simply opted to document.