### PR TITLE
Tab-complete plugin names for `/help`

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandhelp.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandhelp.java
@@ -10,6 +10,7 @@ import com.earth2me.essentials.textreader.TextPager;
 import com.earth2me.essentials.utils.NumberUtil;
 import org.bukkit.Server;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -57,7 +58,9 @@ public class Commandhelp extends EssentialsCommand {
     @Override
     protected List<String> getTabCompleteOptions(final Server server, final CommandSource sender, final String commandLabel, final String[] args) {
         if (args.length == 1) {
-            return getCommands(server);
+            final List<String> suggestions = new ArrayList<>(getCommands(server));
+            suggestions.addAll(getPlugins(server));
+            return suggestions;
         } else {
             return Collections.emptyList();
         }

--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -325,6 +325,20 @@ public abstract class EssentialsCommand implements IEssentialsCommand {
     }
 
     /**
+     * Lists all plugin names
+     *
+     * @param server Server instance
+     * @return List of plugin names
+     */
+    protected final List<String> getPlugins(final Server server) {
+        final List<String> plugins = Lists.newArrayList();
+        for (final Plugin p : server.getPluginManager().getPlugins()) {
+            plugins.add(p.getName());
+        }
+        return plugins;
+    }
+
+    /**
      * Attempts to tab-complete a command or its arguments.
      */
     protected final List<String> tabCompleteCommand(final CommandSource sender, final Server server, final String label, final String[] args, final int index) {


### PR DESCRIPTION
Plugin names are accepted as input to `/essentials:help`, but they are not completed. This makes it easier to lookup plugin commands.