### PR TITLE
Fix Configurate conversions not saving + Baltop Names

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
@@ -39,8 +39,15 @@ public class BalanceTopImpl implements BalanceTop {
                     final BigDecimal userMoney = user.getMoney();
                     user.updateMoneyCache(userMoney);
                     newTotal = newTotal.add(userMoney);
-                    final String name = user.isHidden() ? user.getName() : user.getDisplayName();
-                    entries.add(new BalanceTop.Entry(user.getBase().getUniqueId(), name, userMoney));
+                    final String name;
+                    if (user.getBase() instanceof OfflinePlayer) {
+                        name = user.getLastAccountName();
+                    } else if (user.isHidden()) {
+                        name = user.getName();
+                    } else {
+                        name = user.getDisplayName();
+                    }
+                    entries.add(new BalanceTop.Entry(user.getUUID(), name, userMoney));
                 }
             }
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsUpgrade.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsUpgrade.java
@@ -189,7 +189,7 @@ public class EssentialsUpgrade {
     }
 
     public void convertStupidCamelCaseUserdataKeys() {
-        if (doneFile.getBoolean("updateUsersLegacyPathNames", false)) {
+        if (doneFile.getBoolean("updateUsersStupidLegacyPathNames", false)) {
             return;
         }
 
@@ -232,12 +232,13 @@ public class EssentialsUpgrade {
                     config.removeProperty("acceptingPay");
                     config.setProperty("accepting-pay", isPay);
                 }
+                config.blockingSave();
             } catch (final RuntimeException ex) {
                 LOGGER.log(Level.INFO, "File: " + file.toString());
                 throw ex;
             }
         }
-        doneFile.setProperty("updateUsersLegacyPathNames", true);
+        doneFile.setProperty("updateUsersStupidLegacyPathNames", true);
         doneFile.save();
         LOGGER.info("Done converting legacy userdata keys to Configurate.");
     }


### PR DESCRIPTION
The configuration upgrade paths were not properly saved ~~i wonder who made those~~. And baltop generation was using displaynames for offline users.