### PR TITLE
Add ending user balance as a final field in trade.log

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Trade.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Trade.java
@@ -68,7 +68,7 @@ public class Trade {
         this.ess = ess;
     }
 
-    public static void log(final String type, final String subtype, final String event, final String sender, final Trade charge, final String receiver, final Trade pay, final Location loc, final IEssentials ess) {
+    public static void log(final String type, final String subtype, final String event, final String sender, final Trade charge, final String receiver, final Trade pay, final Location loc, final BigDecimal endBalance, final IEssentials ess) {
         //isEcoLogUpdateEnabled() - This refers to log entries with no location, ie API updates #EasterEgg
         //isEcoLogEnabled() - This refers to log entries with with location, ie /pay /sell and eco signs.
 
@@ -141,6 +141,13 @@ public class Trade {
             sb.append(loc.getBlockX()).append(",");
             sb.append(loc.getBlockY()).append(",");
             sb.append(loc.getBlockZ()).append(",");
+        }
+        
+        if (endBalance == null) {
+            sb.append(",");
+        } else {
+            sb.append(endBalance);
+            sb.append(",");
         }
         sb.append("\n");
         try {

--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -504,7 +504,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             }
         }
         super.setMoney(newBalance, true);
-        Trade.log("Update", "Set", "API", getName(), new Trade(newBalance, ess), null, null, null, ess);
+        Trade.log("Update", "Set", "API", getName(), new Trade(newBalance, ess), null, null, null, newBalance, ess);
     }
 
     public void updateMoneyCache(final BigDecimal value) {

--- a/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java
@@ -234,7 +234,7 @@ public class Economy {
         } catch (final MaxMoneyException ex) {
             //TODO: Update API to show max balance errors
         }
-        Trade.log("API", "Set", "API", user.getName(), new Trade(balance, ess), null, null, null, ess);
+        Trade.log("API", "Set", "API", user.getName(), new Trade(balance, ess), null, null, null, balance, ess);
     }
 
     /**
@@ -307,7 +307,7 @@ public class Economy {
         }
         final BigDecimal result = getMoneyExact(user).add(amount, MATH_CONTEXT);
         setMoney(user, result);
-        Trade.log("API", "Add", "API", user.getName(), new Trade(amount, ess), null, null, null, ess);
+        Trade.log("API", "Add", "API", user.getName(), new Trade(amount, ess), null, null, null, result, ess);
     }
 
     /**
@@ -342,7 +342,7 @@ public class Economy {
     public static void substract(final String name, final BigDecimal amount) throws UserDoesNotExistException, NoLoanPermittedException, ArithmeticException {
         final BigDecimal result = getMoneyExact(name).subtract(amount, MATH_CONTEXT);
         setMoney(name, result);
-        Trade.log("API", "Subtract", "API", name, new Trade(amount, ess), null, null, null, ess);
+        Trade.log("API", "Subtract", "API", name, new Trade(amount, ess), null, null, null, result, ess);
     }
 
     /**
@@ -376,7 +376,7 @@ public class Economy {
         }
         final BigDecimal result = getMoneyExact(user).subtract(amount, MATH_CONTEXT);
         setMoney(user, result);
-        Trade.log("API", "Subtract", "API", user.getName(), new Trade(amount, ess), null, null, null, ess);
+        Trade.log("API", "Subtract", "API", user.getName(), new Trade(amount, ess), null, null, null, result, ess);
     }
 
     /**
@@ -447,7 +447,7 @@ public class Economy {
         }
         final BigDecimal result = getMoneyExact(user).divide(amount, MATH_CONTEXT);
         setMoney(user, result);
-        Trade.log("API", "Divide", "API", user.getName(), new Trade(amount, ess), null, null, null, ess);
+        Trade.log("API", "Divide", "API", user.getName(), new Trade(amount, ess), null, null, null, result, ess);
     }
 
     /**
@@ -518,7 +518,7 @@ public class Economy {
         }
         final BigDecimal result = getMoneyExact(user).multiply(amount, MATH_CONTEXT);
         setMoney(user, result);
-        Trade.log("API", "Multiply", "API", user.getName(), new Trade(amount, ess), null, null, null, ess);
+        Trade.log("API", "Multiply", "API", user.getName(), new Trade(amount, ess), null, null, null, result, ess);
     }
 
     /**
@@ -535,7 +535,7 @@ public class Economy {
             throw new RuntimeException(noCallBeforeLoad);
         }
         setMoney(name, ess.getSettings().getStartingBalance());
-        Trade.log("API", "Reset", "API", name, new Trade(BigDecimal.ZERO, ess), null, null, null, ess);
+        Trade.log("API", "Reset", "API", name, new Trade(BigDecimal.ZERO, ess), null, null, null, ess.getSettings().getStartingBalance(), ess);
     }
 
     /**
@@ -567,7 +567,7 @@ public class Economy {
             throw new IllegalArgumentException("Economy user cannot be null");
         }
         setMoney(user, ess.getSettings().getStartingBalance());
-        Trade.log("API", "Reset", "API", user.getName(), new Trade(BigDecimal.ZERO, ess), null, null, null, ess);
+        Trade.log("API", "Reset", "API", user.getName(), new Trade(BigDecimal.ZERO, ess), null, null, null, ess.getSettings().getStartingBalance(), ess);
     }
 
     /**

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandpay.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandpay.java
@@ -62,7 +62,7 @@ public class Commandpay extends EssentialsLoopCommand {
                 }
                 user.payUser(player, amount, UserBalanceUpdateEvent.Cause.COMMAND_PAY);
                 user.getConfirmingPayments().remove(player);
-                Trade.log("Command", "Pay", "Player", user.getName(), new Trade(amount, ess), player.getName(), new Trade(amount, ess), user.getLocation(), ess);
+                Trade.log("Command", "Pay", "Player", user.getName(), new Trade(amount, ess), player.getName(), new Trade(amount, ess), user.getLocation(), user.getMoney(), ess);
             } catch (final MaxMoneyException ex) {
                 user.sendMessage(tl("maxMoney"));
                 try {

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandsell.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandsell.java
@@ -114,7 +114,7 @@ public class Commandsell extends EssentialsCommand {
         }
         user.getBase().getInventory().removeItem(ris);
         user.getBase().updateInventory();
-        Trade.log("Command", "Sell", "Item", user.getName(), new Trade(ris, ess), user.getName(), new Trade(result, ess), user.getLocation(), ess);
+        Trade.log("Command", "Sell", "Item", user.getName(), new Trade(ris, ess), user.getName(), new Trade(result, ess), user.getLocation(), user.getMoney(), ess);
         user.giveMoney(result, null, UserBalanceUpdateEvent.Cause.COMMAND_SELL);
         user.sendMessage(tl("itemSold", NumberUtil.displayCurrency(result, ess), amount, is.getType().toString().toLowerCase(Locale.ENGLISH), NumberUtil.displayCurrency(worth, ess)));
         logger.log(Level.INFO, tl("itemSoldConsole", user.getName(), is.getType().toString().toLowerCase(Locale.ENGLISH), NumberUtil.displayCurrency(result, ess), amount, NumberUtil.displayCurrency(worth, ess), user.getDisplayName()));

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignBuy.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignBuy.java
@@ -49,7 +49,7 @@ public class SignBuy extends EssentialsSign {
             throw new ChargeException("Inventory full"); //TODO: TL
         }
         charge.charge(player);
-        Trade.log("Sign", "Buy", "Interact", username, charge, username, items, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Buy", "Interact", username, charge, username, items, sign.getBlock().getLocation(), player.getMoney(), ess);
         return true;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignEnchant.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignEnchant.java
@@ -110,7 +110,7 @@ public class SignEnchant extends EssentialsSign {
         }
 
         charge.charge(player);
-        Trade.log("Sign", "Enchant", "Interact", username, charge, username, charge, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Enchant", "Interact", username, charge, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
         player.getBase().updateInventory();
         return true;
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignFree.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignFree.java
@@ -49,7 +49,7 @@ public class SignFree extends EssentialsSign {
             invent.addItem(item);
         }
         player.getBase().openInventory(invent);
-        Trade.log("Sign", "Free", "Interact", username, null, username, new Trade(item, ess), sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Free", "Interact", username, null, username, new Trade(item, ess), sign.getBlock().getLocation(), player.getMoney(), ess);
         return true;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignGameMode.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignGameMode.java
@@ -41,7 +41,7 @@ public class SignGameMode extends EssentialsSign {
 
         performSetMode(mode.toLowerCase(Locale.ENGLISH), player.getBase());
         player.sendMessage(tl("gameMode", tl(player.getBase().getGameMode().toString().toLowerCase(Locale.ENGLISH)), player.getDisplayName()));
-        Trade.log("Sign", "gameMode", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "gameMode", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
         charge.charge(player);
         return true;
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignHeal.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignHeal.java
@@ -30,7 +30,7 @@ public class SignHeal extends EssentialsSign {
         player.getBase().setFireTicks(0);
         player.sendMessage(tl("youAreHealed"));
         charge.charge(player);
-        Trade.log("Sign", "Heal", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Heal", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
         return true;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignInfo.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignInfo.java
@@ -43,7 +43,7 @@ public class SignInfo extends EssentialsSign {
         }
 
         charge.charge(player);
-        Trade.log("Sign", "Info", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Info", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
         return true;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignKit.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignKit.java
@@ -53,7 +53,7 @@ public class SignKit extends EssentialsSign {
                 kit.expandItems(player);
 
                 charge.charge(player);
-                Trade.log("Sign", "Kit", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+                Trade.log("Sign", "Kit", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
             } catch (final NoChargeException ex) {
                 return false;
             } catch (final Exception ex) {

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignRepair.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignRepair.java
@@ -49,7 +49,7 @@ public class SignRepair extends EssentialsSign {
         }
 
         charge.charge(player);
-        Trade.log("Sign", "Repair", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Repair", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
         return true;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignSell.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignSell.java
@@ -48,7 +48,7 @@ public class SignSell extends EssentialsSign {
         charge.isAffordableFor(player);
         money.pay(player, OverflowType.DROP);
         charge.charge(player);
-        Trade.log("Sign", "Sell", "Interact", username, charge, username, money, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Sell", "Interact", username, charge, username, money, sign.getBlock().getLocation(), player.getMoney(), ess);
         return true;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignSpawnmob.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignSpawnmob.java
@@ -34,7 +34,7 @@ public class SignSpawnmob extends EssentialsSign {
         }
 
         charge.charge(player);
-        Trade.log("Sign", "Spawnmob", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Spawnmob", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
         return true;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignTime.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignTime.java
@@ -37,13 +37,13 @@ public class SignTime extends EssentialsSign {
         if ("§2Day".equalsIgnoreCase(timeString)) {
             player.getWorld().setTime(time + 24000);
             charge.charge(player);
-            Trade.log("Sign", "TimeDay", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+            Trade.log("Sign", "TimeDay", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
             return true;
         }
         if ("§2Night".equalsIgnoreCase(timeString)) {
             player.getWorld().setTime(time + 37700);
             charge.charge(player);
-            Trade.log("Sign", "TimeNight", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+            Trade.log("Sign", "TimeNight", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
             return true;
         }
         throw new SignException(tl("onlyDayNight"));

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignTrade.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignTrade.java
@@ -34,7 +34,7 @@ public class SignTrade extends EssentialsSign {
         trade.isAffordableFor(player);
         sign.setLine(3, "§8" + username);
         trade.charge(player);
-        Trade.log("Sign", "Trade", "Create", username, trade, username, null, sign.getBlock().getLocation(), ess);
+        Trade.log("Sign", "Trade", "Create", username, trade, username, null, sign.getBlock().getLocation(), player.getMoney(), ess);
         return true;
     }
 
@@ -50,17 +50,17 @@ public class SignTrade extends EssentialsSign {
                 final Map<Integer, ItemStack> withdraw = stored.pay(player, OverflowType.RETURN);
 
                 if (withdraw == null) {
-                    Trade.log("Sign", "Trade", "Withdraw", username, store, username, null, sign.getBlock().getLocation(), ess);
+                    Trade.log("Sign", "Trade", "Withdraw", username, store, username, null, sign.getBlock().getLocation(), player.getMoney(), ess);
                 } else {
                     setAmount(sign, 1, BigDecimal.valueOf(withdraw.get(0).getAmount()), ess);
-                    Trade.log("Sign", "Trade", "Withdraw", username, stored, username, new Trade(withdraw.get(0), ess), sign.getBlock().getLocation(), ess);
+                    Trade.log("Sign", "Trade", "Withdraw", username, stored, username, new Trade(withdraw.get(0), ess), sign.getBlock().getLocation(), player.getMoney(), ess);
                 }
             } catch (final SignException e) {
                 if (store == null) {
                     throw new SignException(tl("tradeSignEmptyOwner"), e);
                 }
             }
-            Trade.log("Sign", "Trade", "Deposit", username, store, username, null, sign.getBlock().getLocation(), ess);
+            Trade.log("Sign", "Trade", "Deposit", username, store, username, null, sign.getBlock().getLocation(), player.getMoney(), ess);
         } else {
             final Trade charge = getTrade(sign, 1, AmountType.COST, false, true, ess);
             final Trade trade = getTrade(sign, 2, AmountType.COST, true, true, ess);
@@ -73,7 +73,7 @@ public class SignTrade extends EssentialsSign {
                 throw new ChargeException("Full inventory");
             }
             charge.charge(player);
-            Trade.log("Sign", "Trade", "Interact", sign.getLine(3).substring(2), charge, username, trade, sign.getBlock().getLocation(), ess);
+            Trade.log("Sign", "Trade", "Interact", sign.getLine(3).substring(2), charge, username, trade, sign.getBlock().getLocation(), player.getMoney(), ess);
         }
         sign.updateSign();
         return true;
@@ -110,7 +110,7 @@ public class SignTrade extends EssentialsSign {
                 final Trade stored2 = getTrade(sign, 2, AmountType.TOTAL, false, true, ess);
 
                 if (!canCollect) {
-                    Trade.log("Sign", "Trade", "Destroy", signOwner.substring(2), stored2, username, stored1, sign.getBlock().getLocation(), ess);
+                    Trade.log("Sign", "Trade", "Destroy", signOwner.substring(2), stored2, username, stored1, sign.getBlock().getLocation(), player.getMoney(), ess);
                     return true;
                 }
 
@@ -118,15 +118,15 @@ public class SignTrade extends EssentialsSign {
                 final Map<Integer, ItemStack> withdraw2 = stored2.pay(player, OverflowType.RETURN);
 
                 if (withdraw1 == null && withdraw2 == null) {
-                    Trade.log("Sign", "Trade", "Break", signOwner.substring(2), stored2, username, stored1, sign.getBlock().getLocation(), ess);
+                    Trade.log("Sign", "Trade", "Break", signOwner.substring(2), stored2, username, stored1, sign.getBlock().getLocation(), player.getMoney(), ess);
                     return true;
                 }
 
                 setAmount(sign, 1, BigDecimal.valueOf(withdraw1 == null ? 0L : withdraw1.get(0).getAmount()), ess);
-                Trade.log("Sign", "Trade", "Withdraw", signOwner.substring(2), stored1, username, withdraw1 == null ? null : new Trade(withdraw1.get(0), ess), sign.getBlock().getLocation(), ess);
+                Trade.log("Sign", "Trade", "Withdraw", signOwner.substring(2), stored1, username, withdraw1 == null ? null : new Trade(withdraw1.get(0), ess), sign.getBlock().getLocation(), player.getMoney(), ess);
 
                 setAmount(sign, 2, BigDecimal.valueOf(withdraw2 == null ? 0L : withdraw2.get(0).getAmount()), ess);
-                Trade.log("Sign", "Trade", "Withdraw", signOwner.substring(2), stored2, username, withdraw2 == null ? null : new Trade(withdraw2.get(0), ess), sign.getBlock().getLocation(), ess);
+                Trade.log("Sign", "Trade", "Withdraw", signOwner.substring(2), stored2, username, withdraw2 == null ? null : new Trade(withdraw2.get(0), ess), sign.getBlock().getLocation(), player.getMoney(), ess);
 
                 sign.updateSign();
             } catch (final SignException e) {

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignWarp.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignWarp.java
@@ -57,7 +57,7 @@ public class SignWarp extends EssentialsSign {
         player.getAsyncTeleport().warp(player, warpName, charge, TeleportCause.PLUGIN, future);
         future.thenAccept(success -> {
             if (success) {
-                Trade.log("Sign", "Warp", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+                Trade.log("Sign", "Warp", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
             }
         });
         future.exceptionally(e -> {

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignWeather.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignWeather.java
@@ -36,13 +36,13 @@ public class SignWeather extends EssentialsSign {
         if ("§2Sun".equalsIgnoreCase(weatherString)) {
             player.getWorld().setStorm(false);
             charge.charge(player);
-            Trade.log("Sign", "WeatherSun", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+            Trade.log("Sign", "WeatherSun", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
             return true;
         }
         if ("§2Storm".equalsIgnoreCase(weatherString)) {
             player.getWorld().setStorm(true);
             charge.charge(player);
-            Trade.log("Sign", "WeatherStorm", "Interact", username, null, username, charge, sign.getBlock().getLocation(), ess);
+            Trade.log("Sign", "WeatherStorm", "Interact", username, null, username, charge, sign.getBlock().getLocation(), player.getMoney(), ess);
             return true;
         }
         throw new SignException(tl("onlySunStorm"));


### PR DESCRIPTION
### Information
Fixes #3116 

### Details
Add the user's ending balance as the final field in the log where applicable to avoid breaking any existing parsers that rely on field order as much as possible. Chose to modify the method signature as it was the easiest option as a User object is not passed in and recreating one with the partial username that is passed in would be tricky (expensive and I believe would need to use deprecated functions).

**Environments Tested:**
Spigot 1.16.3