### PR TITLE
Fix for essentials and sleeping plugins.

### DIFF
--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -315,7 +315,7 @@ public class EssentialsPlayerListener implements Listener {
                     }
                 }
 
-                if (user.isAuthorized("essentials.sleepingignored") && ess.getSettings().ignoreSleepingIgnored()) {
+                if (user.isAuthorized("essentials.sleepingignored") && !ess.getSettings().ignoreSleepingIgnored()) {
                     user.getBase().setSleepingIgnored(true);
                 }
 

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -315,7 +315,7 @@ public class EssentialsPlayerListener implements Listener {
                     }
                 }
 
-                if (user.isAuthorized("essentials.sleepingignored")) {
+                if (user.isAuthorized("essentials.sleepingignored") && ess.getSettings().ignoreSleepingIgnored()) {
                     user.getBase().setSleepingIgnored(true);
                 }
 

--- a/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -315,7 +315,7 @@ public class EssentialsPlayerListener implements Listener {
                     }
                 }
 
-                if (user.isAuthorized("essentials.sleepingignored") && !ess.getSettings().ignoreSleepingIgnored()) {
+                if (user.isAuthorized("essentials.sleepingignored") && !ess.getSettings().ignoreSleepingIgnored() && !user.isAfk()) {
                     user.getBase().setSleepingIgnored(true);
                 }
 

--- a/Essentials/src/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/com/earth2me/essentials/ISettings.java
@@ -201,6 +201,8 @@ public interface ISettings extends IConf {
 
     boolean sleepIgnoresAfkPlayers();
 
+    boolean ignoreSleepingIgnored();
+
     boolean isAfkListName();
 
     String getAfkListName();

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -89,6 +89,7 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean cancelAfkOnMove;
     private boolean cancelAfkOnInteract;
     private boolean sleepIgnoresAfkPlayers;
+    private boolean ignoreSleepingIgnored;
     private String afkListName;
     private boolean isAfkListName;
     private boolean broadcastAfkMessage;

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -595,6 +595,7 @@ public class Settings implements net.ess3.api.ISettings {
         cancelAfkOnMove = _cancelAfkOnMove();
         getFreezeAfkPlayers = _getFreezeAfkPlayers();
         sleepIgnoresAfkPlayers = _sleepIgnoresAfkPlayers();
+        sleepIgnoresAfkPlayers = _sleepIgnoresAfkPlayers();
         afkListName = _getAfkListName();
         isAfkListName = !afkListName.equalsIgnoreCase("none");
         broadcastAfkMessage = _broadcastAfkMessage();
@@ -982,6 +983,15 @@ public class Settings implements net.ess3.api.ISettings {
 
     private boolean _sleepIgnoresAfkPlayers() {
         return config.getBoolean("sleep-ignores-afk-players", true);
+    }
+    
+    @Override
+    public boolean ignoreSleepingIgnored() {
+        return ignoreSleepingIgnored;
+    }
+
+    private boolean _ignoreSleepingIgnored() {
+        return config.getBoolean("ignore-sleepingignored-permission", false);
     }
 
     public String _getAfkListName() {

--- a/Essentials/src/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/com/earth2me/essentials/Settings.java
@@ -991,7 +991,7 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     private boolean _ignoreSleepingIgnored() {
-        return config.getBoolean("ignore-sleepingignored-permission", false);
+        return config.getBoolean("ignore-sleepingignored-permission-for-non-afk-players", false);
     }
 
     public String _getAfkListName() {

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -455,6 +455,11 @@ cancel-afk-on-move: true
 # Users with the permission node essentials.sleepingignored will always be ignored.
 sleep-ignores-afk-players: true
 
+# Should players with essentials.* permission use essentials.sleepingignored?
+# When this setting is true, sleeping will ignore essentials.sleepingignored.
+# Enabled this if you use a Sleep Plugin.
+ignore-sleepingignored-permission: false
+
 # Set the player's list name when they are AFK. This is none by default which specifies that Essentials 
 # should not interfere with the AFK player's list name.
 # You may use color codes, use {USERNAME} the player's name or {PLAYER} for the player's displayname.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -458,7 +458,7 @@ sleep-ignores-afk-players: true
 # Should players with essentials.* permission use essentials.sleepingignored?
 # When this setting is true, sleeping will ignore essentials.sleepingignored.
 # Enabled this if you use a Sleep Plugin.
-ignore-sleepingignored-permission: false
+ignore-sleepingignored-permission-for-non-afk-players: false
 
 # Set the player's list name when they are AFK. This is none by default which specifies that Essentials 
 # should not interfere with the AFK player's list name.

--- a/Essentials/src/config.yml
+++ b/Essentials/src/config.yml
@@ -455,8 +455,8 @@ cancel-afk-on-move: true
 # Users with the permission node essentials.sleepingignored will always be ignored.
 sleep-ignores-afk-players: true
 
-# Should players with essentials.* permission use essentials.sleepingignored?
-# When this setting is true, sleeping will ignore essentials.sleepingignored.
+# Should players with essentials.* permission that are not afk count as essentials.sleepingignored?
+# When this setting is true, sleeping will ignore essentials.sleepingignored for non afk players.
 # Enabled this if you use a Sleep Plugin.
 ignore-sleepingignored-permission-for-non-afk-players: false
 


### PR DESCRIPTION
Adds a default false config option for players that wish to use a separate plugin to control sleep.
```
# Should players with essentials.* permission that are not afk count as essentials.sleepingignored?
# When this setting is true, sleeping will ignore essentials.sleepingignored for non afk players.
# Enabled this if you use a Sleep Plugin.
ignore-sleepingignored-permission-for-non-afk-players: false
```
It has not been tested, but is only a config, and a boolean check before adding a player to the ignored list.
I welcome cordial comments or criticism.