### PR TITLE
Remove the `/itemdb alias` suggestion

### DIFF
--- a/Essentials/src/main/resources/custom_items.yml
+++ b/Essentials/src/main/resources/custom_items.yml
@@ -1,7 +1,6 @@
 # This file stores custom item aliases.
-# We recommend you use the `/itemdb alias` command to manage these.
-
 # NOTE: If you try and alias an item to another entry in this file, the alias won't work.
+
 aliases:
   bluepaint: blue_dye
   snad: sand


### PR DESCRIPTION
Since the command doesn't exist and doesn't seem like it's going to be added in the near future, the comment should probably be removed until the command is actually added, if ever.