### PR TITLE
Add role placeholder to Discord message format

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -347,7 +347,7 @@ public class DiscordSettings implements IConf {
                 "timestamp", "level", "message");
 
         discordToMcFormat = generateMessageFormat(getFormatString("discord-to-mc"), "&6[#{channel}] &3{fullname}&7: &f{message}", true,
-                "channel", "username", "discriminator", "fullname", "nickname", "color", "message");
+                "channel", "username", "discriminator", "fullname", "nickname", "color", "message", "role");
         unmuteFormat = generateMessageFormat(getFormatString("unmute"), "{displayname} unmuted.", false, "username", "displayname");
         tempMuteFormat = generateMessageFormat(getFormatString("temporary-mute"), "{controllerdisplayname} has muted player {displayname} for {time}.", false,
                 "username", "displayname", "controllername", "controllerdisplayname", "time");

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/DiscordListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/DiscordListener.java
@@ -86,7 +86,7 @@ public class DiscordListener extends ListenerAdapter {
 
         final String formattedMessage = EmojiParser.parseToAliases(MessageUtil.formatMessage(plugin.getPlugin().getSettings().getDiscordToMcFormat(),
                 event.getChannel().getName(), user.getName(), user.getDiscriminator(), user.getAsTag(),
-                member.getEffectiveName(), DiscordUtil.getRoleColorFormat(member), finalMessage), EmojiParser.FitzpatrickAction.REMOVE);
+                member.getEffectiveName(), DiscordUtil.getRoleColorFormat(member), finalMessage, DiscordUtil.getRoleFormat(member)), EmojiParser.FitzpatrickAction.REMOVE);
 
         for (IUser essUser : plugin.getPlugin().getEss().getOnlineUsers()) {
             for (String group : keys) {

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
@@ -122,6 +122,22 @@ public final class DiscordUtil {
     }
 
     /**
+     * Gets the highest role of a given member or an empty string if the member has no roles.
+     *
+     * @param member The target member.
+     * @return The highest role or blank string.
+     */
+    public static String getRoleFormat(Member member) {
+        final List<Role> roles = member.getRoles();
+
+        if (roles.isEmpty()) {
+            return "";
+        }
+
+        return roles.get(0).getName();
+    }
+
+    /**
      * Gets the uppermost bukkit color code of a given member or an empty string if the server version is &lt; 1.16.
      *
      * @param member The target member.

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -212,6 +212,7 @@ messages:
   # - {discriminator}: The four numbers displayed after the user's name
   # - {fullname}: Equivalent to typing "{username}#{discriminator}"
   # - {nickname}: The nickname of the user who sent the message. (Will return username if user has no nickname)
+  # - {role}: The name of the user's topmost role on Discord. If the user doesn't have a role, the placeholder is empty.
   # - {color}: The minecraft color representative of the user's topmost role color on discord. If the user doesn't have a role color, the placeholder is empty.
   # - {message}: The content of the message being sent
   discord-to-mc: "&6[#{channel}] &3{fullname}&7: &f{message}"


### PR DESCRIPTION
Just wanted to be able to show the Discord role in-game. Turns out JDA makes this implementation very easy as the roles for the member are always returned in order from highest -> lowest.