### PR TITLE
Add UserTeleportSpawnEvent

### DIFF
--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/Commandspawn.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/Commandspawn.java
@@ -7,6 +7,7 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.commands.EssentialsCommand;
 import com.earth2me.essentials.commands.NoChargeException;
 import com.earth2me.essentials.commands.NotEnoughArgumentsException;
+import net.essentialsx.api.v2.events.UserTeleportSpawnEvent;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -79,6 +80,11 @@ public class Commandspawn extends EssentialsCommand {
         });
         if (teleportOwner == null) {
             teleportee.getAsyncTeleport().now(spawn, false, TeleportCause.COMMAND, future);
+            return;
+        }
+        final UserTeleportSpawnEvent spawnEvent = new UserTeleportSpawnEvent(teleportee, teleportee.getGroup(), spawn);
+        ess.getServer().getPluginManager().callEvent(spawnEvent);
+        if (spawnEvent.isCancelled()) {
             return;
         }
         teleportOwner.getAsyncTeleport().teleportPlayer(teleportee, spawn, charge, TeleportCause.COMMAND, future);

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/Commandspawn.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/Commandspawn.java
@@ -78,13 +78,13 @@ public class Commandspawn extends EssentialsCommand {
             showError(sender.getSender(), e, commandLabel);
             return false;
         });
-        if (teleportOwner == null) {
-            teleportee.getAsyncTeleport().now(spawn, false, TeleportCause.COMMAND, future);
-            return;
-        }
-        final UserTeleportSpawnEvent spawnEvent = new UserTeleportSpawnEvent(teleportee, teleportee.getGroup(), spawn);
+        final UserTeleportSpawnEvent spawnEvent = new UserTeleportSpawnEvent(teleportee, teleportOwner, teleportee.getGroup(), spawn);
         ess.getServer().getPluginManager().callEvent(spawnEvent);
         if (spawnEvent.isCancelled()) {
+            return;
+        }
+        if (teleportOwner == null) {
+            teleportee.getAsyncTeleport().now(spawn, false, TeleportCause.COMMAND, future);
             return;
         }
         teleportOwner.getAsyncTeleport().teleportPlayer(teleportee, spawn, charge, TeleportCause.COMMAND, future);

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/Commandspawn.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/Commandspawn.java
@@ -39,7 +39,7 @@ public class Commandspawn extends EssentialsCommand {
             });
             respawn(user.getSource(), user, otherUser, charge, commandLabel, future);
         } else {
-            respawn(user.getSource(), user, null, charge, commandLabel, new CompletableFuture<>());
+            respawn(user.getSource(), null, user, charge, commandLabel, new CompletableFuture<>());
         }
 
         throw new NoChargeException();

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/Commandspawn.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/Commandspawn.java
@@ -39,7 +39,7 @@ public class Commandspawn extends EssentialsCommand {
             });
             respawn(user.getSource(), user, otherUser, charge, commandLabel, future);
         } else {
-            respawn(user.getSource(), user, user, charge, commandLabel, new CompletableFuture<>());
+            respawn(user.getSource(), user, null, charge, commandLabel, new CompletableFuture<>());
         }
 
         throw new NoChargeException();

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
@@ -8,7 +8,6 @@ import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.textreader.SimpleTextPager;
 import com.earth2me.essentials.utils.VersionUtil;
 import net.ess3.api.IEssentials;
-import net.essentialsx.api.v2.events.UserTeleportSpawnEvent;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -94,11 +93,6 @@ class EssentialsSpawnPlayerListener implements Listener {
                             ess.showError(user.getSource(), e, "spawn-on-join");
                             return false;
                         });
-                        final UserTeleportSpawnEvent spawnEvent = new UserTeleportSpawnEvent(user, user.getGroup(), spawn);
-                        ess.getServer().getPluginManager().callEvent(spawnEvent);
-                        if (spawnEvent.isCancelled()) {
-                            return;
-                        }
                         user.getAsyncTeleport().nowUnsafe(spawn, TeleportCause.PLUGIN, future);
                     });
                 }
@@ -162,11 +156,6 @@ class EssentialsSpawnPlayerListener implements Listener {
                     logger.log(Level.WARNING, tl("teleportNewPlayerError"), e);
                     return false;
                 });
-                final UserTeleportSpawnEvent spawnEvent = new UserTeleportSpawnEvent(user, user.getGroup(), spawn);
-                ess.getServer().getPluginManager().callEvent(spawnEvent);
-                if (spawnEvent.isCancelled()) {
-                    return;
-                }
                 user.getAsyncTeleport().now(spawn, false, TeleportCause.PLUGIN, future);
             }
         }

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
@@ -8,6 +8,7 @@ import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.textreader.SimpleTextPager;
 import com.earth2me.essentials.utils.VersionUtil;
 import net.ess3.api.IEssentials;
+import net.essentialsx.api.v2.events.UserTeleportSpawnEvent;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -93,6 +94,11 @@ class EssentialsSpawnPlayerListener implements Listener {
                             ess.showError(user.getSource(), e, "spawn-on-join");
                             return false;
                         });
