### PR TITLE
Fix failing gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,11 @@ subprojects {
                 includeGroup "org.bstats"
             }
         }
+        mavenCentral() {
+            content {
+                includeGroup "net.kyori"
+            }
+        }
     }
 
     dependencies {


### PR DESCRIPTION
Paper has recently added adventure as a first party library, and thus has shaded it in. Adventure is on maven central, so we must add it in order for Essentials to build.