### PR TITLE
Fix NPE during reload with invalid discord bot tokens

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -140,6 +140,7 @@ public class JDADiscordService implements DiscordService {
 
         logger.log(Level.INFO, tl("discordLoggingIn"));
         if (plugin.getSettings().getBotToken().replace("INSERT-TOKEN-HERE", "").trim().isEmpty()) {
+            invalidStartup = true;
             throw new IllegalArgumentException(tl("discordErrorNoToken"));
         }
 


### PR DESCRIPTION
### Information

This PR prevents an NPE in `/ess reload` where the user attempts reloading while the Discord config is missing a bot token.

### Details

**Environments tested:**    

OS: Windows 10 20H2
Java version: `openjdk 16.0.1 2021-04-20`

- [x] Most recent Paper version (git-Paper-139 (MC: 1.17.1))
