### PR TITLE
Block removing hats with curse of binding using direct-hat

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -782,8 +783,8 @@ public class EssentialsPlayerListener implements Listener {
             clickedInventory = event.getRawSlot() < top.getSize() ? top : event.getView().getBottomInventory();
         }
 
+        final User user = ess.getUser((Player) event.getWhoClicked());
         if (type == InventoryType.PLAYER) {
-            final User user = ess.getUser((Player) event.getWhoClicked());
             final InventoryHolder invHolder = top.getHolder();
             if (invHolder instanceof HumanEntity) {
                 final User invOwner = ess.getUser((Player) invHolder);
@@ -793,19 +794,16 @@ public class EssentialsPlayerListener implements Listener {
                 }
             }
         } else if (type == InventoryType.ENDER_CHEST) {
-            final User user = ess.getUser((Player) event.getWhoClicked());
             if (user.isEnderSee() && !user.isAuthorized("essentials.enderchest.modify")) {
                 event.setCancelled(true);
                 refreshPlayer = user.getBase();
             }
         } else if (type == InventoryType.WORKBENCH) {
-            final User user = ess.getUser((Player) event.getWhoClicked());
             if (user.isRecipeSee()) {
                 event.setCancelled(true);
                 refreshPlayer = user.getBase();
             }
         } else if (type == InventoryType.CHEST && top.getSize() == 9) {
-            final User user = ess.getUser((Player) event.getWhoClicked());
             final InventoryHolder invHolder = top.getHolder();
             if (invHolder instanceof HumanEntity && user.isInvSee() && event.getClick() != ClickType.MIDDLE) {
                 event.setCancelled(true);
@@ -815,7 +813,8 @@ public class EssentialsPlayerListener implements Listener {
             if (ess.getSettings().isDirectHatAllowed() && event.getClick() == ClickType.LEFT && event.getSlot() == 39
                 && event.getCursor().getType() != Material.AIR && event.getCursor().getType().getMaxDurability() == 0
                 && !MaterialUtil.isSkull(event.getCursor().getType())
-                && ess.getUser(event.getWhoClicked()).isAuthorized("essentials.hat") && !ess.getUser(event.getWhoClicked()).isAuthorized("essentials.hat.prevent-type." + event.getCursor().getType().name().toLowerCase())) {
+                && user.isAuthorized("essentials.hat") && !user.isAuthorized("essentials.hat.prevent-type." + event.getCursor().getType().name().toLowerCase())
+                && !isPreventBindingHat(user, (PlayerInventory) clickedInventory)) {
                 event.setCancelled(true);
                 final PlayerInventory inv = (PlayerInventory) clickedInventory;
                 final ItemStack head = inv.getHelmet();
@@ -827,6 +826,14 @@ public class EssentialsPlayerListener implements Listener {
         if (refreshPlayer != null) {
             ess.scheduleSyncDelayedTask(refreshPlayer::updateInventory, 1);
         }
+    }
+
+    private boolean isPreventBindingHat(User user, PlayerInventory inventory) {
+        if (VersionUtil.getServerBukkitVersion().isHigherThan(VersionUtil.v1_9_4_R01)) {
+            final ItemStack head = inventory.getHelmet();
+            return head != null && head.getEnchantments().containsKey(Enchantment.BINDING_CURSE) && !user.isAuthorized("essentials.hat.ignore-binding");
+        }
+        return false;
     }
 
     @EventHandler(priority = EventPriority.MONITOR)


### PR DESCRIPTION
Fixed loophole that allowed users to bypass curse of binding when using direct hat feature.

Related #3299
