### PR TITLE
Prevent exception when retrieving enchantments

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Enchantments.java
@@ -282,7 +282,11 @@ public final class Enchantments {
         }
         Enchantment enchantment = null;
         if (isFlat) { // 1.13+ only
-            enchantment = Enchantment.getByKey(NamespacedKey.minecraft(name.toLowerCase()));
+            try {
+                enchantment = Enchantment.getByKey(NamespacedKey.minecraft(name.toLowerCase()));
+            } catch (IllegalArgumentException ignored) {
+                // NamespacedKey throws IAE if key does not match regex
+            }
         }
 
         if (enchantment == null) {


### PR DESCRIPTION
### Information

This PR prevents an IllegalArgumentException from bubbling up in `Enchantments.getByName`, allowing a nicer error message (`enchantmentNotFound` tl key) to be displayed instead of `"Invalid key. Must be [a-z0-9/._-]"`. Also fixes tab-complete spam in linked issue.

Fixes #4291

### Details

**Environments tested:**    

OS: Windows 10 20H2
Java version: `openjdk 16.0.1 2021-04-20`

- [x] Most recent Paper version (git-Paper-68 (MC: 1.17))