### PR TITLE
Cache overridden-commands and player-commands in Settings

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -48,8 +48,8 @@ import static com.earth2me.essentials.I18n.tl;
 
 public class Settings implements net.ess3.api.ISettings {
     private static final Logger logger = Logger.getLogger("Essentials");
-    private static final BigDecimal MAXMONEY = new BigDecimal("10000000000000");
-    private static final BigDecimal MINMONEY = new BigDecimal("-10000000000000");
+    private static final BigDecimal DEFAULT_MAX_MONEY = new BigDecimal("10000000000000");
+    private static final BigDecimal DEFAULT_MIN_MONEY = new BigDecimal("-10000000000000");
     private final transient EssentialsConfiguration config;
     private final transient IEssentials ess;
     private final transient AtomicInteger reloadCount = new AtomicInteger(0);
@@ -62,6 +62,8 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean teleportSafety;
     private boolean forceDisableTeleportSafety;
     private Set<String> disabledCommands = new HashSet<>();
+    private List<String> overriddenCommands = Collections.emptyList();
+    private List<String> playerCommands = Collections.emptyList();
     private final transient Map<String, Command> disabledBukkitCommands = new HashMap<>();
     private Map<String, BigDecimal> commandCosts;
     private Set<String> socialSpyCommands = new HashSet<>();
@@ -76,8 +78,8 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean configDebug = false;
     // #easteregg
     private boolean economyDisabled = false;
-    private BigDecimal maxMoney = MAXMONEY;
-    private BigDecimal minMoney = MINMONEY;
+    private BigDecimal maxMoney = DEFAULT_MAX_MONEY;
+    private BigDecimal minMoney = DEFAULT_MIN_MONEY;
     private boolean economyLog = false;
     // #easteregg
     private boolean economyLogUpdate = false;
@@ -317,9 +319,13 @@ public class Settings implements net.ess3.api.ISettings {
         return disCommands;
     }
 
+    private List<String> _getPlayerCommands() {
+        return config.getList("player-commands", String.class);
+    }
+
     @Override
     public boolean isPlayerCommand(final String label) {
-        for (final String c : config.getList("player-commands", String.class)) {
+        for (final String c : playerCommands) {
             if (!c.equalsIgnoreCase(label)) {
                 continue;
             }
@@ -328,9 +334,13 @@ public class Settings implements net.ess3.api.ISettings {
         return false;
     }
 
+    private List<String> _getOverriddenCommands() {
+        return config.getList("overridden-commands", String.class);
+    }
+
     @Override
     public boolean isCommandOverridden(final String name) {
-        for (final String c : config.getList("overridden-commands", String.class)) {
+        for (final String c : overriddenCommands) {
             if (!c.equalsIgnoreCase(name)) {
                 continue;
             }
@@ -643,6 +653,8 @@ public class Settings implements net.ess3.api.ISettings {
         chatFormats.clear();
         changeDisplayName = _changeDisplayName();
         disabledCommands = _getDisabledCommands();
+        overriddenCommands = _getOverriddenCommands();
+        playerCommands = _getPlayerCommands();
 
         // This will be late loaded
         if (ess.getKnownCommandsProvider() != null) {
@@ -934,7 +946,7 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     private BigDecimal _getMaxMoney() {
-        return config.getBigDecimal("max-money", MAXMONEY);
+        return config.getBigDecimal("max-money", DEFAULT_MAX_MONEY);
     }
 
     @Override
@@ -943,7 +955,7 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     private BigDecimal _getMinMoney() {
-        BigDecimal min = config.getBigDecimal("min-money", MINMONEY);
+        BigDecimal min = config.getBigDecimal("min-money", DEFAULT_MIN_MONEY);
         if (min.signum() > 0) {
             min = min.negate();
         }


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes a regression introduced in #4072. Closes #4337. 

### Details

**Proposed fix:**    
This PR changes `Settings` to cache the `overridden-commands` and `player-commands` lists in `Settings`.

Since #4072, `EssentialsPlayerListener.CommandSendListener` has incurred a significant performance penalty, as the Configurate rewrite inadvertently removed caching of these two lists.


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: TODO

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: TODO

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Airplane 1.17.1, git-Airplane-45 (https://github.com/EssentialsX/Essentials/issues/4337#issuecomment-877799253)
- [ ] Paper 1.17.1, git-Paper-??? TODO
- [ ] CraftBukkit/Spigot/Paper 1.12.2 TODO
- [ ] ~~CraftBukkit 1.8.8~~ should be functionally identical to 1.12.2


**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

See comments on #4337 for more details.