### PR TITLE
Add missing respawn-at-home-bed config option

### DIFF
--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -1081,6 +1081,10 @@ spawn-join-listener-priority: high
 # When users die, should they respawn at their first home or bed, instead of the spawnpoint?
 respawn-at-home: false
 
+# When users die, should they respawn at their bed instead of the spawnpoint?
+# The value of respawn-at-home (above) has to be true.
+respawn-at-home-bed: true
+
 # When users die, should EssentialsSpawn respect users' respawn anchors?
 respawn-at-anchor: false
 


### PR DESCRIPTION
This PR adds a missing config option that was accidentally left out in #3802 (thank you @mibby for the heads up).