### PR TITLE
Fix incompatibility on TacoSpigot and derivatives

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -285,7 +285,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 }
 
                 //Spawn Egg Providers
-                if (VersionUtil.getServerBukkitVersion().isLowerThanOrEqualTo(VersionUtil.v1_8_8_R01)) {
+                if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_9_R01)) {
                     spawnEggProvider = new LegacySpawnEggProvider();
                 } else if (VersionUtil.getServerBukkitVersion().isLowerThanOrEqualTo(VersionUtil.v1_12_2_R01)) {
                     spawnEggProvider = new ReflSpawnEggProvider();
@@ -294,7 +294,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 }
 
                 //Potion Meta Provider
-                if (VersionUtil.getServerBukkitVersion().isLowerThanOrEqualTo(VersionUtil.v1_8_8_R01)) {
+                if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_9_R01)) {
                     potionMetaProvider = new LegacyPotionMetaProvider();
                 } else {
                     potionMetaProvider = new BasePotionDataProvider();


### PR DESCRIPTION
The countless support tickets from users of TacoSpigot (and forks of it)
have become so numerous it's not worth holding our ground on this. Taco fucked up
by going against upstream revision numbers, but as they're defunct, it's not
going to change now. We will not fix server implementations that do this in the
future, but hopefully they have all learned their lesson not to use proper
versioning. The way md_5 intended.