### PR TITLE
Track player permissions checks

### DIFF
--- a/Essentials/src/com/earth2me/essentials/User.java
+++ b/Essentials/src/com/earth2me/essentials/User.java
@@ -131,7 +131,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             lastTrackedPermission.clear();
         }
 
-        boolean hasPermission = ess.getPermissionsHandler().hasPermission(base, node);
+        final boolean hasPermission = ess.getPermissionsHandler().hasPermission(base, node);
         lastTrackedPermission.put(node, hasPermission);
 
         try {


### PR DESCRIPTION
This PR improves the processes that luckperms constantly logs done by various plugins. This change is against authorization tracking so that the plugin does not re-check the player authorization if it have already checked it.

Related #2137 

![kép](https://user-images.githubusercontent.com/30026208/99193038-a272f880-2776-11eb-9fa5-900042c16016.png)