### PR TITLE
Fix offline player account creation

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
@@ -9,6 +9,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import net.ess3.api.IEssentials;
+import net.ess3.api.MaxMoneyException;
 import org.bukkit.entity.Player;
 
 import java.io.File;
@@ -177,22 +178,42 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
         }
 
         if (player instanceof Player) {
+            if (ess.getSettings().isDebug()) {
+                ess.getLogger().info("Loading online OfflinePlayer into user map...");
+            }
             final User user = new User((Player) player, ess);
             trackUUID(player.getUniqueId(), player.getName(), true);
             return user;
         }
 
         final File userFile = getUserFileFromID(player.getUniqueId());
-
-        if (userFile.exists()) {
-            final OfflinePlayer essPlayer = new OfflinePlayer(player.getUniqueId(), ess.getServer());
-            final User user = new User(essPlayer, ess);
-            essPlayer.setName(user.getLastAccountName());
-            trackUUID(player.getUniqueId(), user.getName(), false);
-            return user;
+        if (ess.getSettings().isDebug()) {
+            ess.getLogger().info("Loading OfflinePlayer into user map. Has data: " + userFile.exists() + " for " + player);
         }
 
-        throw new UserDoesNotExistException("User not found!");
+        final OfflinePlayer essPlayer = new OfflinePlayer(player.getUniqueId(), ess.getServer());
+        final User user = new User(essPlayer, ess);
+        if (userFile.exists()) {
+            essPlayer.setName(user.getLastAccountName());
+        } else {
+            if (ess.getSettings().isDebug()) {
+                ess.getLogger().info("OfflinePlayer usermap load saving user data for " + player);
+            }
+
+            // this code makes me sad
+            user.startTransaction();
+            try {
+                user.setMoney(ess.getSettings().getStartingBalance());
+            } catch (MaxMoneyException e) {
+                // Shouldn't happen as it would be an illegal configuration state
+                throw new RuntimeException(e);
+            }
+            user.setLastAccountName(user.getName());
+            user.stopTransaction();
+        }
+
+        trackUUID(player.getUniqueId(), user.getName(), false);
+        return user;
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/vault/VaultEconomyProvider.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/vault/VaultEconomyProvider.java
@@ -315,6 +315,9 @@ public class VaultEconomyProvider implements Economy {
 
         // Loading a v4 UUID that we somehow didn't track, mark it as a normal player and hope for the best, vault sucks :/
         try {
+            if (ess.getSettings().isDebug()) {
+                LOGGER.info("Vault requested a player account creation for a v4 UUID: " + player);
+            }
             ess.getUserMap().load(player);
             return true;
         } catch (UserDoesNotExistException e) {


### PR DESCRIPTION
This bug occurs when a player has joined before EssentialsX was installed and a player account creation is requested through Vault while they are offline.

Fixes #4195