### PR TITLE
Add option to ignore vanished players from sleeping

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -209,6 +209,8 @@ public interface ISettings extends IConf {
 
     boolean sleepIgnoresAfkPlayers();
 
+    boolean sleepIgnoresVanishedPlayers();
+
     boolean isAfkListName();
 
     String getAfkListName();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -1101,6 +1101,11 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getBoolean("sleep-ignores-afk-players", true);
     }
 
+    @Override
+    public boolean sleepIgnoresVanishedPlayers() {
+        return config.getBoolean("sleep-ignores-vanished-player", true);
+    }
+
     public String _getAfkListName() {
         return FormatUtil.replaceFormat(config.getString("afk-list-name", "none"));
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -889,6 +889,9 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, false));
             }
+            if (ess.getSettings().sleepIgnoresVanishedPlayers()) {
+                getBase().setSleepingIgnored(true);
+            }
         } else {
             for (final Player p : ess.getOnlinePlayers()) {
                 p.showPlayer(getBase());
@@ -897,6 +900,9 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             ess.getVanishedPlayersNew().remove(getName());
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().removePotionEffect(PotionEffectType.INVISIBILITY);
+            }
+            if (ess.getSettings().sleepIgnoresVanishedPlayers()) {
+                getBase().setSleepingIgnored(false);
             }
         }
     }

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -471,6 +471,11 @@ cancel-afk-on-chat: true
 # Users with the permission node essentials.sleepingignored will always be ignored.
 sleep-ignores-afk-players: true
 
+# Should vanished players be ignored when other players are trying to sleep?
+# When this setting is false, player's won't be able to skip the night if vanished players are not sleeping.
+# Users with the permission node essentials.sleepingignored will always be ignored.
+sleep-ignores-vanished-player: true
+
 # Set the player's list name when they are AFK. This is none by default which specifies that Essentials 
 # should not interfere with the AFK player's list name.
 # You may use color codes, use {USERNAME} the player's name or {PLAYER} for the player's displayname.


### PR DESCRIPTION
Defaults to true as it should kinda be expected behavior

```yml
# Should vanished players be ignored when other players are trying to sleep?
# When this setting is false, player's won't be able to skip the night if vanished players are not sleeping.
# Users with the permission node essentials.sleepingignored will always be ignored.
sleep-ignores-vanished-player: true
```

Closes #4196 