### PR TITLE
Allow users to middle click in armor invsee

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -807,7 +807,7 @@ public class EssentialsPlayerListener implements Listener {
         } else if (type == InventoryType.CHEST && top.getSize() == 9) {
             final User user = ess.getUser((Player) event.getWhoClicked());
             final InventoryHolder invHolder = top.getHolder();
-            if (invHolder instanceof HumanEntity && user.isInvSee()) {
+            if (invHolder instanceof HumanEntity && user.isInvSee() && event.getClick() != ClickType.MIDDLE) {
                 event.setCancelled(true);
                 refreshPlayer = user.getBase();
             }


### PR DESCRIPTION
Allows users in creative mode to middle mouse click in order to duplicate other user's armor items since they cannot be directly removed in the first place.

Closes #3884