### PR TITLE
Strip formatting from webhook displaynames

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
@@ -190,7 +190,7 @@ public final class DiscordUtil {
             return;
         }
 
-        final DiscordMessageEvent event = new DiscordMessageEvent(messageType, FormatUtil.stripFormat(message), allowPing, avatarUrl, name, uuid);
+        final DiscordMessageEvent event = new DiscordMessageEvent(messageType, FormatUtil.stripFormat(message), allowPing, avatarUrl, FormatUtil.stripFormat(name), uuid);
 
         // If the server is stopping, we cannot dispatch events.
         if (messageType == MessageType.DefaultTypes.SERVER_STOP) {


### PR DESCRIPTION
### Information

This PR strips the format from webhook names to prevent color codes being displayed when using the `show-displayname` option.

Closes #4343.

### Details

**Environments tested:**    

OS: Windows 10 20H2
Java version: `openjdk 16.0.1 2021-04-20`

- [x] Most recent Paper version (git-Paper-99 (MC: 1.17.1))