### PR TITLE
Fix barrier considered as unsafe block to teleport

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
@@ -12,7 +12,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -31,8 +31,8 @@ public final class LocationUtil {
         "FLOWING_LAVA", "LAVA", "STATIONARY_LAVA");
     private static final Material PORTAL = EnumUtil.getMaterial("NETHER_PORTAL", "PORTAL");
     // The player can stand inside these materials
-    private static final Set<Material> HOLLOW_MATERIALS = new HashSet<>();
-    private static final Set<Material> TRANSPARENT_MATERIALS = new HashSet<>();
+    private static final Set<Material> HOLLOW_MATERIALS = EnumSet.noneOf(Material.class);
+    private static final Set<Material> TRANSPARENT_MATERIALS = EnumSet.noneOf(Material.class);
 
     static {
         // Materials from Material.isTransparent()
@@ -44,6 +44,9 @@ public final class LocationUtil {
 
         TRANSPARENT_MATERIALS.addAll(HOLLOW_MATERIALS);
         TRANSPARENT_MATERIALS.addAll(WATER_TYPES);
+
+        // Barrier is transparent, but solid
+        HOLLOW_MATERIALS.remove(Material.BARRIER);
     }
 
     static {


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR resolves #3851. 

### Details

**Proposed fix:**    
<!-- Type a description of your proposed fix below this line. -->
A simple removal of barrier block from `HOLLOW_MATERIALS`. As stated in the comments, customizable whitelist might be a better solution, but as for now, I don't think it's required now.
Although, `Material#isTransparent()` is deprecated - in the near future it might be required to create the set manually instead of depending on this method.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Linux Mint 20.2

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: openjdk 16.0.1 2021-04-20

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.17.1, git-Paper-100)
- [x] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8
