### PR TITLE
Prevent stack overflow when finding an EssX cmd as alternative

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -82,6 +82,7 @@ import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
+import org.bukkit.command.PluginIdentifiableCommand;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -571,7 +572,10 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             // Check for disabled commands
             if (getSettings().isCommandDisabled(commandLabel)) {
                 if (getKnownCommandsProvider().getKnownCommands().containsKey(commandLabel)) {
-                    return getKnownCommandsProvider().getKnownCommands().get(commandLabel).tabComplete(cSender, commandLabel, args);
+                    final Command newCmd = getKnownCommandsProvider().getKnownCommands().get(commandLabel);
+                    if (!(newCmd instanceof PluginIdentifiableCommand) || ((PluginIdentifiableCommand) newCmd).getPlugin() != this) {
+                        return newCmd.tabComplete(cSender, commandLabel, args);
+                    }
                 }
                 return Collections.emptyList();
             }
@@ -676,7 +680,10 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             // Check for disabled commands
             if (getSettings().isCommandDisabled(commandLabel)) {
                 if (getKnownCommandsProvider().getKnownCommands().containsKey(commandLabel)) {
-                    return getKnownCommandsProvider().getKnownCommands().get(commandLabel).execute(cSender, commandLabel, args);
+                    final Command newCmd = getKnownCommandsProvider().getKnownCommands().get(commandLabel);
+                    if (!(newCmd instanceof PluginIdentifiableCommand) || ((PluginIdentifiableCommand) newCmd).getPlugin() != this) {
+                        return newCmd.execute(cSender, commandLabel, args);
+                    }
                 }
                 sender.sendMessage(tl("commandDisabled", commandLabel));
                 return true;


### PR DESCRIPTION
This seems to happen when other plugins mess with the command map and re-add us (or maybe on /reload??).

Fixes #4115