### PR TITLE
Add name parameter for Discord avatar URL

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -252,7 +252,7 @@ public class JDADiscordService implements DiscordService {
                 MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(getPlugin().getEss().getPermissionsHandler().getPrefix(player))),
                 MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(getPlugin().getEss().getPermissionsHandler().getSuffix(player))));
 
-        final String avatarUrl = getSettings().isShowAvatar() ? getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()).replace("{name}", player.getName()) : null;
+        final String avatarUrl = DiscordUtil.getAvatarUrl(this, player);
         final String name = getSettings().isShowName() ? player.getName() : (getSettings().isShowDisplayName() ? player.getDisplayName() : null);
 
         DiscordUtil.dispatchDiscordMessage(this, MessageType.DefaultTypes.CHAT, formattedMessage, user.isAuthorized("essentials.discord.ping"), avatarUrl, name, player.getUniqueId());

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -134,11 +134,8 @@ public class BukkitListener implements Listener {
                 MessageUtil.formatMessage(join ? jda.getSettings().getJoinFormat(player) : jda.getSettings().getQuitFormat(player),
                         MessageUtil.sanitizeDiscordMarkdown(player.getName()),
                         MessageUtil.sanitizeDiscordMarkdown(player.getDisplayName()),
-                        MessageUtil.sanitizeDiscordMarkdown(message),
-                        false,
-                        jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()).replace("{name}", player.getName()) : null,
-                        jda.getSettings().isShowName() ? player.getName() : (jda.getSettings().isShowDisplayName() ? player.getDisplayName() : null),
-                        player.getUniqueId()));
+                        MessageUtil.sanitizeDiscordMarkdown(message)),
+                        player);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -154,6 +151,7 @@ public class BukkitListener implements Listener {
             if (!event.getEntity().getWorld().isGameRule("showDeathMessages")) {
                 showDeathMessages = null;
             } else {
+                //noinspection deprecation
                 showDeathMessages = event.getEntity().getWorld().getGameRuleValue("showDeathMessages").equals("true");
             }
         }
@@ -166,10 +164,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getEntity().getName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getEntity().getDisplayName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getDeathMessage())),
-                false,
-                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getEntity().getUniqueId().toString()).replace("{name}", event.getEntity().getName()) : null,
-                jda.getSettings().isShowName() ? event.getEntity().getName() : (jda.getSettings().isShowDisplayName() ? event.getEntity().getDisplayName() : null),
-                event.getEntity().getUniqueId());
+                event.getEntity());
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -189,10 +184,7 @@ public class BukkitListener implements Listener {
                 MessageUtil.formatMessage(format,
                         MessageUtil.sanitizeDiscordMarkdown(event.getAffected().getName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getAffected().getDisplayName())),
-                false,
-                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getAffected().getBase().getUniqueId().toString()).replace("{name}", event.getAffected().getBase().getName()) : null,
-                jda.getSettings().isShowName() ? event.getAffected().getName() : (jda.getSettings().isShowDisplayName() ? event.getAffected().getDisplayName() : null),
-                event.getAffected().getBase().getUniqueId());
+                event.getAffected().getBase());
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -206,10 +198,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getDisplayName()),
                         event.getName()),
-                false,
-                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getPlayer().getUniqueId().toString()).replace("{name}", event.getPlayer().getName()) : null,
-                jda.getSettings().isShowName() ? event.getPlayer().getName() : (jda.getSettings().isShowDisplayName() ? event.getPlayer().getDisplayName() : null),
-                event.getPlayer().getUniqueId());
+                event.getPlayer());
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -233,10 +222,27 @@ public class BukkitListener implements Listener {
     }
 
     private void sendDiscordMessage(final MessageType messageType, final String message) {
-        sendDiscordMessage(messageType, message, false, null, null, null);
+        sendDiscordMessage(messageType, message, null);
     }
 
