### PR TITLE
Prevent getting jail worlds before world load

### DIFF
--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -526,6 +526,7 @@ jailReleased=\u00a76Player \u00a7c{0}\u00a76 unjailed.
 jailReleasedPlayerNotify=\u00a76You have been released\!
 jailSentenceExtended=\u00a76Jail time extended to \u00a7c{0}\u00a76.
 jailSet=\u00a76Jail\u00a7c {0} \u00a76has been set.
+jailWorldNotExist=\u00a74That jail's world does not exist.
 jumpEasterDisable=\u00a76Flying wizard mode disabled.
 jumpEasterEnable=\u00a76Flying wizard mode enabled.
 jailsCommandDescription=List all jails.


### PR DESCRIPTION
### Information

This PR fixes a bug where Jail worlds would be obtained before being loaded by the server.

### Details

**Proposed fix:**
Use `LazyLocation` instead of `Location` inside `Jails` and perform a check inside the `getJail` method to ensure the world has been loaded, throwing an error if unloaded (or nonexistent).

**Environments tested:**    

OS: Windows 10 20H2
Java version: `openjdk version "11.0.10"`

- [x] Most recent Paper version