### PR TITLE
Add some extra keywords

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/IUser.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/IUser.java
@@ -187,6 +187,8 @@ public interface IUser {
 
     String getDisplayName();
 
+    String getFormattedNickname();
+
     String getAfkMessage();
 
     void setAfkMessage(final String message);

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -534,6 +534,7 @@ public class Settings implements net.ess3.api.ISettings {
             mFormat = mFormat.replace("{PREFIX}", "{6}");
             mFormat = mFormat.replace("{SUFFIX}", "{7}");
             mFormat = mFormat.replace("{USERNAME}", "{8}");
+            mFormat = mFormat.replace("{NICKNAME}", "{9}");
             mFormat = "§r".concat(mFormat);
             chatFormats.put(group, mFormat);
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -430,6 +430,15 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
     }
 
     @Override
+    public String getFormattedNickname() {
+        final String rawNickname = getNickname();
+        if (rawNickname == null) {
+            return null;
+        }
+        return FormatUtil.replaceFormat(ess.getSettings().getNicknamePrefix() + rawNickname);
+    }
+
+    @Override
     public AsyncTeleport getAsyncTeleport() {
         return teleport;
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/textreader/KeywordReplacer.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/textreader/KeywordReplacer.java
@@ -6,9 +6,12 @@ import com.earth2me.essentials.PlayerList;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.DescParseTickFormat;
+import com.earth2me.essentials.utils.EnumUtil;
+import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.NumberUtil;
 import net.ess3.api.IEssentials;
 import org.bukkit.Location;
+import org.bukkit.Statistic;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -34,8 +37,13 @@ enum KeywordType {
     PLAYER(KeywordCachable.CACHEABLE),
     DISPLAYNAME(KeywordCachable.CACHEABLE),
     USERNAME(KeywordCachable.NOTCACHEABLE),
+    NICKNAME(KeywordCachable.CACHEABLE),
+    PREFIX(KeywordCachable.CACHEABLE),
+    SUFFIX(KeywordCachable.CACHEABLE),
+    GROUP(KeywordCachable.CACHEABLE),
     BALANCE(KeywordCachable.CACHEABLE),
     MAILS(KeywordCachable.CACHEABLE),
+    PLAYTIME(KeywordCachable.CACHEABLE),
     WORLD(KeywordCachable.CACHEABLE),
     WORLDNAME(KeywordCachable.CACHEABLE),
     ONLINE(KeywordCachable.CACHEABLE),
@@ -83,6 +91,7 @@ enum KeywordCachable {
 }
 
 public class KeywordReplacer implements IText {
+    private static final Statistic PLAY_ONE_TICK = EnumUtil.getStatistic("PLAY_ONE_MINUTE", "PLAY_ONE_TICK");
     private static final Pattern KEYWORD = Pattern.compile("\\{([^\\{\\}]+)\\}");
     private static final Pattern KEYWORDSPLIT = Pattern.compile("\\:");
     private final transient IText input;
@@ -188,6 +197,29 @@ public class KeywordReplacer implements IText {
                             replacer = user.getName();
                         }
                         break;
+                    case NICKNAME:
+                        if (user != null) {
+                            final String nickname = user.getFormattedNickname();
+                            replacer = nickname == null ? user.getName() : nickname;
+                        }
+                        break;
+                    case PREFIX:
+                        if (user != null) {
+                            final String prefix = FormatUtil.replaceFormat(ess.getPermissionsHandler().getPrefix(user.getBase()));
+                            replacer = prefix == null ? "" : prefix;
+                        }
+                        break;
+                    case SUFFIX:
+                        if (user != null) {
+                            final String suffix = FormatUtil.replaceFormat(ess.getPermissionsHandler().getSuffix(user.getBase()));
+                            replacer = suffix == null ? "" : suffix;
+                        }
+                        break;
+                    case GROUP:
+                        if (user != null) {
+                            replacer = user.getGroup();
+                        }
+                        break;
                     case BALANCE:
                         if (user != null) {
                             replacer = NumberUtil.displayCurrency(user.getMoney(), ess);
@@ -196,6 +228,12 @@ public class KeywordReplacer implements IText {
                     case MAILS:
                         if (user != null) {
                             replacer = Integer.toString(user.getMails().size());
+                        }
+                        break;
+                    case PLAYTIME:
+                        if (user != null) {
+                            final long playtimeMs = System.currentTimeMillis() - (user.getBase().getStatistic(PLAY_ONE_TICK) * 50L);
+                            replacer = DateUtil.formatDateDiff(playtimeMs);
                         }
                         break;
                     case WORLD:

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -825,6 +825,21 @@ chat:
   # For more information of chat formatting, check out the wiki: http://wiki.ess3.net/wiki/Chat_Formatting
   # Note: Using the {PREFIX} and {SUFFIX} placeholders along with {DISPLAYNAME} may cause double prefixes/suffixes to be shown in chat unless add-prefix-suffix is uncommented and set to false.
 
+  # Available placeholders:
+  # {MESSAGE} - The content of the chat message.
+  # {USERNAME} - The sender's username.
+  # {DISPLAYNAME} - The sender's display name.
+  # {NICKNAME} - The sender's Essentials nickname. If the sender has no nickname, the username is shown.
+  # {PREFIX} - The sender's prefix, supplied by a permissions plugin.
+  # {SUFFIX} - The sender's suffix, supplied by a permissions plugin.
+  # {GROUP} - The sender's primary group name, supplied by a permissions plugin.
+  # {WORLD} - The world alias of the sender's current world. See the world-aliases section below for details.
+  # {WORLDNAME} - The full name of the sender's current world.
+  # {SHORTWORLDNAME} - The first character of the sender's current world.
+  # {TEAMNAME} - The sender's scoreboard team name.
+  # {TEAMPREFIX} - The sender's scoreboard team prefix.
+  # {TEAMSUFFIX} - The sender's scoreboard team suffix.
+
   format: '<{DISPLAYNAME}> {MESSAGE}'
   #format: '&7[{GROUP}]&r {DISPLAYNAME}&7:&r {MESSAGE}'
   #format: '&7{PREFIX}&r {DISPLAYNAME}&r &7{SUFFIX}&r: {MESSAGE}'

--- a/Essentials/src/main/resources/info.txt
+++ b/Essentials/src/main/resources/info.txt
@@ -36,21 +36,29 @@ Minecraft colors:
 &&o &oItalic&r   &&r &rReset
 
 #Tags
-&6Player's Display name:&r {PLAYER}
+&6Player's Display name:&r {PLAYER}, {DISPLAYNAME}
 &6Player's user name:&r {USERNAME}
-&6IP:&r {IP}
-&6Address:&r {ADDRESS}
-&6Balance:&r {BALANCE}
-&6Unread mails:&r {MAILS}
-&6Current world:&r {WORLD}
-&6Worlds list:&r {WORLDS}
-&6Number of online players:&r {ONLINE}
+&6Player's nickname:&r {NICKNAME}
+&6Player's prefix:&r {PREFIX}
+&6Player's suffix:&r {SUFFIX}
+&6Player's primary group:&r {GROUP}
+&6Player's balance:&r {BALANCE}
+&6Player's unread mails:&r {MAILS}
+&6Player's playtime:&r {PLAYTIME}
+&6Player's coordinates:&r {COORDS}
+&6Player's current world:&r {WORLD}, {WORLDNAME}
+&6Number of online, non-hidden players:&r {ONLINE}
 &6Number of unique players who joined the server:&r {UNIQUE}
+&6Worlds list:&r {WORLDS}
 &6Player list:&r {PLAYERLIST}
 &6Time of server:&r {TIME}
 &6Date of server:&r {DATE}
 &6Time of world PM/AM:&r {WORLDTIME12}
 &6Time of world:&r {WORLDTIME24}
 &6Date of world:&r {WORLDDATE}
+&6TPS:&r {TPS}
+&6Uptime:&r {UPTIME}
+&6IP:&r {IP}
+&6Address:&r {ADDRESS}
 &6Plugin list:&r {PLUGINS}
 &6Version of CraftBukkit:&r {VERSION}

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/EssentialsChatPlayerListenerLowest.java
@@ -46,6 +46,8 @@ public class EssentialsChatPlayerListenerLowest extends EssentialsChatPlayer {
 
         final String group = user.getGroup();
         final String world = user.getWorld().getName();
+        final String username = user.getName();
+        final String nickname = user.getFormattedNickname();
 
         final Player player = user.getBase();
         final String prefix = FormatUtil.replaceFormat(ess.getPermissionsHandler().getPrefix(player));
@@ -61,7 +63,8 @@ public class EssentialsChatPlayerListenerLowest extends EssentialsChatPlayer {
         format = format.replace("{5}", team == null ? "" : team.getDisplayName());
         format = format.replace("{6}", prefix);
         format = format.replace("{7}", suffix);
-        format = format.replace("{8}", player.getName());
+        format = format.replace("{8}", username);
+        format = format.replace("{9}", nickname == null ? username : nickname);
         synchronized (format) {
             event.setFormat(format);
         }


### PR DESCRIPTION
### Information

This PR "answers" #3994 and #4096.

### Details

**Proposed feature:**  

Just a few extra keywords that should be useful for those wanting more options in text files that use KeywordReplacer. Also adds the long overdue `{NICKNAME}` chat format placeholder.

The new `User#getFormattedNickname()` method might be a bit confusing amongst all of the other nick-related methods without some comments though. I decided to add it because there's currently no straightforward way to get just the user's formatted nickname without other bits like prefix/suffix and OP color etc. tacked on.

New tags (KeywordReplacer):
`{NICKNAME}` - The player's nickname. If the player has no nickname, the username is shown.
`{PREFIX}` - The player's prefix.
`{SUFFIX}` - The player's suffix.
`{GROUP}` - The player's primary group
`{PLAYTIME}` - The player's playtime.

New chat placeholder:
`{NICKNAME}` - The player's nickname. If the player has no nickname, the username is shown.

**Environments tested:**    

OS: Windows 10 20H2
Java version: OpenJDK 1.8.0_282

- [X] Most recent Paper version (1.16.5,  git-Paper-571)
