### PR TITLE
Fix NPE in UserData#getLogoutLocation

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserData.java
@@ -277,7 +277,8 @@ public abstract class UserData extends PlayerExtension implements IConf {
     }
 
     public Location getLogoutLocation() {
-        return holder.logoutLocation().location();
+        final LazyLocation logoutLocation = holder.logoutLocation();
+        return logoutLocation != null ? logoutLocation.location() : null;
     }
 
     public void setLogoutLocation(final Location loc) {


### PR DESCRIPTION
Prevents an NPE where a player has joined the server before but doesn't have a recorded logout location.
