### PR TITLE
Split backup command by space

### DIFF
--- a/Essentials/src/com/earth2me/essentials/Backup.java
+++ b/Essentials/src/com/earth2me/essentials/Backup.java
@@ -88,7 +88,7 @@ public class Backup implements Runnable {
 
         ess.runTaskAsynchronously(() -> {
             try {
-                final ProcessBuilder childBuilder = new ProcessBuilder(command);
+                final ProcessBuilder childBuilder = new ProcessBuilder(command.split(" "));
                 childBuilder.redirectErrorStream(true);
                 childBuilder.directory(ess.getDataFolder().getParentFile().getParentFile());
                 final Process child = childBuilder.start();


### PR DESCRIPTION
Splits command sent to ProcessBuilder by spaces. Fixes backup commands with arguments

Fixes #3759