### PR TITLE
Fix weird behavior with legacy mails

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/config/serializers/MailMessageSerializer.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/config/serializers/MailMessageSerializer.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 public class MailMessageSerializer implements TypeSerializer<MailMessage> {
     @Override
     public MailMessage deserialize(Type type, ConfigurationNode node) throws SerializationException {
-        final boolean legacy = !node.node("legacy").isNull() && node.node("legacy").getBoolean(false);
+        final boolean legacy = node.node("legacy").getBoolean(true);
 
         return new MailMessage(node.node("read").getBoolean(false),
                 legacy,


### PR DESCRIPTION
*Some* legacy mails in *some* weird conditions cause problems with fetching values that don't exist, err on the side of caution.