### PR TITLE
Fix invalid configuration section for world aliases

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -550,7 +550,11 @@ public class Settings implements net.ess3.api.ISettings {
 
     private Map<String, String> _getWorldAliases() {
         final Map<String, String> map = new HashMap<>();
-        final ConfigurationSection section = config.getConfigurationSection("");
+        final ConfigurationSection section = config.getConfigurationSection("chat.world-aliases");
+        if (section == null) {
+            return map;
+        }
+
         for (String world : section.getKeys(false)) {
             map.put(world.toLowerCase(), FormatUtil.replaceFormat(section.getString(world)));
         }


### PR DESCRIPTION
must have changed something between my testing build and the build I committed as it even worked fine on the jar i have locally. oops.

Fixes #3999