### PR TITLE
Fix behaviour of /list when showing real names

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
@@ -38,7 +38,7 @@ public final class PlayerList {
             user.setDisplayNick();
             groupString.append(user.getDisplayName());
 
-            String strippedNick = FormatUtil.stripEssentialsFormat(user.getNickname());
+            final String strippedNick = FormatUtil.stripEssentialsFormat(user.getNickname());
             if (ess.getSettings().realNamesOnList() && strippedNick != null && !strippedNick.equals(user.getName())) {
                 groupString.append(" (").append(user.getName()).append(")");
             }

--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
@@ -37,7 +37,9 @@ public final class PlayerList {
             }
             user.setDisplayNick();
             groupString.append(user.getDisplayName());
-            if (ess.getSettings().realNamesOnList() && !ChatColor.stripColor(user.getDisplayName()).equals(user.getName())) {
+
+            String strippedNick = FormatUtil.stripEssentialsFormat(user.getNickname());
+            if (ess.getSettings().realNamesOnList() && strippedNick != null && !strippedNick.equals(user.getName())) {
                 groupString.append(" (").append(user.getName()).append(")");
             }
             groupString.append(ChatColor.WHITE.toString());

--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
@@ -38,7 +38,7 @@ public final class PlayerList {
             user.setDisplayNick();
             groupString.append(user.getDisplayName());
 
-            final String strippedNick = FormatUtil.stripEssentialsFormat(user.getNickname());
+            final String strippedNick = FormatUtil.stripFormat(user.getNickname());
             if (ess.getSettings().realNamesOnList() && strippedNick != null && !strippedNick.equals(user.getName())) {
                 groupString.append(" (").append(user.getName()).append(")");
             }


### PR DESCRIPTION
### Information

This PR fixes #3790, where in some cases `real-names-on-list` appends the player's real name to the `/list` output when they don't have a nickname.

### Details

**Proposed fix:**    
The current `real-names-on-list` implementation uses the displayname of the user, which causes the real name check to fail if prefixes or suffixes have been added to the displayname. This PR limits the real name check to just the user's nickname instead of using the whole displayname.

**Environments tested:**    
- [x] [Latest](https://papermc.io/downloads) Paper Version (any OS, any Java 8+ version)