### PR TITLE
Fix incorrect /me behaviour in local chat

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandme.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandme.java
@@ -40,12 +40,13 @@ public class Commandme extends EssentialsCommand {
         message = FormatUtil.formatMessage(user, "essentials.chat", message);
 
         user.setDisplayNick();
-        final int radius = ess.getSettings().getChatRadius();
+        long radius = ess.getSettings().getChatRadius();
         final String toSend = tl("action", user.getDisplayName(), message);
         if (radius < 1) {
             ess.broadcastMessage(user, toSend);
             return;
         }
+        radius *= radius;
 
         final World world = user.getWorld();
         final Location loc = user.getLocation();


### PR DESCRIPTION
### Information

This PR fixes #3834, where /me does not correctly respect the local chat radius if one is set.

### Details

**Proposed fix:**    
This PR adds the missing operation to square the chat radius before comparing it. This operation is present in EssentialsXChat's local chat listener, but was left out here.

**Environments tested:**    
- [x] [Latest](https://papermc.io/downloads) Paper Version (any OS, any Java 8+ version)