### PR TITLE
Allow the usage of UUID's to find Offline Users

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -148,7 +148,7 @@ public abstract class EssentialsCommand implements IEssentialsCommand {
             Object searchId;
             try {
                 searchId = UUID.fromString(searchTerm);
-            }catch(final IllegalArgumentException ex) {
+            } catch(final IllegalArgumentException ex) {
                 searchId = searchTerm;
             }
             

--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -145,18 +145,15 @@ public abstract class EssentialsCommand implements IEssentialsCommand {
         if (exPlayer != null) {
             user = ess.getUser(exPlayer);
         } else {
-            Object searchId;
-            try {
-                searchId = UUID.fromString(searchTerm);
-            } catch(final IllegalArgumentException ex) {
-                searchId = searchTerm;
-            }
+            User mutableUser;
             
-            if (searchId instanceof String) {
-                user = ess.getUser((String) searchId);
-            } else { 
-                user = ess.getUser((UUID) searchId);
+            try {
+                mutableUser = ess.getUser(UUID.fromString(searchTerm));
+            } catch(final IllegalArgumentException ex) {
+                mutableUser = ess.getUser(searchTerm);
             }
+
+            user = mutableUser;
         }
 
         if (user != null) {

--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -145,12 +145,17 @@ public abstract class EssentialsCommand implements IEssentialsCommand {
         if (exPlayer != null) {
             user = ess.getUser(exPlayer);
         } else {
+            Object searchId;
             try {
-                UUID playerId = UUID.fromString(searchTerm);
-                
-                user = ess.getUser(playerId);
+                searchId = UUID.fromString(searchTerm);
             }catch(final IllegalArgumentException ex) {
-                user = ess.getUser(searchTerm);
+                searchId = searchTerm;
+            }
+            
+            if (searchId instanceof String) {
+                user = ess.getUser((String) searchId);
+            } else { 
+                user = ess.getUser((UUID) searchId);
             }
         }
 

--- a/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -145,7 +145,13 @@ public abstract class EssentialsCommand implements IEssentialsCommand {
         if (exPlayer != null) {
             user = ess.getUser(exPlayer);
         } else {
-            user = ess.getUser(searchTerm);
+            try {
+                UUID playerId = UUID.fromString(searchTerm);
+                
+                user = ess.getUser(playerId);
+            }catch(final IllegalArgumentException ex) {
+                user = ess.getUser(searchTerm);
+            }
         }
 
         if (user != null) {


### PR DESCRIPTION
### **First of all, how came I to the conclusion that this change was needed?**
I was using the plugin as a server owner and due to administrative purposes I needed to teleport into the home of an offline User, but essentials didn't resolve the UUID correctly, so I tried to use directly the UUID to teleport into that user's home but that wasn't allowed by essentials.
### **What are the changes?**
There's only one change, when the EssentialsCommand#getPlayer(Server, User, String, boolean, boolean) method is called with a search term that's a UUID and the user is offline(exPlayer == null) we try to parse the searchTerm as a UUID first, if the parsing fails with an IllegalArgumentException then the searchTerm is used as a String.