### PR TITLE
EssentialsX Discord Features/Fixup Day 2

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/utils/FormatUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/FormatUtil.java
@@ -44,7 +44,7 @@ public final class FormatUtil {
         if (input == null) {
             return null;
         }
-        return stripColor(input, REPLACE_ALL_PATTERN);
+        return stripColor(stripColor(input, REPLACE_ALL_PATTERN), REPLACE_ALL_RGB_PATTERN);
     }
 
     public static String stripAnsi(final String input) {

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -253,6 +253,7 @@ discordErrorWebhook=An error occurred while sending messages to your console cha
 discordLoggingIn=Attempting to login to Discord...
 discordLoggingInDone=Successfully logged in as {0}
 discordNoSendPermission=Cannot send message in channel: #{0} Please ensure the bot has "Send Messages" permission in that channel\!
+discordReloadInvalid=Tried to reload EssentialsX Discord config while the plugin is in an invalid state! If you've modified your config, restart your server.
 disposal=Disposal
 disposalCommandDescription=Opens a portable disposal menu.
 disposalCommandUsage=/<command>

--- a/EssentialsDiscord/build.gradle
+++ b/EssentialsDiscord/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     compileOnly project(':EssentialsX')
-    implementation('net.dv8tion:JDA:4.3.0_277') {
+    implementation('net.dv8tion:JDA:4.3.0_293') {
         //noinspection GroovyAssignabilityCheck
         exclude module: 'opus-java'
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
@@ -58,11 +58,12 @@ public final class MessageType {
         public final static MessageType CHAT = new MessageType("chat", true);
         public final static MessageType DEATH = new MessageType("death", true);
         public final static MessageType AFK = new MessageType("afk", true);
+        public final static MessageType ADVANCEMENT = new MessageType("advancement", true);
         public final static MessageType SERVER_START = new MessageType("server-start", false);
         public final static MessageType SERVER_STOP = new MessageType("server-stop", false);
         public final static MessageType KICK = new MessageType("kick", false);
         public final static MessageType MUTE = new MessageType("mute", false);
-        private final static MessageType[] VALUES = new MessageType[]{JOIN, LEAVE, CHAT, DEATH, AFK, SERVER_START, SERVER_STOP, KICK, MUTE};
+        private final static MessageType[] VALUES = new MessageType[]{JOIN, LEAVE, CHAT, DEATH, AFK, ADVANCEMENT, SERVER_START, SERVER_STOP, KICK, MUTE};
 
         /**
          * Gets an array of all the default {@link MessageType MessageTypes}.

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -277,6 +277,18 @@ public class DiscordSettings implements IConf {
                 "username", "displayname");
     }
 
+    public MessageFormat getAdvancementFormat(Player player) {
+        final String format = getFormatString("advancement");
+        final String filled;
+        if (plugin.isPAPI() && format != null) {
+            filled = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, format);
+        } else {
+            filled = format;
+        }
+        return generateMessageFormat(filled, ":medal: {displayname} has completed the advancement **{advancement}**!", false,
+                "username", "displayname", "advancement");
+    }
+
     public String getStartMessage() {
         return config.getString("messages.server-start", ":white_check_mark: The server has started!");
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -121,6 +121,10 @@ public class DiscordSettings implements IConf {
         return config.getBoolean("chat.show-all-chat", false);
     }
 
+    public List<String> getRelayToConsoleList() {
+        return config.getList("chat.relay-to-console", String.class);
+    }
+
     public String getConsoleChannelDef() {
         return config.getString("console.channel", "none");
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import static com.earth2me.essentials.I18n.tl;
+
 public class DiscordSettings implements IConf {
     private final EssentialsConfiguration config;
     private final EssentialsDiscord plugin;
@@ -306,6 +308,11 @@ public class DiscordSettings implements IConf {
 
     @Override
     public void reloadConfig() {
+        if (plugin.isInvalidStartup()) {
+            plugin.getLogger().warning(tl("discordReloadInvalid"));
+            return;
+        }
+
         config.load();
 
         // Build channel maps

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -153,6 +153,10 @@ public class DiscordSettings implements IConf {
         return config.getBoolean("show-name", false);
     }
 
+    public boolean isShowDisplayName() {
+        return config.getBoolean("show-displayname", false);
+    }
+
     public String getAvatarURL() {
         return config.getString("avatar-url", "https://crafthead.net/helm/{uuid}");
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -151,6 +151,14 @@ public class DiscordSettings implements IConf {
         return config.getString("avatar-url", "https://crafthead.net/helm/{uuid}");
     }
 
+    public boolean isVanishFakeJoinLeave() {
+        return config.getBoolean("vanish-fake-join-leave", true);
+    }
+
+    public boolean isVanishHideMessages() {
+        return config.getBoolean("vanish-hide-messages", true);
+    }
+
     // General command settings
 
     public boolean isCommandEnabled(String command) {

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/EssentialsDiscord.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/EssentialsDiscord.java
@@ -36,6 +36,10 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
         settings = new DiscordSettings(this);
         ess.addReloadListener(settings);
 
+        if (metrics == null) {
+            metrics = new MetricsWrapper(this, 9824, false);
+        }
+
         if (jda == null) {
             jda = new JDADiscordService(this);
             try {
@@ -46,23 +50,22 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
                 if (ess.getSettings().isDebug()) {
                     e.printStackTrace();
                 }
-                setEnabled(false);
-                return;
+                jda.shutdown();
             }
-        }
-
-        if (metrics == null) {
-            metrics = new MetricsWrapper(this, 9824, false);
         }
     }
 
     public void onReload() {
-        if (jda != null) {
+        if (jda != null && !jda.isInvalidStartup()) {
             jda.updatePresence();
             jda.updatePrimaryChannel();
             jda.updateConsoleRelay();
             jda.updateTypesRelay();
         }
+    }
+
+    public boolean isInvalidStartup() {
+        return jda != null && jda.isInvalidStartup();
     }
 
     public IEssentials getEss() {
@@ -79,7 +82,7 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
 
     @Override
     public void onDisable() {
-        if (jda != null) {
+        if (jda != null && !jda.isInvalidStartup()) {
             jda.shutdown();
         }
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -63,6 +63,7 @@ public class JDADiscordService implements DiscordService {
     private ConsoleInjector injector;
     private DiscordCommandDispatcher commandDispatcher;
     private InteractionControllerImpl interactionController;
+    private boolean invalidStartup = false;
 
     public JDADiscordService(EssentialsDiscord plugin) {
         this.plugin = plugin;
@@ -148,11 +149,13 @@ public class JDADiscordService implements DiscordService {
         logger.log(Level.INFO, tl("discordLoggingInDone", jda.getSelfUser().getAsTag()));
 
         if (jda.getGuilds().isEmpty()) {
+            invalidStartup = true;
             throw new IllegalArgumentException(tl("discordErrorNoGuildSize"));
         }
 
         guild = jda.getGuildById(plugin.getSettings().getGuildId());
         if (guild == null) {
+            invalidStartup = true;
             throw new IllegalArgumentException(tl("discordErrorNoGuild"));
         }
 
@@ -348,8 +351,10 @@ public class JDADiscordService implements DiscordService {
         }
 
         if (jda != null) {
-            sendMessage(MessageType.DefaultTypes.SERVER_STOP, getSettings().getStopMessage(), true);
-            DiscordUtil.dispatchDiscordMessage(JDADiscordService.this, MessageType.DefaultTypes.SERVER_STOP, getSettings().getStopMessage(), true, null, null, null);
+            if (!invalidStartup) {
+                sendMessage(MessageType.DefaultTypes.SERVER_STOP, getSettings().getStopMessage(), true);
+                DiscordUtil.dispatchDiscordMessage(JDADiscordService.this, MessageType.DefaultTypes.SERVER_STOP, getSettings().getStopMessage(), true, null, null, null);
+            }
 
             shutdownConsoleRelay(true);
 
@@ -408,6 +413,10 @@ public class JDADiscordService implements DiscordService {
 
     public WebhookClient getConsoleWebhook() {
         return consoleWebhook;
+    }
+
+    public boolean isInvalidStartup() {
+        return invalidStartup;
     }
 
     public boolean isDebug() {

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -5,6 +5,7 @@ import club.minnced.discord.webhook.WebhookClientBuilder;
 import club.minnced.discord.webhook.send.WebhookMessage;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
 import com.earth2me.essentials.utils.FormatUtil;
+import com.earth2me.essentials.utils.VersionUtil;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Guild;
@@ -13,6 +14,8 @@ import net.dv8tion.jda.api.entities.Webhook;
 import net.dv8tion.jda.api.events.ShutdownEvent;
 import net.dv8tion.jda.api.hooks.EventListener;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.ess3.nms.refl.providers.AchievementListenerProvider;
+import net.ess3.nms.refl.providers.AdvancementListenerProvider;
 import net.essentialsx.api.v2.events.discord.DiscordMessageEvent;
 import net.essentialsx.api.v2.services.discord.DiscordService;
 import net.essentialsx.api.v2.services.discord.InteractionController;
@@ -181,6 +184,17 @@ public class JDADiscordService implements DiscordService {
         updateTypesRelay();
 
         Bukkit.getPluginManager().registerEvents(new BukkitListener(this), plugin);
+
+        try {
+            if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_12_0_R01)) {
+                Bukkit.getPluginManager().registerEvents(new AdvancementListenerProvider(), plugin);
+            } else {
+                Bukkit.getPluginManager().registerEvents(new AchievementListenerProvider(), plugin);
+            }
+        } catch (final Throwable e) {
+            logger.log(Level.WARNING, "Error while loading the achievement/advancement listener. You will not receive achievement/advancement notifications on Discord.", e);
+        }
+
         getPlugin().getEss().scheduleSyncDelayedTask(() -> DiscordUtil.dispatchDiscordMessage(JDADiscordService.this, MessageType.DefaultTypes.SERVER_START, getSettings().getStartMessage(), true, null, null, null));
 
         Bukkit.getServicesManager().register(DiscordService.class, this, plugin, ServicePriority.Normal);

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -252,7 +252,7 @@ public class JDADiscordService implements DiscordService {
     }
 
     public void updateTypesRelay() {
-        if (!getSettings().isShowAvatar() && !getSettings().isShowName()) {
+        if (!getSettings().isShowAvatar() && !getSettings().isShowName() && !getSettings().isShowDisplayName()) {
             for (WebhookClient webhook : channelIdToWebhook.values()) {
                 webhook.close();
             }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -160,12 +160,18 @@ public class JDADiscordService implements DiscordService {
         }
 
         interactionController = new InteractionControllerImpl(this);
+        // Each will throw an exception if disabled
         try {
             interactionController.registerCommand(new ExecuteCommand(this));
+        } catch (InteractionException ignored) {
+        }
+        try {
             interactionController.registerCommand(new MessageCommand(this));
+        } catch (InteractionException ignored) {
+        }
+        try {
             interactionController.registerCommand(new ListCommand(this));
         } catch (InteractionException ignored) {
-            // won't happen
         }
 
         updatePrimaryChannel();

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -101,7 +101,7 @@ public class BukkitListener implements Listener {
                             MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(jda.getPlugin().getEss().getPermissionsHandler().getSuffix(player)))),
                     player.hasPermission("essentials.discord.ping"),
                     jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()) : null,
-                    jda.getSettings().isShowName() ? player.getName() : null,
+                    jda.getSettings().isShowName() ? player.getName() : (jda.getSettings().isShowDisplayName() ? player.getDisplayName() : null),
                     player.getUniqueId());
         });
     }
@@ -149,7 +149,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(message),
                         false,
                         jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()) : null,
-                        jda.getSettings().isShowName() ? player.getName() : null,
+                        jda.getSettings().isShowName() ? player.getName() : (jda.getSettings().isShowDisplayName() ? player.getDisplayName() : null),
                         player.getUniqueId()));
     }
 
@@ -180,7 +180,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getDeathMessage())),
                 false,
                 jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getEntity().getUniqueId().toString()) : null,
-                jda.getSettings().isShowName() ? event.getEntity().getName() : null,
+                jda.getSettings().isShowName() ? event.getEntity().getName() : (jda.getSettings().isShowDisplayName() ? event.getEntity().getDisplayName() : null),
                 event.getEntity().getUniqueId());
     }
 
@@ -203,7 +203,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getAffected().getDisplayName())),
                 false,
                 jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getAffected().getBase().getUniqueId().toString()) : null,
-                jda.getSettings().isShowName() ? event.getAffected().getName() : null,
+                jda.getSettings().isShowName() ? event.getAffected().getName() : (jda.getSettings().isShowDisplayName() ? event.getAffected().getDisplayName() : null),
                 event.getAffected().getBase().getUniqueId());
     }
 
@@ -219,8 +219,8 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getDisplayName()),
                         event.getName()),
                 false,
-                jda.getSettings().isShowAvatar() ? AVATAR_URL.replace("{uuid}", event.getPlayer().getUniqueId().toString()) : null,
-                jda.getSettings().isShowName() ? event.getPlayer().getName() : null,
+                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getPlayer().getUniqueId().toString()) : null,
+                jda.getSettings().isShowName() ? event.getPlayer().getName() : (jda.getSettings().isShowDisplayName() ? event.getPlayer().getDisplayName() : null),
                 event.getPlayer().getUniqueId());
     }
 

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -3,6 +3,7 @@ package net.essentialsx.discord.listeners;
 import com.earth2me.essentials.Console;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.FormatUtil;
+import com.earth2me.essentials.utils.VersionUtil;
 import net.ess3.api.IUser;
 import net.ess3.api.events.AfkStatusChangeEvent;
 import net.ess3.api.events.MuteStatusChangeEvent;
@@ -17,6 +18,7 @@ import net.essentialsx.discord.util.DiscordUtil;
 import net.essentialsx.discord.util.MessageUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -148,6 +150,21 @@ public class BukkitListener implements Listener {
         if (isVanishHide(event.getEntity())) {
             return;
         }
+
+        final Boolean showDeathMessages;
+        if (VersionUtil.getServerBukkitVersion().isHigherThan(VersionUtil.v1_12_2_R01)) {
+            showDeathMessages = event.getEntity().getWorld().getGameRuleValue(GameRule.SHOW_DEATH_MESSAGES);
+        } else {
+            if (!event.getEntity().getWorld().isGameRule("showDeathMessages")) {
+                showDeathMessages = null;
+            } else {
+                showDeathMessages = event.getEntity().getWorld().getGameRuleValue("showDeathMessages").equals("true");
+            }
+        }
+        if ((showDeathMessages != null && !showDeathMessages) || event.getDeathMessage() == null || event.getDeathMessage().trim().isEmpty()) {
+            return;
+        }
+
         sendDiscordMessage(MessageType.DefaultTypes.DEATH,
                 MessageUtil.formatMessage(jda.getSettings().getDeathFormat(event.getEntity()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getEntity().getName()),

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -7,6 +7,7 @@ import net.ess3.api.IUser;
 import net.ess3.api.events.AfkStatusChangeEvent;
 import net.ess3.api.events.MuteStatusChangeEvent;
 import net.ess3.api.events.VanishStatusChangeEvent;
+import net.ess3.provider.AbstractAchievementEvent;
 import net.essentialsx.api.v2.events.AsyncUserDataLoadEvent;
 import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
 import net.essentialsx.api.v2.events.discord.DiscordMessageEvent;
@@ -179,6 +180,23 @@ public class BukkitListener implements Listener {
                 jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getAffected().getBase().getUniqueId().toString()) : null,
                 jda.getSettings().isShowName() ? event.getAffected().getName() : null,
                 event.getAffected().getBase().getUniqueId());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onAdvancement(AbstractAchievementEvent event) {
+        if (isVanishHide(event.getPlayer())) {
+            return;
+        }
+
+        sendDiscordMessage(MessageType.DefaultTypes.ADVANCEMENT,
+                MessageUtil.formatMessage(jda.getSettings().getAdvancementFormat(event.getPlayer()),
+                        MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getName()),
+                        MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getDisplayName()),
+                        event.getName()),
+                false,
+                jda.getSettings().isShowAvatar() ? AVATAR_URL.replace("{uuid}", event.getPlayer().getUniqueId().toString()) : null,
+                jda.getSettings().isShowName() ? event.getPlayer().getName() : null,
+                event.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -109,16 +109,24 @@ public class BukkitListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onJoin(AsyncUserDataLoadEvent event) {
         // Delay join to let nickname load
-        if (event.getJoinMessage() != null && !isVanishHide(event.getUser())) {
+        if (!isSilentJoinQuit(event.getUser(), "join") && !isVanishHide(event.getUser())) {
             sendJoinQuitMessage(event.getUser().getBase(), event.getJoinMessage(), true);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onQuit(PlayerQuitEvent event) {
-        if (event.getQuitMessage() != null && !isVanishHide(event.getPlayer())) {
+        if (!isSilentJoinQuit(event.getPlayer(), "quit") && !isVanishHide(event.getPlayer())) {
             sendJoinQuitMessage(event.getPlayer(), event.getQuitMessage(), false);
         }
+    }
+
+    public boolean isSilentJoinQuit(final Player player, final String type) {
+        return isSilentJoinQuit(jda.getPlugin().getEss().getUser(player), type);
+    }
+
+    public boolean isSilentJoinQuit(final IUser user, final String type) {
+        return jda.getPlugin().getEss().getSettings().allowSilentJoinQuit() && user.isAuthorized("essentials.silent" + type);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -3,8 +3,10 @@ package net.essentialsx.discord.listeners;
 import com.earth2me.essentials.Console;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.FormatUtil;
+import net.ess3.api.IUser;
 import net.ess3.api.events.AfkStatusChangeEvent;
 import net.ess3.api.events.MuteStatusChangeEvent;
+import net.ess3.api.events.VanishStatusChangeEvent;
 import net.essentialsx.api.v2.events.AsyncUserDataLoadEvent;
 import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
 import net.essentialsx.api.v2.events.discord.DiscordMessageEvent;
@@ -13,6 +15,7 @@ import net.essentialsx.discord.JDADiscordService;
 import net.essentialsx.discord.util.DiscordUtil;
 import net.essentialsx.discord.util.MessageUtil;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -103,36 +106,47 @@ public class BukkitListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onJoin(AsyncUserDataLoadEvent event) {
         // Delay join to let nickname load
-        if (event.getJoinMessage() != null) {
-            sendDiscordMessage(MessageType.DefaultTypes.JOIN,
-                    MessageUtil.formatMessage(jda.getSettings().getJoinFormat(event.getUser().getBase()),
-                            MessageUtil.sanitizeDiscordMarkdown(event.getUser().getName()),
-                            MessageUtil.sanitizeDiscordMarkdown(event.getUser().getDisplayName()),
-                            MessageUtil.sanitizeDiscordMarkdown(event.getJoinMessage())),
-                    false,
-                    jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getUser().getBase().getUniqueId().toString()) : null,
-                    jda.getSettings().isShowName() ? event.getUser().getName() : null,
-                    event.getUser().getBase().getUniqueId());
+        if (event.getJoinMessage() != null && !isVanishHide(event.getUser())) {
+            sendJoinQuitMessage(event.getUser().getBase(), event.getJoinMessage(), true);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onQuit(PlayerQuitEvent event) {
-        if (event.getQuitMessage() != null) {
-            sendDiscordMessage(MessageType.DefaultTypes.LEAVE,
-                    MessageUtil.formatMessage(jda.getSettings().getQuitFormat(event.getPlayer()),
-                            MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getName()),
-                            MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getDisplayName()),
-                            MessageUtil.sanitizeDiscordMarkdown(event.getQuitMessage())),
-                    false,
-                    jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getPlayer().getUniqueId().toString()) : null,
-                    jda.getSettings().isShowName() ? event.getPlayer().getName() : null,
-                    event.getPlayer().getUniqueId());
+        if (event.getQuitMessage() != null && !isVanishHide(event.getPlayer())) {
+            sendJoinQuitMessage(event.getPlayer(), event.getQuitMessage(), false);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onVanishStatusChange(VanishStatusChangeEvent event) {
+        if (!jda.getSettings().isVanishFakeJoinLeave()) {
+            return;
+        }
+        if (event.getValue()) {
+            sendJoinQuitMessage(event.getAffected().getBase(), ChatColor.YELLOW + event.getAffected().getName() + " left the game", false);
+            return;
+        }
+        sendJoinQuitMessage(event.getAffected().getBase(), ChatColor.YELLOW + event.getAffected().getName() + " joined the game", true);
+    }
+
+    public void sendJoinQuitMessage(final Player player, final String message, boolean join) {
+        sendDiscordMessage(join ? MessageType.DefaultTypes.JOIN : MessageType.DefaultTypes.LEAVE,
+                MessageUtil.formatMessage(join ? jda.getSettings().getJoinFormat(player) : jda.getSettings().getQuitFormat(player),
+                        MessageUtil.sanitizeDiscordMarkdown(player.getName()),
+                        MessageUtil.sanitizeDiscordMarkdown(player.getDisplayName()),
+                        MessageUtil.sanitizeDiscordMarkdown(message),
+                        false,
+                        jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()) : null,
+                        jda.getSettings().isShowName() ? player.getName() : null,
+                        player.getUniqueId()));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onDeath(PlayerDeathEvent event) {
+        if (isVanishHide(event.getEntity())) {
+            return;
+        }
         sendDiscordMessage(MessageType.DefaultTypes.DEATH,
                 MessageUtil.formatMessage(jda.getSettings().getDeathFormat(event.getEntity()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getEntity().getName()),
@@ -146,6 +160,10 @@ public class BukkitListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onAfk(AfkStatusChangeEvent event) {
+        if (isVanishHide(event.getAffected())) {
+            return;
+        }
+
         final MessageFormat format;
         if (event.getValue()) {
             format = jda.getSettings().getAfkFormat(event.getAffected().getBase());
@@ -165,11 +183,22 @@ public class BukkitListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onKick(PlayerKickEvent event) {
+        if (isVanishHide(event.getPlayer())) {
+            return;
+        }
         sendDiscordMessage(MessageType.DefaultTypes.KICK,
                 MessageUtil.formatMessage(jda.getSettings().getKickFormat(),
                         MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getDisplayName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getReason())));
+    }
+
+    private boolean isVanishHide(final Player player) {
+        return isVanishHide(jda.getPlugin().getEss().getUser(player));
+    }
+
+    private boolean isVanishHide(final IUser user) {
+        return jda.getSettings().isVanishHideMessages() && user.isHidden();
     }
 
     private void sendDiscordMessage(final MessageType messageType, final String message) {

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/DiscordListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/DiscordListener.java
@@ -88,12 +88,20 @@ public class DiscordListener extends ListenerAdapter {
                 event.getChannel().getName(), user.getName(), user.getDiscriminator(), user.getAsTag(),
                 member.getEffectiveName(), DiscordUtil.getRoleColorFormat(member), finalMessage, DiscordUtil.getRoleFormat(member)), EmojiParser.FitzpatrickAction.REMOVE);
 
+        for (final String group : keys) {
+            if (plugin.getSettings().getRelayToConsoleList().contains(group)) {
+                logger.info(formattedMessage);
+                break;
+            }
+        }
+
         for (IUser essUser : plugin.getPlugin().getEss().getOnlineUsers()) {
             for (String group : keys) {
                 final String perm = "essentials.discord.receive." + group;
                 final boolean primaryOverride = plugin.getSettings().isAlwaysReceivePrimary() && group.equalsIgnoreCase("primary");
                 if (primaryOverride || (essUser.isPermissionSet(perm) && essUser.isAuthorized(perm))) {
                     essUser.sendMessage(formattedMessage);
+                    break;
                 }
             }
         }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/ConsoleInjector.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/ConsoleInjector.java
@@ -73,7 +73,7 @@ public class ConsoleInjector extends AbstractAppender {
         }
 
         //noinspection UnstableApiUsage
-        messageQueue.addAll(Splitter.fixedLength(Message.MAX_CONTENT_LENGTH).splitToList(
+        messageQueue.addAll(Splitter.fixedLength(Message.MAX_CONTENT_LENGTH - 2).splitToList(
                 MessageUtil.formatMessage(jda.getSettings().getConsoleFormat(),
                         TimeFormat.TIME_LONG.format(Instant.now()),
                         event.getLevel().name(),

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/ConsoleInjector.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/ConsoleInjector.java
@@ -3,6 +3,7 @@ package net.essentialsx.discord.util;
 import com.earth2me.essentials.utils.FormatUtil;
 import com.google.common.base.Splitter;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import net.essentialsx.discord.JDADiscordService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
@@ -11,8 +12,7 @@ import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.bukkit.Bukkit;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -24,7 +24,6 @@ public class ConsoleInjector extends AbstractAppender {
 
     private final JDADiscordService jda;
     private final BlockingQueue<String> messageQueue = new LinkedBlockingQueue<>();
-    private final SimpleDateFormat timestampFormat = new SimpleDateFormat("HH:mm:ss");
     private final int taskId;
 
     public ConsoleInjector(JDADiscordService jda) {
@@ -76,7 +75,7 @@ public class ConsoleInjector extends AbstractAppender {
         //noinspection UnstableApiUsage
         messageQueue.addAll(Splitter.fixedLength(Message.MAX_CONTENT_LENGTH).splitToList(
                 MessageUtil.formatMessage(jda.getSettings().getConsoleFormat(),
-                        timestampFormat.format(new Date()),
+                        TimeFormat.TIME_LONG.format(Instant.now()),
                         event.getLevel().name(),
                         MessageUtil.sanitizeDiscordMarkdown(entry))));
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
@@ -144,11 +144,10 @@ public final class DiscordUtil {
      * @return The bukkit color code or blank string.
      */
     public static String getRoleColorFormat(Member member) {
-        final int rawColor = member.getColorRaw();
-
-        if (rawColor == Role.DEFAULT_COLOR_RAW) {
+        if (member.getColorRaw() == Role.DEFAULT_COLOR_RAW) {
             return "";
         }
+        final int rawColor = 0xff000000 | member.getColorRaw();
 
         if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_16_1_R01)) {
             // Essentials' FormatUtil allows us to not have to use bungee's chatcolor since bukkit's own one doesn't support rgb

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -134,6 +134,9 @@ show-avatar: false
 avatar-url: "https://crafthead.net/helm/{uuid}"
 # Whether or not player messages should show their name as the bot name in Discord.
 show-name: false
+# Whether or not player messages should show their display-name/nickname as the bot name in Discord.
+# You must disable show-name for this option to work.
+show-displayname: false
 
 # Whether or not fake join and leave messages should be sent to Discord when a player toggles vanish in Minecraft.
 # Fake join/leave messages will be sent the same as real join and leave messages (and to the same channel).

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -110,6 +110,8 @@ message-types:
   death: primary
   # AFK status change messages sent when a player's AFK status changes.
   afk: primary
+  # Achievement/advancement messages sent when a player is awarded an achievement/advancement.
+  advancement: primary
   # Message sent when the server starts up.
   server-start: primary
   # Message sent when the server shuts down.
@@ -296,10 +298,6 @@ messages:
   # - {deathmessage}: The full default death message used in game
   # ... PlaceholderAPI placeholders are also supported here too!
   death: ":skull: {deathmessage}"
-  # This is the message sent to discord when the server starts.
-  server-start: ":white_check_mark: The server has started!"
-  # This is the message sent to discord when the server stops.
-  server-stop: ":octagonal_sign: The server has stopped!"
   # This is the message sent to discord when a player becomes afk.
   # The following placeholders can be used here:
   # - {username}: The name of the user who became afk
@@ -312,6 +310,17 @@ messages:
   # - {displayname}: The display name of the user who is no longer afk
   # ... PlaceholderAPI placeholders are also supported here too!
   un-afk: ":keyboard: {displayname} is no longer AFK!"
+  # This is the message sent to Discord when a player is awarded an advancement.
+  # The following placeholders can be used here:
+  # - {username}: The name of the user who was awarded the advancement.
+  # - {displayname}: The display name of the user who was awarded the advancement.
+  # - {advancement}: The name of the advancement.
+  # ... PlaceholderAPI placeholders are also supported here too!
+  advancement: ":medal: {displayname} has completed the advancement **{advancement}**!"
+  # This is the message sent to discord when the server starts.
+  server-start: ":white_check_mark: The server has started!"
+  # This is the message sent to discord when the server stops.
+  server-stop: ":octagonal_sign: The server has stopped!"
   # This is the message sent to discord when a player is kicked from the server.
   # The following placeholders can be used here:
   # - {username}: The name of the user who got kicked

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -51,8 +51,8 @@ chat:
   discord-max-length: 2000
   # Whether or not new lines from Discord should be filtered or not.
   filter-newlines: true
-  # A regex pattern which will not send matching messages through to Discord.
-  # By default, this will ignore messages starting with '!' and '?'.
+  # A regex pattern which will ignore matching incoming messages from Discord.
+  # By default, this will ignore messages starting with '!' or '?'.
   discord-filter: "^[!?]"
   # Whether or not webhook messages from Discord should be shown in Minecraft.
   show-webhook-messages: false
@@ -134,13 +134,13 @@ show-name: false
 # Fake join/leave messages will be sent the same as real join and leave messages (and to the same channel).
 vanish-fake-join-leave: true
 
-# Whether or not messages from vanished players should be sent to discord.
+# Whether or not messages from vanished players should be sent to Discord.
 # This affects join, leave, death, and afk message types by default.
 vanish-hide-messages: true
 
 # Settings pertaining to the varies commands registered by EssentialsX on Discord.
 commands:
-  # The execute command allows for discord users to execute MC commands from Discord.
+  # The execute command allows for Discord users to execute MC commands from Discord.
   # MC commands executed by this will be ran as the console and you should therefore be careful to who you grant this to.
   execute:
     # Set to false if you do not want this command to show up on the Discord command selector.
@@ -219,18 +219,18 @@ presence:
 # The following entries allow you to customize the formatting of messages sent by the plugin.
 # Each message has a description of how it is used along with placeholders that can be used.
 messages:
-  # This is the message that is used to show discord chat to players in game.
+  # This is the message that is used to show Discord chat to players in game.
   # Color/formatting codes and the follow placeholders can be used here:
-  # - {channel}: The name of the discord channel the message was sent from
+  # - {channel}: The name of the Discord channel the message was sent from
   # - {username}: The username of the user who sent the message
   # - {discriminator}: The four numbers displayed after the user's name
   # - {fullname}: Equivalent to typing "{username}#{discriminator}"
   # - {nickname}: The nickname of the user who sent the message. (Will return username if user has no nickname)
   # - {role}: The name of the user's topmost role on Discord. If the user doesn't have a role, the placeholder is empty.
-  # - {color}: The minecraft color representative of the user's topmost role color on discord. If the user doesn't have a role color, the placeholder is empty.
+  # - {color}: The minecraft color representative of the user's topmost role color on Discord. If the user doesn't have a role color, the placeholder is empty.
   # - {message}: The content of the message being sent
   discord-to-mc: "&6[#{channel}] &3{fullname}&7: &f{message}"
-  # This is the message that is used to relay minecraft chat in discord.
+  # This is the message that is used to relay minecraft chat in Discord.
   # The following placeholders can be used here:
   # - {username}: The username of the player sending the message
   # - {displayname}: The display name of the player sending the message (This would be their nickname)
@@ -240,7 +240,7 @@ messages:
   # - {suffix}: The suffix of the player sending the message
   # ... PlaceholderAPI placeholders are also supported here too!
   mc-to-discord: "{displayname}: {message}"
-  # This is the message sent to discord when a player is temporarily muted in minecraft.
+  # This is the message sent to Discord when a player is temporarily muted in minecraft.
   # The following placeholders can be used here:
   # - {username}: The username of the player being muted
   # - {displayname}: The display name of the player being muted
@@ -248,7 +248,7 @@ messages:
   # - {controllerdisplayname}: The display name of the user who muted the player
   # - {time}: The amount of time the player was muted for
   temporary-mute: "{controllerdisplayname} has muted player {displayname} for {time}."
-  # This is the message sent to discord when a player is temporarily muted (with a reason specified) in minecraft.
+  # This is the message sent to Discord when a player is temporarily muted (with a reason specified) in minecraft.
   # The following placeholders can be used here:
   # - {username}: The username of the player being muted
   # - {displayname}: The display name of the player being muted
@@ -257,14 +257,14 @@ messages:
   # - {time}: The amount of time the player was muted for
   # - {reason}: The reason the player was muted for
   temporary-mute-reason: "{controllerdisplayname} has muted player {displayname} for {time}. Reason: {reason}."
-  # This is the message sent to discord when a player is permanently muted in minecraft.
+  # This is the message sent to Discord when a player is permanently muted in minecraft.
   # The following placeholders can be used here:
   # - {username}: The username of the player being muted
   # - {displayname}: The display name of the player being muted
   # - {controllername}: The username of the user who muted the player
   # - {controllerdisplayname}: The display name of the user who muted the player
   permanent-mute: "{controllerdisplayname} has muted player {displayname}."
-  # This is the message sent to discord when a player is permanently muted (with a reason specified) in minecraft.
+  # This is the message sent to Discord when a player is permanently muted (with a reason specified) in minecraft.
   # The following placeholders can be used here:
   # - {username}: The username of the player being muted
   # - {displayname}: The display name of the player being muted
@@ -272,39 +272,39 @@ messages:
   # - {controllerdisplayname}: The display name of the user who muted the player
   # - {reason}: The reason the player was muted for
   permanent-mute-reason: "{controllerdisplayname} has permanently muted player {displayname}. Reason: {reason}."
-  # This is the message sent to discord when a player is unmuted in minecraft.
+  # This is the message sent to Discord when a player is unmuted in minecraft.
   # The following placeholders can be used here:
   # - {username}: The username of the player being unmuted
   # - {displayname}: The display name of the player being unmuted
   unmute: "{displayname} unmuted."
-  # This is the message sent to discord when a player joins the minecraft server.
+  # This is the message sent to Discord when a player joins the minecraft server.
   # The following placeholders can be used here:
   # - {username}: The name of the user joining
   # - {displayname}: The display name of the user joining
   # - {joinmessage}: The full default join message used in game
   # ... PlaceholderAPI placeholders are also supported here too!
   join: ":arrow_right: {displayname} has joined!"
-  # This is the message sent to discord when a player leaves the minecraft server.
+  # This is the message sent to Discord when a player leaves the minecraft server.
   # The following placeholders can be used here:
   # - {username}: The name of the user leaving
   # - {displayname}: The display name of the user leaving
   # - {quitmessage}: The full default leave message used in game
   # ... PlaceholderAPI placeholders are also supported here too!
   quit: ":arrow_left: {displayname} has left!"
-  # This is the message sent to discord when a player dies.
+  # This is the message sent to Discord when a player dies.
   # The following placeholders can be used here:
   # - {username}: The name of the user who died
   # - {displayname}: The display name of the user who died
   # - {deathmessage}: The full default death message used in game
   # ... PlaceholderAPI placeholders are also supported here too!
   death: ":skull: {deathmessage}"
-  # This is the message sent to discord when a player becomes afk.
+  # This is the message sent to Discord when a player becomes afk.
   # The following placeholders can be used here:
   # - {username}: The name of the user who became afk
   # - {displayname}: The display name of the user who became afk
   # ... PlaceholderAPI placeholders are also supported here too!
   afk: ":person_walking: {displayname} is now AFK!"
-  # This is the message sent to discord when a player is no longer afk.
+  # This is the message sent to Discord when a player is no longer afk.
   # The following placeholders can be used here:
   # - {username}: The name of the user who is no longer afk
   # - {displayname}: The display name of the user who is no longer afk
@@ -317,11 +317,11 @@ messages:
   # - {advancement}: The name of the advancement.
   # ... PlaceholderAPI placeholders are also supported here too!
   advancement: ":medal: {displayname} has completed the advancement **{advancement}**!"
-  # This is the message sent to discord when the server starts.
+  # This is the message sent to Discord when the server starts.
   server-start: ":white_check_mark: The server has started!"
-  # This is the message sent to discord when the server stops.
+  # This is the message sent to Discord when the server stops.
   server-stop: ":octagonal_sign: The server has stopped!"
-  # This is the message sent to discord when a player is kicked from the server.
+  # This is the message sent to Discord when a player is kicked from the server.
   # The following placeholders can be used here:
   # - {username}: The name of the user who got kicked
   # - {displayname}: The display name of the user who got kicked

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -61,6 +61,11 @@ chat:
   # Whether or not to show all Minecraft chat messages that are not shown to all players.
   # You shouldn't need to enable this unless you're not seeing all chat messages go through to Discord.
   show-all-chat: false
+  # A list of Discord channels which should be logged to console.
+  # If you want to use the channels below, remember to uncomment the line by removing the '#' before the '-'.
+  relay-to-console:
+    #- primary
+    #- chat
 
 # Console relay settings
 # The console relay sends every message shown in the console to a Discord channel.

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -128,6 +128,14 @@ avatar-url: "https://crafthead.net/helm/{uuid}"
 # Whether or not player messages should show their name as the bot name in Discord.
 show-name: false
 
+# Whether or not fake join and leave messages should be sent to Discord when a player toggles vanish in Minecraft.
+# Fake join/leave messages will be sent the same as real join and leave messages (and to the same channel).
+vanish-fake-join-leave: true
+
+# Whether or not messages from vanished players should be sent to discord.
+# This affects join, leave, death, and afk message types by default.
+vanish-hide-messages: true
+
 # Settings pertaining to the varies commands registered by EssentialsX on Discord.
 commands:
   # The execute command allows for discord users to execute MC commands from Discord.

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/AbstractAchievementEvent.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/AbstractAchievementEvent.java
@@ -1,0 +1,34 @@
+package net.ess3.provider;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class AbstractAchievementEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Player player;
+    private final String name;
+
+    public AbstractAchievementEvent(Player player, String name) {
+        this.player = player;
+        this.name = name;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/providers/NMSReflectionProvider/src/main/java/net/ess3/nms/refl/ReflUtil.java
+++ b/providers/NMSReflectionProvider/src/main/java/net/ess3/nms/refl/ReflUtil.java
@@ -61,6 +61,10 @@ public final class ReflUtil {
         return nmsVersionObject;
     }
 
+    public static boolean isMojMap() {
+        return getNmsVersionObject().getMajor() == 99;
+    }
+
     public static Class<?> getNMSClass(final String className) {
         return getClassCached("net.minecraft.server" + (ReflUtil.getNmsVersionObject().isLowerThan(ReflUtil.V1_17_R1) ? "." + getNMSVersion() : "") + "." + className);
     }

--- a/providers/NMSReflectionProvider/src/main/java/net/ess3/nms/refl/providers/AchievementListenerProvider.java
+++ b/providers/NMSReflectionProvider/src/main/java/net/ess3/nms/refl/providers/AchievementListenerProvider.java
@@ -1,0 +1,127 @@
+package net.ess3.nms.refl.providers;
+
+import net.ess3.provider.AbstractAchievementEvent;
+import org.bukkit.Achievement;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerAchievementAwardedEvent;
+
+@SuppressWarnings("deprecation")
+public class AchievementListenerProvider implements Listener {
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onAchievement(final PlayerAchievementAwardedEvent event) {
+        Bukkit.getPluginManager().callEvent(new AbstractAchievementEvent(event.getPlayer(), getAchievementName(event.getAchievement())));
+    }
+
+    private String getAchievementName(final Achievement achievement) {
+        switch (achievement) {
+            case OPEN_INVENTORY: {
+                return "Taking Inventory";
+            }
+            case MINE_WOOD: {
+                return "Getting Wood";
+            }
+            case BUILD_WORKBENCH: {
+                return "Benchmarking";
+            }
+            case BUILD_PICKAXE: {
+                return "Time to Mine!";
+            }
+            case BUILD_FURNACE: {
+                return "Hot Topic";
+            }
+            case ACQUIRE_IRON: {
+                return "Acquire Hardware!";
+            }
+            case BUILD_HOE: {
+                return "Time to Farm!";
+            }
+            case MAKE_BREAD: {
+                return "Bake Bread";
+            }
+            case BAKE_CAKE: {
+                return "The Lie";
+            }
+            case BUILD_BETTER_PICKAXE: {
+                return "Getting an Upgrade";
+            }
+            case COOK_FISH: {
+                return "Delicious Fish";
+            }
+            case ON_A_RAIL: {
+                return "On A Rail";
+            }
+            case BUILD_SWORD: {
+                return "Time to Strike";
+            }
+            case KILL_ENEMY: {
+                return "Monster Hunter";
+            }
+            case KILL_COW: {
+                return "Cow Tipper";
+            }
+            case FLY_PIG: {
+                return "When Pigs Fly!";
+            }
+            case SNIPE_SKELETON: {
+                return "Sniper Duel";
+            }
+            case GET_DIAMONDS: {
+                return "DIAMONDS!";
+            }
+            case NETHER_PORTAL: {
+                return "We Need to Go Deeper";
+            }
+            case GHAST_RETURN: {
+                return "Return to Sender";
+            }
+            case GET_BLAZE_ROD: {
+                return "Into Fire";
+            }
+            case BREW_POTION: {
+                return "Local Brewery";
+            }
+            case END_PORTAL: {
+                return "The End?";
+            }
+            case THE_END: {
+                return "The End.";
+            }
+            case ENCHANTMENTS: {
+                return "Enchanter";
+            }
+            case OVERKILL: {
+                return "Overkill";
+            }
+            case BOOKCASE: {
+                return "Librarian";
+            }
+            case EXPLORE_ALL_BIOMES: {
+                return "Adventuring Time";
+            }
+            case SPAWN_WITHER: {
+                return "The Beginning?";
+            }
+            case KILL_WITHER: {
+                return "The Beginning.";
+            }
+            case FULL_BEACON: {
+                return "Beaconator";
+            }
+            case BREED_COW: {
+                return "Repopulation";
+            }
+            case DIAMONDS_TO_YOU: {
+                return "Diamonds to you!";
+            }
+            case OVERPOWERED: {
+                return "Overpowered";
+            }
+            default: {
+                throw new IllegalStateException();
+            }
+        }
+    }
+}

--- a/providers/NMSReflectionProvider/src/main/java/net/ess3/nms/refl/providers/AdvancementListenerProvider.java
+++ b/providers/NMSReflectionProvider/src/main/java/net/ess3/nms/refl/providers/AdvancementListenerProvider.java
@@ -1,0 +1,46 @@
+package net.ess3.nms.refl.providers;
+
+import net.ess3.nms.refl.ReflUtil;
+import net.ess3.provider.AbstractAchievementEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class AdvancementListenerProvider implements Listener {
+    private final Object language;
+    private final MethodHandle languageGetOrDefault;
+
+    public AdvancementListenerProvider() throws Throwable {
+        final Class<?> languageClass;
+        if (ReflUtil.isMojMap()) {
+            languageClass = ReflUtil.getClassCached("net.minecraft.locale.Language");
+        } else if (ReflUtil.getNmsVersionObject().isHigherThanOrEqualTo(ReflUtil.V1_17_R1)) {
+            languageClass = ReflUtil.getClassCached("net.minecraft.locale.LocaleLanguage");
+        } else {
+            languageClass = ReflUtil.getNMSClass("LocaleLanguage");
+        }
+        final MethodHandles.Lookup lookup = MethodHandles.lookup();
+        //noinspection ConstantConditions
+        language = lookup.findStatic(languageClass, ReflUtil.isMojMap() ? "getInstance" : "a", MethodType.methodType(languageClass)).invoke();
+        languageGetOrDefault = lookup.findVirtual(languageClass, ReflUtil.isMojMap() ? "getOrDefault" : "a", MethodType.methodType(String.class, String.class));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onAdvancement(final PlayerAdvancementDoneEvent event) {
+        try {
+            final String key = "advancements." + event.getAdvancement().getKey().getKey().replace('/', '.') + ".title";
+            final String translation = (String) languageGetOrDefault.invoke(language, key);
+            if (!key.equals(translation)) {
+                Bukkit.getPluginManager().callEvent(new AbstractAchievementEvent(event.getPlayer(), translation));
+            }
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Summary of Changes;
* Added a advancement message type:
  ```yml
  message-types:
    ...
    # Achievement/Advancement messages sent when a player is awarded an achievement/advancement.
    advancement: primary
  ```
  ```yml
  messages:
    ...
    # This is the message sent to discord when a player is awarded an advancement.
    # The following placeholders can be used here:
    # - {username}: The name of the user who was awarded the advancement.
    # - {displayname}: The display name of the user who was awarded the advancement.
    # - {advancement}: The name of the advancement.
    # ... PlaceholderAPI placeholders are also supported here too!
    advancement: ":medal: {displayname} has completed the advancement **{advancement}**"
  ```
* Added option to show channels in console:
  ```yml
  chat:
    ...
    # A list of Discord channels which should be logged to console.
    # If you want to use the channels bellow, make sure to remove the '#' before the '-'.
    relay-to-console:
      #- primary
      #- chat
  ```
* Added the following config options to manage vanished users: 
  ```yml
  # Whether or not fake join and leave messages should be sent to discord when a player vanishes/un-vanishes in Minecraft.
  # Fake join/leave messages will be sent the same as real join and leave messages (and to the same channel).
  vanish-fake-join-leave: true
  
  # Whether or not messages from vanished players should be sent to discord.
  # This affects join, leave, death, and afk message types by default.
  vanish-hide-messages: true
  ```
* Added an option to show display name as webhook name:
  ```yml
  # Whether or not player messages should show their display-name/nickname as the bot name in Discord.
  # You must disable show-name for this option to work.
  show-displayname: false
  ```
* Changed the console timespamp placeholder to use native Discord timestamps.
* Fixed occasional exceptions with the console logger.
* Fixed join and quit messages not always showing when they should.
* Fixed numerous errors when EssentialsX Discord had invalid configs.
* Fixed the role color placeholder not working.
* Fixed death messages sometimes showing when they shouldn't.
* Fixed prefixes/suffixes sometimes showing hex format in discord.
* Fixed disabling one command causing all commands to be disabled.