### PR TITLE
Prevent NPE in teleport command

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtp.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtp.java
@@ -25,7 +25,6 @@ public class Commandtp extends EssentialsCommand {
         switch (args.length) {
             case 0:
                 throw new NotEnoughArgumentsException();
-
             case 1:
                 final User player = getPlayer(server, user, args, 0, false, true);
 
@@ -33,8 +32,11 @@ public class Commandtp extends EssentialsCommand {
                     throw new Exception(tl("teleportDisabled", player.getDisplayName()));
                 }
 
-                if (!player.getBase().isOnline() && user.isAuthorized("essentials.tpoffline")) {
-                    throw new Exception(tl("teleportOffline", player.getDisplayName()));
+                if (!player.getBase().isOnline()) {
+                    if (user.isAuthorized("essentials.tpoffline")) {
+                        throw new Exception(tl("teleportOffline", player.getDisplayName()));
+                    }
+                    throw new PlayerNotFoundException();
                 }
 
                 if (user.getWorld() != player.getWorld() && ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + player.getWorld().getName())) {


### PR DESCRIPTION
### Information

This PR prevents an NPE from occurring in `/tp` when attempting to teleport to an offline player without the permission `essentials.tpoffline`.

Closes #4323.

### Details

**Environments tested:**    

OS: Windows 10 20H2
Java version: `openjdk 16.0.1 2021-04-20`

- [x] Most recent Paper version (git-Paper-90 (MC: 1.17.1))