### PR TITLE
Remove acacia & birch tree type arguments from tree command

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
@@ -30,11 +30,9 @@ public class Commandtree extends EssentialsCommand {
                     break;
                 }
             }
-
             if (args[0].equalsIgnoreCase("jungle")) {
                 tree = TreeType.SMALL_JUNGLE;
             }
- 
             if (tree == null) {
                 throw new NotEnoughArgumentsException();
             }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandtree.java
@@ -30,13 +30,11 @@ public class Commandtree extends EssentialsCommand {
                     break;
                 }
             }
+
             if (args[0].equalsIgnoreCase("jungle")) {
                 tree = TreeType.SMALL_JUNGLE;
-            } else if (args[0].equalsIgnoreCase("acacia")) {
-                tree = TreeType.ACACIA;
-            } else if (args[0].equalsIgnoreCase("birch")) {
-                tree = TreeType.BIRCH;
             }
+ 
             if (tree == null) {
                 throw new NotEnoughArgumentsException();
             }


### PR DESCRIPTION
`acacia` & `birch` literally **redundant** because in the for loop it finds if the argument is equal to these values. Also `TreeType` had already [BIRCH](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/TreeType.java?until=101dc61d0f76f4654ab3a72762aed7b1c7846843&autoSincePath=false#27) and [ACACIA](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/browse/src/main/java/org/bukkit/TreeType.java?until=101dc61d0f76f4654ab3a72762aed7b1c7846843&autoSincePath=false#59) values.

See https://github.com/EssentialsX/Essentials/blob/e2f17f11d3ec415ce7008cc34e4d163c7c4259ff/Essentials/src/com/earth2me/essentials/commands/Commandtree.java#L27-L32

_This PR does not produces any of fix, just cleanup_