### PR TITLE
Only use convert spawners tagged by the give command

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -353,7 +353,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                     serverStateProvider = new PaperServerStateProvider();
                     containerProvider = new PaperContainerProvider();
                 } else {
-                    serverStateProvider = new ReflServerStateProvider(getLogger());
+                    serverStateProvider = new ReflServerStateProvider();
                 }
 
                 //Event Providers

--- a/Essentials/src/main/java/com/earth2me/essentials/items/FlatItemDb.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/items/FlatItemDb.java
@@ -152,6 +152,7 @@ public class FlatItemDb extends AbstractItemDb {
         final EntityType entity = data.getEntity();
         if (entity != null && material.toString().contains("SPAWNER")) {
             ess.getSpawnerItemProvider().setEntityType(stack, entity);
+            ess.getPersistentDataProvider().set(stack, "convert", "true");
         }
 
         return stack;

--- a/Essentials/src/main/java/com/earth2me/essentials/items/LegacyItemDb.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/items/LegacyItemDb.java
@@ -191,6 +191,7 @@ public class LegacyItemDb extends AbstractItemDb {
             if (metaData == 0) metaData = EntityType.PIG.getTypeId();
             try {
                 retval = ess.getSpawnerItemProvider().setEntityType(retval, EntityType.fromId(metaData));
+                ess.getPersistentDataProvider().set(retval, "convert", "true");
             } catch (final IllegalArgumentException e) {
                 throw new Exception("Can't spawn entity ID " + metaData + " from mob spawners.");
             }

--- a/providers/NMSReflectionProvider/src/main/java/net/ess3/nms/refl/providers/ReflServerStateProvider.java
+++ b/providers/NMSReflectionProvider/src/main/java/net/ess3/nms/refl/providers/ReflServerStateProvider.java
@@ -6,13 +6,12 @@ import net.ess3.provider.ServerStateProvider;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.util.logging.Logger;
 
 public class ReflServerStateProvider implements ServerStateProvider {
     private final Object nmsServer;
     private final MethodHandle nmsIsRunning;
 
-    public ReflServerStateProvider(final Logger logger) {
+    public ReflServerStateProvider() {
         Object serverObject = null;
         MethodHandle isRunning = null;
         final Class<?> nmsClass = ReflUtil.getNMSClass("MinecraftServer");


### PR DESCRIPTION
Marks all spawners made by EssentialsX with a special PDC tag that denotes if we should run "spawnerconvert" operations on it.

Tested on 1.8.8 & 1.16.5

Fixes #3811