### PR TITLE
Fix invalid empty value for BigDecimal

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/config/serializers/BigDecimalTypeSerializer.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/config/serializers/BigDecimalTypeSerializer.java
@@ -1,7 +1,5 @@
 package com.earth2me.essentials.config.serializers;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.configurate.ConfigurationOptions;
 import org.spongepowered.configurate.serialize.ScalarSerializer;
 import org.spongepowered.configurate.serialize.SerializationException;
 
@@ -52,10 +50,5 @@ public class BigDecimalTypeSerializer extends ScalarSerializer<BigDecimal> {
     @Override
     protected Object serialize(BigDecimal item, Predicate<Class<?>> typeSupported) {
         return item.toString();
-    }
-
-    @Override
-    public @Nullable BigDecimal emptyValue(Type specificType, ConfigurationOptions options) {
-        return BigDecimal.ZERO;
     }
 }


### PR DESCRIPTION
The BigDecimal shouldn't have zero as the empty value, we rely on it defaulting to null for behavior.

Fixes #4236