### PR TITLE
Commandvanish: Fix affected and controller user being switched for VanishStatusChangeEvent

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandvanish.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandvanish.java
@@ -28,7 +28,7 @@ public class Commandvanish extends EssentialsToggleCommand {
             enabled = !user.isVanished();
         }
 
-        final VanishStatusChangeEvent vanishEvent = new VanishStatusChangeEvent(sender.isPlayer() ? ess.getUser(sender.getPlayer()) : null, user, enabled);
+        final VanishStatusChangeEvent vanishEvent = new VanishStatusChangeEvent(user, sender.isPlayer() ? ess.getUser(sender.getPlayer()) : null, enabled);
         ess.getServer().getPluginManager().callEvent(vanishEvent);
         if (vanishEvent.isCancelled()) {
             return;


### PR DESCRIPTION
### Details

**Proposed fix:**    

The affected and controller user arguments were incorrectly passed to the VanishStatusChangeEvent constructor

**Environments tested:**    

- [x] [Latest](https://papermc.io/downloads) Paper Version (any OS, any Java 8+ version)
- [ ] CraftBukkit/Spigot/Paper 1.12.2 (any OS, any Java 8+ version)
- [ ] CraftBukkit 1.8.8 (any OS, any Java 8+ version)

**Demonstration:**    

Before:

![image](https://user-images.githubusercontent.com/42888162/106251342-23d61500-6215-11eb-9be3-7559c958ad9f.png)
(Log statements printing the name of a fired VanishStatusChangeEvent to stdout)

![image](https://user-images.githubusercontent.com/42888162/106251327-1fa9f780-6215-11eb-9f99-792ab8bb709c.png)
(A vanish command being run on another user as well as the log output for affected and controller)

After
![image](https://user-images.githubusercontent.com/42888162/106252651-c5aa3180-6216-11eb-9822-71fb76c4bf0d.png)
