### PR TITLE
Add option to disable custom server-full message

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -472,7 +472,9 @@ public class EssentialsPlayerListener implements Listener {
                 event.allow();
                 return;
             }
-            event.disallow(Result.KICK_FULL, tl("serverFull"));
+            if (ess.getSettings().isCustomServerFullMessage()) {
+                event.disallow(Result.KICK_FULL, tl("serverFull"));
+            }
         }
     }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -285,6 +285,8 @@ public interface ISettings extends IConf {
 
     String getCustomQuitMessage();
 
+    boolean isCustomServerFullMessage();
+
     boolean isNotifyNoNewMail();
 
     boolean isDropItemsIfFull();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -111,6 +111,7 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean isCustomJoinMessage;
     private String customQuitMessage;
     private boolean isCustomQuitMessage;
+    private boolean isCustomServerFullMessage;
     private List<String> spawnOnJoinGroups;
     private Map<Pattern, Long> commandCooldowns;
     private boolean npcsInBalanceRanking = false;
@@ -630,6 +631,8 @@ public class Settings implements net.ess3.api.ISettings {
         isCustomJoinMessage = !customJoinMessage.equals("none");
         customQuitMessage = _getCustomQuitMessage();
         isCustomQuitMessage = !customQuitMessage.equals("none");
+        isCustomServerFullMessage = _isCustomServerFullMessage();
+
         muteCommands = _getMuteCommands();
         spawnOnJoinGroups = _getSpawnOnJoinGroups();
         commandCooldowns = _getCommandCooldowns();
@@ -1274,6 +1277,15 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean isCustomQuitMessage() {
         return isCustomQuitMessage;
+    }
+
+    @Override
+    public boolean isCustomServerFullMessage() {
+        return isCustomServerFullMessage;
+    }
+
+    private boolean _isCustomServerFullMessage() {
+        return config.getBoolean("use-custom-server-full-message", true);
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -111,7 +111,6 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean isCustomJoinMessage;
     private String customQuitMessage;
     private boolean isCustomQuitMessage;
-    private boolean isCustomServerFullMessage;
     private List<String> spawnOnJoinGroups;
     private Map<Pattern, Long> commandCooldowns;
     private boolean npcsInBalanceRanking = false;
@@ -631,8 +630,6 @@ public class Settings implements net.ess3.api.ISettings {
         isCustomJoinMessage = !customJoinMessage.equals("none");
         customQuitMessage = _getCustomQuitMessage();
         isCustomQuitMessage = !customQuitMessage.equals("none");
-        isCustomServerFullMessage = _isCustomServerFullMessage();
-
         muteCommands = _getMuteCommands();
         spawnOnJoinGroups = _getSpawnOnJoinGroups();
         commandCooldowns = _getCommandCooldowns();
@@ -1281,10 +1278,6 @@ public class Settings implements net.ess3.api.ISettings {
 
     @Override
     public boolean isCustomServerFullMessage() {
-        return isCustomServerFullMessage;
-    }
-
-    private boolean _isCustomServerFullMessage() {
         return config.getBoolean("use-custom-server-full-message", true);
     }
 

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -497,7 +497,8 @@ allow-silent-join-quit: false
 custom-join-message: "none"
 custom-quit-message: "none"
 
-# Override default Minecraft "The server is full!" message with the custom one from the language file?
+# Should Essentials override the vanilla "Server Full" message with its own from the language file?
+# Set to false to keep the vanilla message.
 use-custom-server-full-message: true
 
 # You can disable join and quit messages when the player count reaches a certain limit.

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -497,7 +497,7 @@ allow-silent-join-quit: false
 custom-join-message: "none"
 custom-quit-message: "none"
 
-# Override default Minecraft "Server full" message with the custom one from the language file?
+# Override default Minecraft "The server is full!" message with the custom one from the language file?
 use-custom-server-full-message: true
 
 # You can disable join and quit messages when the player count reaches a certain limit.

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -497,6 +497,9 @@ allow-silent-join-quit: false
 custom-join-message: "none"
 custom-quit-message: "none"
 
+# Override default Minecraft "Server full" message with the custom one from the language file?
+use-custom-server-full-message: true
+
 # You can disable join and quit messages when the player count reaches a certain limit.
 # When the player count is below this number, join/quit messages will always be shown.
 # Set this to -1 to always show join and quit messages regardless of player count.


### PR DESCRIPTION
Related to #3898.

Described in the issue will break current behavior, so instead just a configurable option to disable Ess' message.

Otherwise, I guess checking for `Paper.isSpigot()` and using `Bukkit.spigot().getConfig().getString("server-full")` (according to [helpch.at](https://helpch.at/docs/1.8.8/org/bukkit/Server.Spigot.html#getConfig()), should be compatible with 1.8) will do the thing.