### PR TITLE
Fix behaviour of `/itemdb` on legacy versions

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commanditemdb.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commanditemdb.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,9 +56,13 @@ public class Commanditemdb extends EssentialsCommand {
         }
 
         List<String> nameList = ess.getItemDb().nameList(itemStack);
+        nameList = nameList != null ? new ArrayList<>(nameList) : new ArrayList<>();
         nameList.addAll(ess.getCustomItemResolver().getAliasesFor(ess.getItemDb().name(itemStack)));
-        Collections.sort(nameList);
+        if (nameList.isEmpty()) {
+            return;
+        }
 
+        Collections.sort(nameList);
         if (nameList.size() > 15) {
             nameList = nameList.subList(0, 14);
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/items/CustomItemResolver.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/items/CustomItemResolver.java
@@ -44,9 +44,11 @@ public class CustomItemResolver implements IItemDb.ItemResolver, IConf {
 
     public List<String> getAliasesFor(String item) throws Exception {
         final List<String> results = new ArrayList<>();
-        for (Map.Entry<String, String> entry : map.entrySet()) {
-            if (item.equalsIgnoreCase(ess.getItemDb().name(ess.getItemDb().get(entry.getValue())))) {
-                results.add(entry.getKey());
+        if (item != null) {
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                if (item.equalsIgnoreCase(ess.getItemDb().name(ess.getItemDb().get(entry.getValue())))) {
+                    results.add(entry.getKey());
+                }
             }
         }
         return results;

--- a/Essentials/src/main/resources/items.csv
+++ b/Essentials/src/main/resources/items.csv
@@ -7490,6 +7490,9 @@ sparklymelon,382,0
 shiningmelon,382,0
 gmelon,382,0
 smelon,382,0
+mobegg,383,0
+spawnegg,383,0
+mobspawnegg,383,0
 creeperegg,383,50
 eggcreeper,383,50
 skeletonegg,383,51


### PR DESCRIPTION
### Information

This PR adds some missing `items.csv` aliases for the base `MONSTER_EGG` item and makes some changes to handle failure more gracefully on versions using the legacy item database (below 1.13).

Closes #4275.

### Details

**Environments tested:**    

OS: Windows 10 20H2
Java version: `openjdk 16.0.1 2021-04-20`

- [x] Most recent Paper version (git-Paper-75 (MC: 1.17))
- [x] Latest 1.12.2 Paper build (git-Paper-1618 (MC: 1.12.2))