### PR TITLE
Fix server shutdown not setting logout location

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -513,7 +513,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 user.sendMessage(tl("unvanishedReload"));
             }
             if (stopping) {
-                user.setLastLocation();
+                user.setLogoutLocation();
                 if (!user.isHidden()) {
                     user.setLastLogout(System.currentTimeMillis());
                 }


### PR DESCRIPTION
Tiny fix, this should be setting the user's logout location instead of their last location. 

The "last location" is only used to record the location for `/back`, so overwriting it when the player is booted during server shutdown can erase previous death or teleport locations.