### PR TITLE
Properly detect enchantments with improper names

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
@@ -286,7 +286,7 @@ public final class Enchantments {
             enchatment = Enchantment.getByName(name);
         }
         if (enchantment == null) {
-            enchantment = Enchantment.getByName(name.toLowerCaseCase());
+            enchantment = Enchantment.getByName(name.toLowerCase());
         }        
         if (enchantment == null) {
             enchantment = Enchantment.getByName(name.toUpperCase());

--- a/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
@@ -283,6 +283,12 @@ public final class Enchantments {
         }
 
         if (enchantment == null) {
+            enchatment = Enchantment.getByName(name);
+        }
+        if (enchantment == null) {
+            enchantment = Enchantment.getByName(name.toLowerCaseCase());
+        }        
+        if (enchantment == null) {
             enchantment = Enchantment.getByName(name.toUpperCase());
         }
         if (enchantment == null) {

--- a/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
@@ -289,7 +289,7 @@ public final class Enchantments {
             enchantment = Enchantment.getByName(name.toLowerCase());
         }   
         if (enchantment == null) {
-            enchatment = Enchantment.getByName(name);
+            enchantment = Enchantment.getByName(name);
         }
         if (enchantment == null) {
             enchantment = ENCHANTMENTS.get(name.toLowerCase(Locale.ENGLISH));

--- a/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
@@ -283,13 +283,13 @@ public final class Enchantments {
         }
 
         if (enchantment == null) {
-            enchatment = Enchantment.getByName(name);
+            enchantment = Enchantment.getByName(name.toUpperCase());
         }
         if (enchantment == null) {
             enchantment = Enchantment.getByName(name.toLowerCase());
-        }        
+        }   
         if (enchantment == null) {
-            enchantment = Enchantment.getByName(name.toUpperCase());
+            enchatment = Enchantment.getByName(name);
         }
         if (enchantment == null) {
             enchantment = ENCHANTMENTS.get(name.toLowerCase(Locale.ENGLISH));


### PR DESCRIPTION
Avoid assuming registered names are in UPPER cases.