### PR TITLE
Fix incorrect behaviours in /back

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
@@ -163,7 +163,10 @@ public class AsyncTeleport implements IAsyncTeleport {
             future.complete(false);
             return;
         }
-        teleportee.setLastLocation();
+
+        if (teleportee.isAuthorized("essentials.back.onteleport")) {
+            teleportee.setLastLocation();
+        }
 
         if (!ess.getSettings().isForcePassengerTeleport() && !teleportee.getBase().isEmpty()) {
             if (!ess.getSettings().isTeleportPassengerDismount()) {
@@ -178,7 +181,7 @@ public class AsyncTeleport implements IAsyncTeleport {
                 return;
             }
         }
-        teleportee.setLastLocation();
+
         final Location targetLoc = target.getLocation();
         if (ess.getSettings().isTeleportSafetyEnabled() && LocationUtil.isBlockOutsideWorldBorder(targetLoc.getWorld(), targetLoc.getBlockX(), targetLoc.getBlockZ())) {
             targetLoc.setX(LocationUtil.getXInsideWorldBorder(targetLoc.getWorld(), targetLoc.getBlockX()));

--- a/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
@@ -164,10 +164,6 @@ public class AsyncTeleport implements IAsyncTeleport {
             return;
         }
 
-        if (teleportee.isAuthorized("essentials.back.onteleport")) {
-            teleportee.setLastLocation();
-        }
-
         if (!ess.getSettings().isForcePassengerTeleport() && !teleportee.getBase().isEmpty()) {
             if (!ess.getSettings().isTeleportPassengerDismount()) {
                 future.completeExceptionally(new Exception(tl("passengerTeleportFail")));
@@ -180,6 +176,10 @@ public class AsyncTeleport implements IAsyncTeleport {
                 future.completeExceptionally(e);
                 return;
             }
+        }
+
+        if (teleportee.isAuthorized("essentials.back.onteleport")) {
+            teleportee.setLastLocation();
         }
 
         final Location targetLoc = target.getLocation();

--- a/Essentials/src/main/java/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserData.java
@@ -262,7 +262,8 @@ public abstract class UserData extends PlayerExtension implements IConf {
     }
 
     public Location getLastLocation() {
-        return holder.lastLocation().location();
+        final LazyLocation lastLocation = holder.lastLocation();
+        return lastLocation != null ? lastLocation.location() : null;
     }
 
     public void setLastLocation(final Location loc) {


### PR DESCRIPTION
### Information

This PR re-adds the `essentials.back.onteleport` permission check for setting the user's last location during teleports, which was accidentally left out during the async teleport refactor. Without the check, it's not possible to restrict the use of `/back` to only on death.

Additionally, this PR prevents an NPE when accessing a player's `lastLocation` before it has been set.

Reported by `DarkChroma#3333` on the MOSS support server.

### Details

**Environments tested:**    

OS: Windows 10 20H2
Java version: `openjdk version "11.0.10"`

- [x] Most recent Paper version (1.16.5-R0.1-SNAPSHOT git-Paper-778 (MC: 1.16.5))