### PR TITLE
Prevent NPE in RandomTeleport when center is not set

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/RandomTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/RandomTeleport.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials;
 
 import com.earth2me.essentials.config.EssentialsConfiguration;
+import com.earth2me.essentials.config.entities.LazyLocation;
 import com.earth2me.essentials.utils.LocationUtil;
 import com.earth2me.essentials.utils.VersionUtil;
 import io.papermc.lib.PaperLib;
@@ -40,9 +41,9 @@ public class RandomTeleport implements IConf {
 
     public Location getCenter() {
         try {
-            final Location center = config.getLocation("center").location();
-            if (center != null) {
-                return center;
+            final LazyLocation center = config.getLocation("center");
+            if (center != null && center.location() != null) {
+                return center.location();
             }
         } catch (final InvalidWorldException ignored) {
         }


### PR DESCRIPTION
### Information

This PR prevents an NPE from occurring when `center` is not set in the random teleport config file. 

The NPE occurs when running `/tpr` on a fresh install (i.e. no center defined in tpr.yml): https://paste.gg/p/anonymous/f47523f54fdb4fbca961aef952ce7296

Reported by `swayQ#5660` on the MOSS support server.

### Details

**Environments tested:**    

OS: Windows 10 20H2
Java version: `openjdk version "11.0.10"`

- [x] Most recent Paper version (1.16.5-R0.1-SNAPSHOT git-Paper-777 (MC: 1.16.5))

