### PR TITLE
Prevent sending usage info when executing alternative commands

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/AlternativeCommandsHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/AlternativeCommandsHandler.java
@@ -92,7 +92,7 @@ public class AlternativeCommandsHandler {
 
     public void executed(final String label, final Command pc) {
         if (pc instanceof PluginIdentifiableCommand) {
-            final String altString = ((PluginIdentifiableCommand) pc).getPlugin().getName() + ":" + pc.getLabel();
+            final String altString = ((PluginIdentifiableCommand) pc).getPlugin().getName() + ":" + pc.getName();
             if (ess.getSettings().isDebug()) {
                 LOGGER.log(Level.INFO, "Essentials: Alternative command " + label + " found, using " + altString);
             }

--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -581,12 +581,12 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             if (pc != null) {
                 alternativeCommandsHandler.executed(commandLabel, pc);
                 try {
-                    return pc.execute(cSender, commandLabel, args);
+                    pc.execute(cSender, commandLabel, args);
                 } catch (final Exception ex) {
                     Bukkit.getLogger().log(Level.SEVERE, ex.getMessage(), ex);
                     cSender.sendMessage(tl("internalError"));
-                    return true;
                 }
+                return true;
             }
         }
 


### PR DESCRIPTION
### Information

This PR fixes #3902, where Essentials will send its own command usage information during the execution of an alternative command if the alternative command returns `false`.

This PR also fixes a tiny bug where running `/ess commands` would output the name of an overriding plugin twice if the overriding plugin directly registered their command (not an alias).

Before and after:
![image](https://user-images.githubusercontent.com/10545540/104104765-33d99380-52fe-11eb-8a3e-999789a1402a.png)
![image](https://user-images.githubusercontent.com/10545540/104104771-39cf7480-52fe-11eb-831f-751e83fe7d63.png)

### Details

**Proposed fix:**    
Always return `true` when executing alternative commands to prevent Essentials from sending its own usage, regardless of the outcome of the alternative command.

**Environments tested:**    
- [x] [Latest](https://papermc.io/downloads) Paper Version (any OS, any Java 8+ version)