### PR TITLE
Add config option to disable verbose usage strings

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -770,7 +770,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 sender.sendMessage(tl("commandHelpLine1", commandLabel));
                 sender.sendMessage(tl("commandHelpLine2", command.getDescription()));
                 sender.sendMessage(tl("commandHelpLine3"));
-                if (!cmd.getUsageStrings().isEmpty()) {
+                if (getSettings().isVerboseCommandUsages() && !cmd.getUsageStrings().isEmpty()) {
                     for (Map.Entry<String, String> usage : cmd.getUsageStrings().entrySet()) {
                         sender.sendMessage(tl("commandHelpLineUsage", usage.getKey().replace("<command>", commandLabel), usage.getValue()));
                     }

--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -775,7 +775,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                         sender.sendMessage(tl("commandHelpLineUsage", usage.getKey().replace("<command>", commandLabel), usage.getValue()));
                     }
                 } else {
-                    sender.sendMessage(command.getUsage());
+                    sender.sendMessage(command.getUsage().replace("<command>", commandLabel));
                 }
                 if (!ex.getMessage().isEmpty()) {
                     sender.sendMessage(ex.getMessage());

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -126,6 +126,8 @@ public interface ISettings extends IConf {
 
     Set<String> getDisabledCommands();
 
+    boolean isVerboseCommandUsages();
+
     boolean isCommandOverridden(String name);
 
     boolean isDebug();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -289,6 +289,11 @@ public class Settings implements net.ess3.api.ISettings {
         return disabledCommands;
     }
 
+    @Override
+    public boolean isVerboseCommandUsages() {
+        return config.getBoolean("verbose-command-usages", true);
+    }
+
     private void _addAlternativeCommand(final String label, final Command current) {
         Command cmd = ess.getAlternativeCommandsHandler().getAlternative(label);
         if (cmd == null) {

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -170,6 +170,10 @@ disabled-commands:
 #  - nick
 #  - clear
 
+# Weather or not Essentials should show detailed command usages.
+# If set to false, Essentials will collapse all usages in to one single usage message.
+verbose-command-usages: true
+
 # These commands will be shown to players with socialSpy enabled.
 # You can add commands from other plugins you may want to track or
 # remove commands that are used for something you dont want to spy on.

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -170,7 +170,7 @@ disabled-commands:
 #  - nick
 #  - clear
 
-# Weather or not Essentials should show detailed command usages.
+# Whether or not Essentials should show detailed command usages.
 # If set to false, Essentials will collapse all usages in to one single usage message.
 verbose-command-usages: true
 


### PR DESCRIPTION
```yml
# Weather or not Essentials should show detailed command usages.
# If set to false, Essentials will collapse all usages in to one single usage message.
verbose-command-usages: true
```

This PR also fixes a regression in legacy usage strings where the `<command>` wasn't replaced.