### PR TITLE
Allow disabling MOTD task and cancel on player logout

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -368,12 +368,14 @@ public class EssentialsPlayerListener implements Listener, FakeAccessor {
 
                 ess.runTaskAsynchronously(() -> ess.getServer().getPluginManager().callEvent(new AsyncUserDataLoadEvent(user, effectiveMessage)));
 
-                final int motdDelay = ess.getSettings().getMotdDelay() / 50;
-                final DelayMotdTask motdTask = new DelayMotdTask(user);
-                if (motdDelay > 0) {
-                    pendingMotdTasks.put(user.getUUID(), ess.scheduleSyncDelayedTask(motdTask, motdDelay));
-                } else {
-                    motdTask.run();
+                if (ess.getSettings().getMotdDelay() < 0) {
+                    final int motdDelay = ess.getSettings().getMotdDelay() / 50;
+                    final DelayMotdTask motdTask = new DelayMotdTask(user);
+                    if (motdDelay > 0) {
+                        pendingMotdTasks.put(user.getUUID(), ess.scheduleSyncDelayedTask(motdTask, motdDelay));
+                    } else {
+                        motdTask.run();
+                    }
                 }
 
                 if (!ess.getSettings().isCommandDisabled("mail") && user.isAuthorized("essentials.mail")) {

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -669,6 +669,7 @@ allow-selling-named-items: false
 
 # Delay for the MOTD display for players on join, in milliseconds.
 # This has no effect if the MOTD command or permission are disabled.
+# This can also be set to -1 to completely disable the join MOTD all together.
 delay-motd: 0
 
 # A list of commands that should have their complementary confirm commands enabled by default.


### PR DESCRIPTION
This PR allows setting `delay-motd` to a negative value in `config.yml` to disable the MOTD join task without disabling `/motd`, and fixes an issue where delayed MOTD tasks would run even after a player logged out (in case someone previously set an insanely high MOTD delay to "disable" the MOTD on join).

Fixes #4408.