### PR TITLE
Added different join/quit messages for each group

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -283,11 +283,11 @@ public interface ISettings extends IConf {
 
     boolean isCustomJoinMessage();
 
-    String getCustomJoinMessage();
+    String getCustomJoinMessage(String group);
 
     boolean isCustomQuitMessage();
 
-    String getCustomQuitMessage();
+    String getCustomQuitMessage(String group);
 
     boolean isCustomServerFullMessage();
 
@@ -396,5 +396,6 @@ public interface ISettings extends IConf {
         DELETE,
         DROP
     }
+
 
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -108,8 +108,10 @@ public class Settings implements net.ess3.api.ISettings {
     private long permissionsLagWarning;
     private boolean allowSilentJoin;
     private String customJoinMessage;
+    private final Map<String, String> groupJoinMessages = Collections.synchronizedMap(new HashMap<>());
     private boolean isCustomJoinMessage;
     private String customQuitMessage;
+    private final Map<String, String> groupQuitMessages = Collections.synchronizedMap(new HashMap<>());
     private boolean isCustomQuitMessage;
     private List<String> spawnOnJoinGroups;
     private Map<Pattern, Long> commandCooldowns;
@@ -534,7 +536,7 @@ public class Settings implements net.ess3.api.ISettings {
             mFormat = mFormat.replace("{PREFIX}", "{6}");
             mFormat = mFormat.replace("{SUFFIX}", "{7}");
             mFormat = mFormat.replace("{USERNAME}", "{8}");
-            mFormat = "§r".concat(mFormat);
+            mFormat = "Â§r".concat(mFormat);
             chatFormats.put(group, mFormat);
         }
         if (isDebug()) {
@@ -550,11 +552,7 @@ public class Settings implements net.ess3.api.ISettings {
 
     private Map<String, String> _getWorldAliases() {
         final Map<String, String> map = new HashMap<>();
-        final ConfigurationSection section = config.getConfigurationSection("chat.world-aliases");
-        if (section == null) {
-            return map;
-        }
-
+        final ConfigurationSection section = config.getConfigurationSection("");
         for (String world : section.getKeys(false)) {
             map.put(world.toLowerCase(), FormatUtil.replaceFormat(section.getString(world)));
         }
@@ -650,10 +648,8 @@ public class Settings implements net.ess3.api.ISettings {
         economyLogUpdate = _isEcoLogUpdateEnabled();
         economyDisabled = _isEcoDisabled();
         allowSilentJoin = _allowSilentJoinQuit();
-        customJoinMessage = _getCustomJoinMessage();
-        isCustomJoinMessage = !customJoinMessage.equals("none");
-        customQuitMessage = _getCustomQuitMessage();
-        isCustomQuitMessage = !customQuitMessage.equals("none");
+        isCustomJoinMessage = !getCustomJoinMessage("").equals("none");
+        isCustomQuitMessage = !getCustomQuitMessage("").equals("none");
         muteCommands = _getMuteCommands();
         spawnOnJoinGroups = _getSpawnOnJoinGroups();
         commandCooldowns = _getCommandCooldowns();
@@ -1272,14 +1268,18 @@ public class Settings implements net.ess3.api.ISettings {
     public boolean allowSilentJoinQuit() {
         return allowSilentJoin;
     }
-
-    public String _getCustomJoinMessage() {
-        return FormatUtil.replaceFormat(config.getString("custom-join-message", "none"));
-    }
-
+    
     @Override
-    public String getCustomJoinMessage() {
-        return customJoinMessage;
+    public String getCustomJoinMessage(final String group) {
+        String joinMessage = groupJoinMessages.get(group);
+        if (joinMessage == null) {
+            joinMessage = config.getString("group-custom-join-messages." + (group == null ? "Default" : group), config.getString("custom-join-message", "none"));
+            groupJoinMessages.put(group, joinMessage);
+        }
+        if (isDebug()) {
+            ess.getLogger().info(String.format("Found join message '%s' for group '%s'", joinMessage, group));
+        }
+        return joinMessage;
     }
 
     @Override
@@ -1287,13 +1287,17 @@ public class Settings implements net.ess3.api.ISettings {
         return isCustomJoinMessage;
     }
 
-    public String _getCustomQuitMessage() {
-        return FormatUtil.replaceFormat(config.getString("custom-quit-message", "none"));
-    }
-
     @Override
-    public String getCustomQuitMessage() {
-        return customQuitMessage;
+    public String getCustomQuitMessage(final String group) {
+        String quitMessage = groupQuitMessages.get(group);
+        if (quitMessage == null) {
+            quitMessage = config.getString("group-custom-quit-messages." + (group == null ? "Default" : group), config.getString("custom-quit-message", "none"));
+            groupQuitMessages.put(group, quitMessage);
+        }
+        if (isDebug()) {
+            ess.getLogger().info(String.format("Found quit message '%s' for group '%s'", quitMessage, group));
+        }
+        return quitMessage;
     }
 
     @Override

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -347,6 +347,7 @@ enabledSigns:
   #- sell
   #- trade
   #- free
+  #- disposal
   #- warp
   #- kit
   #- mail
@@ -358,13 +359,6 @@ enabledSigns:
   #- repair
   #- time
   #- weather
-  #- anvil
-  #- cartography
-  #- disposal
-  #- grindstone
-  #- loom
-  #- smithing
-  #- workbench
 
 # How many times per second can Essentials signs be interacted with per player.
 # Values should be between 1-20, 20 being virtually no lag protection.
@@ -506,9 +500,17 @@ allow-silent-join-quit: false
 
 # You can set custom join and quit messages here. Set this to "none" to use the default Minecraft message,
 # or set this to "" to hide the message entirely.
+# You can also give certain groups their own join and quit message for more variety.
 # You may use color codes, {USERNAME} for the player's name, and {PLAYER} for the player's displayname.
 custom-join-message: "none"
 custom-quit-message: "none"
+
+
+
+group-custom-join-messages:
+  admin: "&4The admin &6&l{USERNAME}&r&4 joined the game."
+group-custom-quit-messages:
+  admin: "&4The admin &6&l{USERNAME}&r&4 left the game."
 
 # Should Essentials override the vanilla "Server Full" message with its own from the language file?
 # Set to false to keep the vanilla message.


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

This PR closes #3993. 

### Details

**Proposed feature:**  
The ability to have different groups with different join/leave messages, a good donator perk. Can also be used to distinguish staff and other players joining.


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows and Ubuntu

<!-- Type the JDK version (from java --version) you have used below. -->
Java version:  1.8.0_271

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.16.5, git-Paper-496)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [x] CraftBukkit 1.8.8


**Demonstration:**  

![backup join message](https://user-images.githubusercontent.com/69736165/109031609-bb465080-7679-11eb-896c-2d12bf98ee43.png)
![Default rank join message](https://user-images.githubusercontent.com/69736165/109031453-9baf2800-7679-11eb-96e2-82c9d254f86e.png)
![Admin rank join message](https://user-images.githubusercontent.com/69736165/109031715-d4e79800-7679-11eb-9819-01c8ed65eb18.png)

All can be configured in the config (see image)
![config](https://user-images.githubusercontent.com/69736165/109031888-fe082880-7679-11eb-8b6a-87efea3cbe98.png)

Re made this, no updates just fixing to latest commit like I was asked.