+                        final UserTeleportSpawnEvent spawnEvent = new UserTeleportSpawnEvent(user, user.getGroup(), spawn);
+                        ess.getServer().getPluginManager().callEvent(spawnEvent);
+                        if (spawnEvent.isCancelled()) {
+                            return;
+                        }
                         user.getAsyncTeleport().nowUnsafe(spawn, TeleportCause.PLUGIN, future);
                     });
                 }
@@ -156,6 +162,11 @@ class EssentialsSpawnPlayerListener implements Listener {
                     logger.log(Level.WARNING, tl("teleportNewPlayerError"), e);
                     return false;
                 });
+                final UserTeleportSpawnEvent spawnEvent = new UserTeleportSpawnEvent(user, user.getGroup(), spawn);
+                ess.getServer().getPluginManager().callEvent(spawnEvent);
+                if (spawnEvent.isCancelled()) {
+                    return;
+                }
                 user.getAsyncTeleport().now(spawn, false, TeleportCause.PLUGIN, future);
             }
         }

--- a/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
+++ b/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
@@ -13,12 +13,14 @@ public class UserTeleportSpawnEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     private final IUser user;
+    private final IUser controller;
     private final String spawnGroup;
     private final Location target;
     private boolean cancelled = false;
 
-    public UserTeleportSpawnEvent(final IUser user, final String spawnGroup, final Location target) {
+    public UserTeleportSpawnEvent(final IUser user, final IUser controller, final String spawnGroup, final Location target) {
         this.user = user;
+        this.controller = controller;
         this.spawnGroup = spawnGroup;
         this.target = target;
     }
@@ -28,6 +30,13 @@ public class UserTeleportSpawnEvent extends Event implements Cancellable {
      */
     public IUser getUser() {
         return user;
+    }
+
+    /**
+     * @return The user who caused teleport to spawn or null if there is none
+     */
+    public IUser getController() {
+        return controller;
     }
 
     /**
@@ -55,7 +64,6 @@ public class UserTeleportSpawnEvent extends Event implements Cancellable {
     public void setCancelled(final boolean cancelled) {
         this.cancelled = cancelled;
     }
-
 
     @Override
     public HandlerList getHandlers() {

--- a/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
+++ b/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
@@ -24,9 +24,7 @@ public class UserTeleportSpawnEvent extends Event implements Cancellable {
     }
 
     /**
-     * Returns the user who is being teleported
-     *
-     * @return The teleportee.
+     * @return The user who is being teleported to spawn.
      */
     public IUser getUser() {
         return user;

--- a/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
+++ b/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
@@ -40,9 +40,8 @@ public class UserTeleportSpawnEvent extends Event implements Cancellable {
     }
 
     /**
-     * Returns the location the user is teleporting to.
-     *
-     * @return Teleportation destination location.
+     * The spawn location of the {@link #getUser() user's} {@link #getSpawnGroup() group}.
+     * @return The spawn location of the user's group.
      */
     public Location getSpawnLocation() {
         return target;

--- a/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
+++ b/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
@@ -7,7 +7,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 /**
- * Called when a user is teleported home via the /spawn command.
+ * Called before a user is teleported to spawn via the /spawn command.
  */
 public class UserTeleportSpawnEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();

--- a/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
+++ b/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
@@ -31,9 +31,8 @@ public class UserTeleportSpawnEvent extends Event implements Cancellable {
     }
 
     /**
-     * Return the group of spawn
-     *
-     * @return Name of group
+     * The {@link #getUser() user's} group used to determine their spawn location.
+     * @return The user's group.
      */
     public String getSpawnGroup() {
         return spawnGroup;

--- a/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
+++ b/EssentialsSpawn/src/main/java/net/essentialsx/api/v2/events/UserTeleportSpawnEvent.java
@@ -1,0 +1,72 @@
+package net.essentialsx.api.v2.events;
+
+import net.ess3.api.IUser;
+import org.bukkit.Location;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Called when a user is teleported home via the /spawn command.
+ */
+public class UserTeleportSpawnEvent extends Event implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final IUser user;
+    private final String spawnGroup;
+    private final Location target;
+    private boolean cancelled = false;
+
+    public UserTeleportSpawnEvent(final IUser user, final String spawnGroup, final Location target) {
+        this.user = user;
+        this.spawnGroup = spawnGroup;
+        this.target = target;
+    }
+
+    /**
+     * Returns the user who is being teleported
+     *
+     * @return The teleportee.
+     */
+    public IUser getUser() {
+        return user;
+    }
+
+    /**
+     * Return the group of spawn
+     *
+     * @return Name of group
+     */
+    public String getSpawnGroup() {
+        return spawnGroup;
+    }
+
+    /**
+     * Returns the location the user is teleporting to.
+     *
+     * @return Teleportation destination location.
+     */
+    public Location getSpawnLocation() {
+        return target;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(final boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
### Details ###
I propose to add an event for listening to the player's teleportation to the spawn, and include it in the new api v2

I've recently had a case myself where having this event would have been a lot easier than having to listen to the `PlayerCommandPreprocessEvent`.

**Proposed feature:**  
Event is called when the user teleports to the spawn using command

**Environments tested:**    

OS: Windows 10 x64

Java version: 16 x64

- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8
