### PR TITLE
Correct handling of tprandom min-range

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/RandomTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/RandomTeleport.java
@@ -157,7 +157,7 @@ public class RandomTeleport implements IConf {
         final CompletableFuture<Location> future = new CompletableFuture<>();
         // Find an equally distributed offset by randomly rotating a point inside a rectangle about the origin
         final double rectX = RANDOM.nextDouble() * (maxRange - minRange) + minRange;
-        final double rectZ = RANDOM.nextDouble() * (maxRange + minRange) - minRange;
+        final double rectZ = RANDOM.nextDouble() * (maxRange - minRange) + minRange;
         final double offsetX;
         final double offsetZ;
         final int transform = RANDOM.nextInt(4);
@@ -165,14 +165,14 @@ public class RandomTeleport implements IConf {
             offsetX = rectX;
             offsetZ = rectZ;
         } else if (transform == 1) {
-            offsetX = -rectZ;
-            offsetZ = rectX;
+            offsetX = -rectX;
+            offsetZ = rectZ;
         } else if (transform == 2) {
             offsetX = -rectX;
             offsetZ = -rectZ;
         } else {
-            offsetX = rectZ;
-            offsetZ = -rectX;
+            offsetX = rectX;
+            offsetZ = -rectZ;
         }
         final Location location = new Location(
             center.getWorld(),


### PR DESCRIPTION
This corrects the calculation of the coordinates for the /tprandom command. The old calculation could result in coordinates that are less than the min-range distance from the center point. See the linked issue for details.

This also changes the X/Z assignments for two of the quadrants to be consistent with the others, to avoid confusing more people in the future.

Fixes #3870