### PR TITLE
OP opt-in for update checks

### DIFF
--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -684,6 +684,9 @@ permissions:
   essentials.back.ondeath:
     default: false
     description: Players with this permission will have back location stored during death
+  essentials.updatecheck:
+    default: false
+    description: Players with this permission will receive a message on join if there are new updates
   essentials.exempt:
     default: false
     description: Parent permission to be exempt from many moderator actions


### PR DESCRIPTION
I'm not sure if this was the intended behavior, but just noticed that the update check messages get sent to OPs even when not opted in with `essentials.updatecheck`. We can avoid this by simply setting the default to `false` in plugin.yml.

I think it'd be a good idea to do this since otherwise we're going to get a ton of questions asking us how to disable this message, since it spams every log in if you do not have permissions configured on your server. The update checker should still function in `/ess version` if people want to manually check (and not get bugged constantly for every new build).