### PR TITLE
Set Gradle toolchain to JDK 16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,7 @@ subprojects {
 
         javaVersions {
             target 8
+            minimumToolchain 16
         }
     }
 


### PR DESCRIPTION
This bumps the toolchain used for compiling EssentialsX to JDK 16, but keeps the release target at Java 8.

This shouldn't impact any existing development environments - Gradle will download and cache the correct toolchain as needed.