### PR TITLE
Add config option to change discord show-avatar url 

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -147,6 +147,10 @@ public class DiscordSettings implements IConf {
         return config.getBoolean("show-name", false);
     }
 
+    public String getAvatarURL() {
+        return config.getString("avatar-url", "https://crafthead.net/helm/{uuid}");
+    }
+
     // General command settings
 
     public boolean isCommandEnabled(String command) {

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -26,7 +26,6 @@ import java.text.MessageFormat;
 import java.util.UUID;
 
 public class BukkitListener implements Listener {
-    private final static String AVATAR_URL = "https://crafthead.net/helm/{uuid}";
     private final JDADiscordService jda;
 
     public BukkitListener(JDADiscordService jda) {
@@ -95,7 +94,7 @@ public class BukkitListener implements Listener {
                             MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(jda.getPlugin().getEss().getPermissionsHandler().getPrefix(player))),
                             MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(jda.getPlugin().getEss().getPermissionsHandler().getSuffix(player)))),
                     player.hasPermission("essentials.discord.ping"),
-                    jda.getSettings().isShowAvatar() ? AVATAR_URL.replace("{uuid}", player.getUniqueId().toString()) : null,
+                    jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()) : null,
                     jda.getSettings().isShowName() ? player.getName() : null,
                     player.getUniqueId());
         });
@@ -111,7 +110,7 @@ public class BukkitListener implements Listener {
                             MessageUtil.sanitizeDiscordMarkdown(event.getUser().getDisplayName()),
                             MessageUtil.sanitizeDiscordMarkdown(event.getJoinMessage())),
                     false,
-                    jda.getSettings().isShowAvatar() ? AVATAR_URL.replace("{uuid}", event.getUser().getBase().getUniqueId().toString()) : null,
+                    jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getUser().getBase().getUniqueId().toString()) : null,
                     jda.getSettings().isShowName() ? event.getUser().getName() : null,
                     event.getUser().getBase().getUniqueId());
         }
@@ -126,7 +125,7 @@ public class BukkitListener implements Listener {
                             MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getDisplayName()),
                             MessageUtil.sanitizeDiscordMarkdown(event.getQuitMessage())),
                     false,
-                    jda.getSettings().isShowAvatar() ? AVATAR_URL.replace("{uuid}", event.getPlayer().getUniqueId().toString()) : null,
+                    jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getPlayer().getUniqueId().toString()) : null,
                     jda.getSettings().isShowName() ? event.getPlayer().getName() : null,
                     event.getPlayer().getUniqueId());
         }
@@ -140,7 +139,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getEntity().getDisplayName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getDeathMessage())),
                 false,
-                jda.getSettings().isShowAvatar() ? AVATAR_URL.replace("{uuid}", event.getEntity().getUniqueId().toString()) : null,
+                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getEntity().getUniqueId().toString()) : null,
                 jda.getSettings().isShowName() ? event.getEntity().getName() : null,
                 event.getEntity().getUniqueId());
     }
@@ -159,7 +158,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getAffected().getName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getAffected().getDisplayName())),
                 false,
-                jda.getSettings().isShowAvatar() ? AVATAR_URL.replace("{uuid}", event.getAffected().getBase().getUniqueId().toString()) : null,
+                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getAffected().getBase().getUniqueId().toString()) : null,
                 jda.getSettings().isShowName() ? event.getAffected().getName() : null,
                 event.getAffected().getBase().getUniqueId());
     }

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -121,6 +121,8 @@ message-types:
 
 # Whether or not player messages should show their avatar as the profile picture in Discord.
 show-avatar: false
+# What api to use for the avatars in discord. Replace "{uuid}" with the uuid of the player.
+avatar-url: https://crafthead.net/helm/{uuid}
 # Whether or not player messages should show their name as the bot name in Discord.
 show-name: false
 

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -121,8 +121,10 @@ message-types:
 
 # Whether or not player messages should show their avatar as the profile picture in Discord.
 show-avatar: false
-# What api to use for the avatars in discord. Replace "{uuid}" with the uuid of the player.
-avatar-url: https://crafthead.net/helm/{uuid}
+# The URL which should be used to get the avatars of users when "show-avatar" is set to true.
+# Any URL in here should only return a proper JPEG/PNG image and nothing else.
+# To include the UUID of the player in this URL, use "{uuid}".
+avatar-url: "https://crafthead.net/helm/{uuid}"
 # Whether or not player messages should show their name as the bot name in Discord.
 show-name: false
 


### PR DESCRIPTION
### Details

This PR will allow for custom API URLs for the MC -> Discord avatar.

**Environments tested:**    

OS: Mac OS 11.3

Java version:  AdoptOpenJDK 16.0.1

- [x] Most recent Paper version (1.17.1, Paper-88)
- [ ] CraftBukkit 1.8.8 
- [ ] CraftBukkit/Spigot/Paper 1.12.2

**Demonstration:**  
Before:
<img width="254" alt="Screen Shot 2021-07-07 at 8 28 35 AM" src="https://user-images.githubusercontent.com/85046405/124787654-8090d680-defd-11eb-94d1-f0bcad8b2dd6.png">
After with a change to the config.yml:
<img width="216" alt="Screen Shot 2021-07-07 at 8 40 41 AM" src="https://user-images.githubusercontent.com/85046405/124789671-5b04cc80-deff-11eb-897e-f7abc9d9afee.png">