### PR TITLE
Fix Java version command in pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug-fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug-fix.md
@@ -72,7 +72,7 @@ This PR fixes #nnnn.
 <!-- Type the OS you have used below. -->
 OS: 
 
-<!-- Type the JDK version (from java --version) you have used below. -->
+<!-- Type the JDK version (from java -version) you have used below. -->
 Java version:  
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE/new-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new-feature.md
@@ -72,7 +72,7 @@ This PR closes #nnnn.
 <!-- Type the OS you have used below. -->
 OS: 
 
-<!-- Type the JDK version (from java --version) you have used below. -->
+<!-- Type the JDK version (from java -version) you have used below. -->
 Java version:  
 
 <!--


### PR DESCRIPTION
Proposed fix: Remove the additional `-` in the comments
![image](https://user-images.githubusercontent.com/61277953/119105602-55e0d200-b9d2-11eb-8b2b-65b5ec545451.png)