### PR TITLE
Use ray-tracing based target block for 1.13.2+

### DIFF
--- a/Essentials/src/com/earth2me/essentials/IUser.java
+++ b/Essentials/src/com/earth2me/essentials/IUser.java
@@ -7,6 +7,7 @@ import net.ess3.api.MaxMoneyException;
 import net.ess3.api.events.AfkStatusChangeEvent;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 import java.math.BigDecimal;
@@ -207,4 +208,6 @@ public interface IUser {
     void setLastMessageReplyRecipient(boolean enabled);
 
     Map<User, BigDecimal> getConfirmingPayments();
+
+    Block getTargetBlock(int maxDistance);
 }

--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -17,6 +17,7 @@ import net.ess3.api.events.MuteStatusChangeEvent;
 import net.ess3.api.events.UserBalanceUpdateEvent;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.ItemStack;
@@ -1008,5 +1009,14 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
 
     public void setLastHomeConfirmationTimestamp() {
         this.lastHomeConfirmationTimestamp = System.currentTimeMillis();
+    }
+
+    @Override
+    public Block getTargetBlock(int maxDistance) {
+        final Block block;
+        if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_13_2_R01) || (block = base.getTargetBlockExact(maxDistance)) == null) {
+            return base.getTargetBlock(null, maxDistance);
+        }
+        return block;
     }
 }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandbreak.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandbreak.java
@@ -17,7 +17,7 @@ public class Commandbreak extends EssentialsCommand {
     @Override
     public void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
 
-        final Block block = user.getBase().getTargetBlock(null, 20);
+        final Block block = user.getTargetBlock(20);
         if (block.getType() == Material.AIR) {
             throw new NoChargeException();
         }

--- a/Essentials/src/com/earth2me/essentials/commands/Commandeditsign.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandeditsign.java
@@ -25,7 +25,7 @@ public class Commandeditsign extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
 
-        final Block target = user.getBase().getTargetBlock(null, 5); //5 is a good number
+        final Block target = user.getTargetBlock(5); //5 is a good number
         if (!(target.getState() instanceof Sign)) {
             throw new Exception(tl("editsignCommandTarget"));
         }
@@ -69,7 +69,7 @@ public class Commandeditsign extends EssentialsCommand {
             return Lists.newArrayList("1", "2", "3", "4");
         } else if (args.length == 3 && args[0].equalsIgnoreCase("set") && NumberUtil.isPositiveInt(args[1])) {
             final int line = Integer.parseInt(args[1]);
-            final Block target = user.getBase().getTargetBlock(null, 5);
+            final Block target = user.getTargetBlock(5);
             if (target.getState() instanceof Sign && line <= 4) {
                 final Sign sign = (Sign) target.getState();
                 return Lists.newArrayList(FormatUtil.unformatString(user, "essentials.editsign", sign.getLine(line - 1)));

--- a/Essentials/src/com/earth2me/essentials/commands/Commandlightning.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commandlightning.java
@@ -20,7 +20,7 @@ public class Commandlightning extends EssentialsLoopCommand {
     public void run(final Server server, final CommandSource sender, final String commandLabel, final String[] args) throws Exception {
         if (args.length == 0 || !sender.isAuthorized("essentials.lightning.others", ess)) {
             if (sender.isPlayer()) {
-                sender.getPlayer().getWorld().strikeLightning(sender.getPlayer().getTargetBlock(null, 600).getLocation());
+                sender.getPlayer().getWorld().strikeLightning(sender.getUser(ess).getTargetBlock(600).getLocation());
                 return;
             }
             throw new NotEnoughArgumentsException();

--- a/Essentials/src/com/earth2me/essentials/signs/SignPlayerListener.java
+++ b/Essentials/src/com/earth2me/essentials/signs/SignPlayerListener.java
@@ -37,7 +37,7 @@ public class SignPlayerListener implements Listener {
         if (event.isCancelled() && event.getAction() == Action.RIGHT_CLICK_AIR) {
             Block targetBlock = null;
             try {
-                targetBlock = event.getPlayer().getTargetBlock(null, 5);
+                targetBlock = ess.getUser(event.getPlayer()).getTargetBlock(5);
             } catch (final IllegalStateException ex) {
                 if (ess.getSettings().isDebug()) {
                     ess.getLogger().log(Level.WARNING, ex.getMessage(), ex);


### PR DESCRIPTION
Uses new method of ray-tracing to target block instead of using BlockIterator which doesn't respect the player looking at a different y-level. Falls back to old BlockIterator method on server versions older than 1.13.2

Fixes #3756