### PR TITLE
Add config option to allow webhooks/bots to send commands

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -141,6 +141,10 @@ public class DiscordSettings implements IConf {
         return config.getBoolean("console.command-relay", false);
     }
 
+    public boolean isConsoleBotCommandRelay() {
+        return config.getBoolean("console.bot-command-relay", false);
+    }
+
     public Level getConsoleLogLevel() {
         return consoleLogLevel;
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/DiscordCommandDispatcher.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/DiscordCommandDispatcher.java
@@ -4,6 +4,7 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.essentialsx.discord.JDADiscordService;
 import net.essentialsx.discord.util.DiscordCommandSender;
+import net.essentialsx.discord.util.DiscordUtil;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,8 +18,11 @@ public class DiscordCommandDispatcher extends ListenerAdapter {
 
     @Override
     public void onGuildMessageReceived(@NotNull GuildMessageReceivedEvent event) {
-        if (jda.getConsoleWebhook() != null && event.getChannel().getId().equals(channelId)
-                && !event.isWebhookMessage() && !event.getAuthor().isBot()) {
+        if (jda.getConsoleWebhook() != null && event.getChannel().getId().equals(channelId)) {
+            if ((event.isWebhookMessage() || event.getAuthor().isBot()) && (!jda.getSettings().isConsoleBotCommandRelay() || DiscordUtil.ACTIVE_WEBHOOKS.contains(event.getAuthor().getId()))) {
+                return;
+            }
+
             Bukkit.getScheduler().runTask(jda.getPlugin(), () ->
                     Bukkit.dispatchCommand(new DiscordCommandSender(jda, Bukkit.getConsoleSender(), message ->
                             event.getMessage().reply(message).queue()).getSender(), event.getMessage().getContentRaw()));

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -86,6 +86,8 @@ console:
   # console. It's recommended you stick to the /execute command which has role permission checks (see command configuration below).
   # Note 2: This option requires a channel ID and is not supported if you specify a webhook URL above. You'll need to use /execute in Discord if you use a webhook URL.
   command-relay: false
+  # Set to true if bots/webhooks should be able to send commands through the command relay.
+  bot-command-relay: false
   # The maximum log level of messages to send to the console relay.
   # The following is a list of available log levels in order of lowest to highest.
   # Changing the log level will send all log levels above it to the console relay.


### PR DESCRIPTION
```yml
# Console relay settings
# The console relay sends every message shown in the console to a Discord channel.
console:
  ...
  # Set to true if bots/webhooks should be able to send commands through the command relay.
  bot-command-relay: false
```