### PR TITLE
Fix issues with 3rd-party Vault economy providers

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -331,6 +331,8 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             confList.add(jails);
             execTimer.mark("Init(Jails)");
 
+            EconomyLayers.onEnable(this);
+
             //Spawner item provider only uses one but it's here for legacy...
             spawnerItemProvider = new BlockMetaSpawnerItemProvider();
 

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPluginListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPluginListener.java
@@ -26,6 +26,12 @@ public class EssentialsPluginListener implements Listener, IConf {
         ess.getPermissionsHandler().setUseSuperperms(ess.getSettings().useBukkitPermissions());
         ess.getPermissionsHandler().checkPermissions();
         ess.getAlternativeCommandsHandler().addPlugin(event.getPlugin());
+        if (EconomyLayers.isServerStarted()) {
+            final EconomyLayer layer = EconomyLayers.onPluginEnable(event.getPlugin());
+            if (layer != null) {
+                ess.getLogger().log(Level.INFO, "Essentials found a compatible payment resolution method: " + layer.getName() + " (v" + layer.getPluginVersion() + ")!");
+            }
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPluginListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPluginListener.java
@@ -13,19 +13,9 @@ import java.util.logging.Level;
 
 public class EssentialsPluginListener implements Listener, IConf {
     private final transient IEssentials ess;
-    private boolean serverLoaded = false;
 
     public EssentialsPluginListener(final IEssentials ess) {
         this.ess = ess;
-
-        // Run on first server tick
-        ess.scheduleSyncDelayedTask(() -> {
-            if (EconomyLayers.getSelectedLayer() == null || serverLoaded) {
-                return;
-            }
-            serverLoaded = true;
-            EconomyLayers.onServerLoad();
-        });
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -36,10 +26,6 @@ public class EssentialsPluginListener implements Listener, IConf {
         ess.getPermissionsHandler().setUseSuperperms(ess.getSettings().useBukkitPermissions());
         ess.getPermissionsHandler().checkPermissions();
         ess.getAlternativeCommandsHandler().addPlugin(event.getPlugin());
-        final EconomyLayer layer = EconomyLayers.onPluginEnable(event.getPlugin());
-        if (layer != null) {
-            ess.getLogger().log(Level.INFO, "Essentials found a compatible payment resolution method: " + layer.getName() + " (v" + layer.getPluginVersion() + ")!");
-        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -49,7 +35,7 @@ public class EssentialsPluginListener implements Listener, IConf {
         }
         ess.getPermissionsHandler().checkPermissions();
         ess.getAlternativeCommandsHandler().removePlugin(event.getPlugin());
-        if (EconomyLayers.onPluginDisable(event.getPlugin(), serverLoaded)) {
+        if (EconomyLayers.onPluginDisable(event.getPlugin())) {
             final EconomyLayer layer = EconomyLayers.getSelectedLayer();
             if (layer != null) {
                 ess.getLogger().log(Level.INFO, "Essentials found a new compatible payment resolution method: " + layer.getName() + " (v" + layer.getPluginVersion() + ")!");

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandessentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandessentials.java
@@ -4,6 +4,8 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.EssentialsUpgrade;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.UserMap;
+import com.earth2me.essentials.economy.EconomyLayer;
+import com.earth2me.essentials.economy.EconomyLayers;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.EnumUtil;
 import com.earth2me.essentials.utils.FloatUtil;
@@ -430,6 +432,17 @@ public class Commandessentials extends EssentialsCommand {
 
             if (name.equals("Vault")) isVaultInstalled = true;
         }
+
+        final String layer;
+        if (ess.getSettings().isEcoDisabled()) {
+            layer = "Disabled";
+        } else if (EconomyLayers.isLayerSelected()) {
+            final EconomyLayer economyLayer = EconomyLayers.getSelectedLayer();
+            layer = economyLayer.getName() + " (" + economyLayer.getBackendName() + ")";
+        } else {
+            layer = "None";
+        }
+        sender.sendMessage(tl("versionOutputEconLayer", layer));
 
         if (isMismatched) {
             sender.sendMessage(tl("versionMismatchAll"));

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/EconomyLayers.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/EconomyLayers.java
@@ -48,6 +48,10 @@ public final class EconomyLayers {
         });
     }
 
+    public static boolean isServerStarted() {
+        return serverStarted;
+    }
+
     public static EconomyLayer getSelectedLayer() {
         return selectedLayer;
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/EconomyLayers.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/EconomyLayers.java
@@ -1,12 +1,15 @@
 package com.earth2me.essentials.economy;
 
+import com.earth2me.essentials.Essentials;
 import com.earth2me.essentials.economy.layers.VaultLayer;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * Abstraction layer for economy abstraction layers.
@@ -15,6 +18,7 @@ public final class EconomyLayers {
     private static final Map<String, EconomyLayer> registeredLayers = new HashMap<>();
     private static final List<String> availableLayers = new ArrayList<>();
     private static EconomyLayer selectedLayer = null;
+    private static boolean serverStarted = false;
 
     private EconomyLayers() {
     }
@@ -25,6 +29,23 @@ public final class EconomyLayers {
         }
 
         registerLayer(new VaultLayer());
+    }
+
+    public static void onEnable(final Essentials ess) {
+        ess.scheduleSyncDelayedTask(() -> {
+            serverStarted = true;
+            for (final Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
+                if (!plugin.isEnabled()) {
+                    continue;
+                }
+                final EconomyLayer layer = onPluginEnable(plugin);
+                if (layer != null) {
+                    ess.getLogger().log(Level.INFO, "Essentials found a compatible payment resolution method: " + layer.getName() + " (v" + layer.getPluginVersion() + ")!");
+                }
+            }
+
+            onServerLoad();
+        });
     }
 
     public static EconomyLayer getSelectedLayer() {
@@ -52,7 +73,7 @@ public final class EconomyLayers {
         return selectedLayer;
     }
 
-    public static boolean onPluginDisable(final Plugin plugin, final boolean serverStarted) {
+    public static boolean onPluginDisable(final Plugin plugin) {
         if (!availableLayers.contains(plugin.getName())) {
             return false;
         }
@@ -75,7 +96,7 @@ public final class EconomyLayers {
             return;
         }
 
-        availableLayers.remove(getSelectedLayer().getPluginVersion());
+        availableLayers.remove(getSelectedLayer().getPluginName());
         selectedLayer = null;
         if (!availableLayers.isEmpty()) {
             selectedLayer = registeredLayers.get(availableLayers.get(0));

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/layers/VaultLayer.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/layers/VaultLayer.java
@@ -34,7 +34,7 @@ public class VaultLayer implements EconomyLayer {
 
     @Override
     public boolean withdraw(OfflinePlayer player, BigDecimal amount) {
-        return false;
+        return adapter.withdrawPlayer(player, amount.doubleValue()).transactionSuccess();
     }
 
     @Override

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -1384,6 +1384,7 @@ versionOutputFine=\u00a76{0} version: \u00a7a{1}
 versionOutputWarn=\u00a76{0} version: \u00a7c{1}
 versionOutputUnsupported=\u00a7d{0} \u00a76version: \u00a7d{1}
 versionOutputUnsupportedPlugins=\u00a76You are running \u00a7dunsupported plugins\u00a76!
+versionOutputEconLayer=\u00a76Economy Layer: \u00a7r{0}
 versionMismatch=\u00a74Version mismatch\! Please update {0} to the same version.
 versionMismatchAll=\u00a74Version mismatch\! Please update all Essentials jars to the same version.
 versionReleaseLatest=\u00a76You''re running the latest stable version of EssentialsX!


### PR DESCRIPTION
Turns out that when you depend on a plugin, get this, the plugin *will* load before you. So we need to rework how we do things here.

Fixes #4075
Fixes #4304