-    private void sendDiscordMessage(final MessageType messageType, final String message, final boolean allowPing, final String avatarUrl, final String name, final UUID uuid) {
-        DiscordUtil.dispatchDiscordMessage(jda, messageType, message, allowPing, avatarUrl, name, uuid);
+    private void sendDiscordMessage(final MessageType messageType, final String message, final Player player) {
+        String avatarUrl = null;
+        String name = null;
+        UUID uuid = null;
+        if (player != null) {
+            if (jda.getSettings().isShowAvatar()) {
+                avatarUrl = DiscordUtil.getAvatarUrl(jda, player);
+            }
+
+            if (jda.getSettings().isShowName()) {
+                name = player.getName();
+            } else if (jda.getSettings().isShowDisplayName()) {
+                name = player.getDisplayName();
+            }
+
+            uuid = player.getUniqueId();
+        }
+
+        DiscordUtil.dispatchDiscordMessage(jda, messageType, message, false, avatarUrl, name, uuid);
     }
 }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -100,7 +100,7 @@ public class BukkitListener implements Listener {
                             MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(jda.getPlugin().getEss().getPermissionsHandler().getPrefix(player))),
                             MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(jda.getPlugin().getEss().getPermissionsHandler().getSuffix(player)))),
                     player.hasPermission("essentials.discord.ping"),
-                    jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()) : null,
+                    jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()).replace("{name}", player.getName()) : null,
                     jda.getSettings().isShowName() ? player.getName() : (jda.getSettings().isShowDisplayName() ? player.getDisplayName() : null),
                     player.getUniqueId());
         });
@@ -148,7 +148,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(player.getDisplayName()),
                         MessageUtil.sanitizeDiscordMarkdown(message),
                         false,
-                        jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()) : null,
+                        jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()).replace("{name}", player.getName()) : null,
                         jda.getSettings().isShowName() ? player.getName() : (jda.getSettings().isShowDisplayName() ? player.getDisplayName() : null),
                         player.getUniqueId()));
     }
@@ -179,7 +179,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getEntity().getDisplayName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getDeathMessage())),
                 false,
-                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getEntity().getUniqueId().toString()) : null,
+                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getEntity().getUniqueId().toString()).replace("{name}", event.getEntity().getName()) : null,
                 jda.getSettings().isShowName() ? event.getEntity().getName() : (jda.getSettings().isShowDisplayName() ? event.getEntity().getDisplayName() : null),
                 event.getEntity().getUniqueId());
     }
@@ -202,7 +202,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getAffected().getName()),
                         MessageUtil.sanitizeDiscordMarkdown(event.getAffected().getDisplayName())),
                 false,
-                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getAffected().getBase().getUniqueId().toString()) : null,
+                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getAffected().getBase().getUniqueId().toString()).replace("{name}", event.getAffected().getBase().getName()) : null,
                 jda.getSettings().isShowName() ? event.getAffected().getName() : (jda.getSettings().isShowDisplayName() ? event.getAffected().getDisplayName() : null),
                 event.getAffected().getBase().getUniqueId());
     }
@@ -219,7 +219,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getDisplayName()),
                         event.getName()),
                 false,
-                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getPlayer().getUniqueId().toString()) : null,
+                jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", event.getPlayer().getUniqueId().toString()).replace("{name}", event.getPlayer().getName()) : null,
                 jda.getSettings().isShowName() ? event.getPlayer().getName() : (jda.getSettings().isShowDisplayName() ? event.getPlayer().getDisplayName() : null),
                 event.getPlayer().getUniqueId());
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
@@ -19,6 +19,7 @@ import net.essentialsx.api.v2.services.discord.MessageType;
 import net.essentialsx.discord.JDADiscordService;
 import okhttp3.OkHttpClient;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
 import java.util.List;
 import java.util.UUID;
@@ -192,6 +193,10 @@ public final class DiscordUtil {
             }
         }
         return false;
+    }
+
+    public static String getAvatarUrl(final JDADiscordService jda, final Player player) {
+        return jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()).replace("{name}", player.getName());
     }
 
     public static void dispatchDiscordMessage(final JDADiscordService jda, final MessageType messageType, final String message, final boolean allowPing, final String avatarUrl, final String name, final UUID uuid) {

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -131,6 +131,7 @@ show-avatar: false
 # The URL which should be used to get the avatars of users when "show-avatar" is set to true.
 # Any URL in here should only return a proper JPEG/PNG image and nothing else.
 # To include the UUID of the player in this URL, use "{uuid}".
+# To include the name of the player in this URL, use "{name}".
 avatar-url: "https://crafthead.net/helm/{uuid}"
 # Whether or not player messages should show their name as the bot name in Discord.
 show-name: false


### PR DESCRIPTION
allows offline mode/geyser users to configure their own avatar url based on names.