### PR TITLE
Fix Improper Use of Event API

### DIFF
--- a/Essentials/src/main/java/net/ess3/api/events/AfkStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/AfkStatusChangeEvent.java
@@ -1,11 +1,13 @@
 package net.ess3.api.events;
 
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when a player's AFK status changes.
  */
 public class AfkStatusChangeEvent extends StatusChangeEvent {
+    private static final HandlerList handlers = new HandlerList();
     private final Cause cause;
 
     @Deprecated
@@ -20,6 +22,15 @@ public class AfkStatusChangeEvent extends StatusChangeEvent {
 
     public Cause getCause() {
         return cause;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 
     /**

--- a/Essentials/src/main/java/net/ess3/api/events/FlyStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/FlyStatusChangeEvent.java
@@ -1,12 +1,24 @@
 package net.ess3.api.events;
 
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when a player's flight status is toggled using /fly.
  */
 public class FlyStatusChangeEvent extends StatusChangeEvent {
+    private static final HandlerList handlers = new HandlerList();
+
     public FlyStatusChangeEvent(final IUser affected, final IUser controller, final boolean value) {
         super(affected, controller, value);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/GodStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/GodStatusChangeEvent.java
@@ -1,6 +1,7 @@
 package net.ess3.api.events;
 
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when a user's god status is toggled.
@@ -9,7 +10,18 @@ import net.ess3.api.IUser;
  * and #getController methods are inverted.
  */
 public class GodStatusChangeEvent extends StatusChangeEvent {
+    private static final HandlerList handlers = new HandlerList();
+
     public GodStatusChangeEvent(final IUser affected, final IUser controller, final boolean value) {
         super(affected, controller, value);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/IgnoreStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/IgnoreStatusChangeEvent.java
@@ -1,12 +1,24 @@
 package net.ess3.api.events;
 
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * This event is currently unused, and is retained for ABI compatibility and potential future implementation.
  */
 public class IgnoreStatusChangeEvent extends StatusChangeEvent {
+    private static final HandlerList handlers = new HandlerList();
+
     public IgnoreStatusChangeEvent(final IUser affected, final IUser controller, final boolean value) {
         super(affected, controller, value);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/JailStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/JailStatusChangeEvent.java
@@ -11,6 +11,7 @@ import org.bukkit.event.HandlerList;
  */
 public class JailStatusChangeEvent extends StatusChangeEvent {
     private static final HandlerList handlers = new HandlerList();
+
     public JailStatusChangeEvent(final IUser affected, final IUser controller, final boolean value) {
         super(affected, controller, value);
     }

--- a/Essentials/src/main/java/net/ess3/api/events/JailStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/JailStatusChangeEvent.java
@@ -1,6 +1,7 @@
 package net.ess3.api.events;
 
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when a player's jail status changes.
@@ -9,7 +10,17 @@ import net.ess3.api.IUser;
  * You <i>can</i>, however, access the player's current jail when they are about to be unjailed by calling {@link IUser#getJail()}.
  */
 public class JailStatusChangeEvent extends StatusChangeEvent {
+    private static final HandlerList handlers = new HandlerList();
     public JailStatusChangeEvent(final IUser affected, final IUser controller, final boolean value) {
         super(affected, controller, value);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/MuteStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/MuteStatusChangeEvent.java
@@ -1,6 +1,7 @@
 package net.ess3.api.events;
 
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 import java.util.Optional;
 
@@ -8,6 +9,7 @@ import java.util.Optional;
  * Fired when a player's mute status is changed.
  */
 public class MuteStatusChangeEvent extends StatusChangeEvent {
+    private static final HandlerList handlers = new HandlerList();
     private final Long timestamp;
     private final String reason;
 
@@ -29,5 +31,14 @@ public class MuteStatusChangeEvent extends StatusChangeEvent {
      */
     public String getReason() {
         return reason;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/NickChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/NickChangeEvent.java
@@ -2,6 +2,7 @@ package net.ess3.api.events;
 
 import net.ess3.api.IUser;
 import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when a player's nickname is changed.
@@ -9,6 +10,7 @@ import org.bukkit.event.Cancellable;
  * <b>WARNING: The values of {@link NickChangeEvent#getAffected()} and {@link NickChangeEvent#getController()} are inverted due to a long-standing implementation bug.</b>
  */
 public class NickChangeEvent extends StateChangeEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
     private final String newValue;
 
     public NickChangeEvent(final IUser affected, final IUser controller, final String value) {
@@ -40,5 +42,14 @@ public class NickChangeEvent extends StateChangeEvent implements Cancellable {
     @Override
     public IUser getController() {
         return super.getController();
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/SignBreakEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/SignBreakEvent.java
@@ -2,6 +2,7 @@ package net.ess3.api.events;
 
 import com.earth2me.essentials.signs.EssentialsSign;
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when an Essentials sign is broken.
@@ -9,7 +10,18 @@ import net.ess3.api.IUser;
  * This is primarily intended for use with EssentialsX's sign abstraction - external plugins should not listen on this event.
  */
 public class SignBreakEvent extends SignEvent {
+    private static final HandlerList handlers = new HandlerList();
+
     public SignBreakEvent(final EssentialsSign.ISign sign, final EssentialsSign essSign, final IUser user) {
         super(sign, essSign, user);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/SignCreateEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/SignCreateEvent.java
@@ -2,6 +2,7 @@ package net.ess3.api.events;
 
 import com.earth2me.essentials.signs.EssentialsSign;
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when an Essentials sign is created.
@@ -9,7 +10,18 @@ import net.ess3.api.IUser;
  * This is primarily intended for use with EssentialsX's sign abstraction - external plugins should not listen on this event.
  */
 public class SignCreateEvent extends SignEvent {
+    private static final HandlerList handlers = new HandlerList();
+
     public SignCreateEvent(final EssentialsSign.ISign sign, final EssentialsSign essSign, final IUser user) {
         super(sign, essSign, user);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/SignEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/SignEvent.java
@@ -6,13 +6,11 @@ import net.ess3.api.IUser;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
-import org.bukkit.event.HandlerList;
 
 /**
  * This handles common boilerplate for other SignEvent
  */
-public class SignEvent extends Event implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
+public abstract class SignEvent extends Event implements Cancellable {
     final ISign sign;
     final EssentialsSign essSign;
     final IUser user;
@@ -25,10 +23,6 @@ public class SignEvent extends Event implements Cancellable {
         this.user = user;
     }
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
     public ISign getSign() {
         return sign;
     }
@@ -39,11 +33,6 @@ public class SignEvent extends Event implements Cancellable {
 
     public IUser getUser() {
         return user;
-    }
-
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
     }
 
     @Override

--- a/Essentials/src/main/java/net/ess3/api/events/SignInteractEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/SignInteractEvent.java
@@ -2,6 +2,7 @@ package net.ess3.api.events;
 
 import com.earth2me.essentials.signs.EssentialsSign;
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when an Essentials sign is interacted with.
@@ -9,7 +10,18 @@ import net.ess3.api.IUser;
  * This is primarily intended for use with EssentialsX's sign abstraction - external plugins should not listen on this event.
  */
 public class SignInteractEvent extends SignEvent {
+    private static final HandlerList handlers = new HandlerList();
+
     public SignInteractEvent(final EssentialsSign.ISign sign, final EssentialsSign essSign, final IUser user) {
         super(sign, essSign, user);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }

--- a/Essentials/src/main/java/net/ess3/api/events/StateChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/StateChangeEvent.java
@@ -3,14 +3,12 @@ package net.ess3.api.events;
 import net.ess3.api.IUser;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
-import org.bukkit.event.HandlerList;
 
 /**
  * This handles common boilerplate for events for changes in state.
  * For boolean state, events should extend StatusChangeEvent instead.
  */
 public abstract class StateChangeEvent extends Event implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
     final IUser affected;
     final IUser controller;
     private boolean cancelled = false;
@@ -25,10 +23,6 @@ public abstract class StateChangeEvent extends Event implements Cancellable {
         super(isAsync);
         this.affected = affected;
         this.controller = controller;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
     }
 
     /**
@@ -47,11 +41,6 @@ public abstract class StateChangeEvent extends Event implements Cancellable {
      */
     public IUser getController() {
         return controller;
-    }
-
-    @Override
-    public HandlerList getHandlers() {
-        return handlers;
     }
 
     @Override

--- a/Essentials/src/main/java/net/ess3/api/events/VanishStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/VanishStatusChangeEvent.java
@@ -1,6 +1,7 @@
 package net.ess3.api.events;
 
 import net.ess3.api.IUser;
+import org.bukkit.event.HandlerList;
 
 /**
  * Fired when a player's vanish status changes due to the /vanish command.
@@ -9,7 +10,18 @@ import net.ess3.api.IUser;
  * check with {@link IUser#isVanished()}.
  */
 public class VanishStatusChangeEvent extends StatusChangeEvent {
+    private static final HandlerList handlers = new HandlerList();
+
     public VanishStatusChangeEvent(final IUser affected, final IUser controller, final boolean value) {
         super(affected, controller, value);
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
     }
 }


### PR DESCRIPTION
Some of Essentials' general event classes such as `StatusChangeEvent` or `StateChangeEvent` store the handler lists for events rather then keep them in the actual event classes. This causes bukkit to dispatch events for all events extending the super-class when using event executors since there isn't a separate handler list per event.

Fixes #3852