### PR TITLE
Fix tab completion for /delhome

### DIFF
--- a/Essentials/src/com/earth2me/essentials/commands/Commanddelhome.java
+++ b/Essentials/src/com/earth2me/essentials/commands/Commanddelhome.java
@@ -57,7 +57,7 @@ public class Commanddelhome extends EssentialsCommand {
         final IUser user = sender.getUser(ess);
         final boolean canDelOthers = sender.isAuthorized("essentials.delhome.others", ess);
         if (args.length == 1) {
-            final List<String> homes = sender.isPlayer() ? new ArrayList<>() : user.getHomes();
+            final List<String> homes = user == null ? new ArrayList<>() : user.getHomes();
             if (canDelOthers) {
                 final int sepIndex = args[0].indexOf(':');
                 if (sepIndex < 0) {


### PR DESCRIPTION
There was a minor issue with one line of code in delhome which was causing the user's homes not to be listed since the condition was effectively reversed. This was also causing an NPE for console senders attempting to tab complete.

Fixes #3774
