### PR TITLE
Add DiscordService#sendChatMessage to send formatting config messages

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/events/discord/DiscordMessageEvent.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/events/discord/DiscordMessageEvent.java
@@ -25,7 +25,7 @@ public class DiscordMessageEvent extends Event implements Cancellable {
     /**
      * @param type               The message type/destination of this event.
      * @param message            The raw message content of this event.
-     * @param allowGroupMentions Whether or not the message should allow the pinging of roles, users, or emotes.
+     * @param allowGroupMentions Whether the message should allow the pinging of roles, @here, or @everyone.
      */
     public DiscordMessageEvent(final MessageType type, final String message, final boolean allowGroupMentions) {
         this(type, message, allowGroupMentions, null, null, null);
@@ -34,7 +34,7 @@ public class DiscordMessageEvent extends Event implements Cancellable {
     /**
      * @param type               The message type/destination of this event.
      * @param message            The raw message content of this event.
-     * @param allowGroupMentions Whether or not the message should allow the pinging of roles, users, or emotes.
+     * @param allowGroupMentions Whether the message should allow the pinging of roles, @here, or @everyone.
      * @param avatarUrl          The avatar URL to use for this message (if supported) or null to use the default bot avatar.
      * @param name               The name to use for this message (if supported) or null to use the default bot name.
      * @param uuid               The UUID of the player which caused this event or null if this wasn't a player triggered event.

--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/DiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/DiscordService.java
@@ -1,5 +1,7 @@
 package net.essentialsx.api.v2.services.discord;
 
+import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
 /**
@@ -13,6 +15,16 @@ public interface DiscordService {
      * @param allowGroupMentions Whether the message should allow the pinging of roles, @here, or @everyone.
      */
     void sendMessage(final MessageType type, final String message, final boolean allowGroupMentions);
+
+    /**
+     * Sends a chat messages to the {@link MessageType.DefaultTypes#CHAT default chat channel} with the same format
+     * used for regular chat messages specified in the EssentialsX Discord configuration.
+     * <p>
+     * Note: Messages sent with this method will not fire a {@link DiscordChatMessageEvent}.
+     * @param player      The player who send the message.
+     * @param chatMessage The chat message the player has sent.
+     */
+    void sendChatMessage(final Player player, final String chatMessage);
 
     /**
      * Checks if a {@link MessageType} by the given key is already registered.

--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/DiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/DiscordService.java
@@ -10,7 +10,7 @@ public interface DiscordService {
      * Sends a message to a message type channel.
      * @param type               The message type/destination of this message.
      * @param message            The exact message to be sent.
-     * @param allowGroupMentions Whether or not the message should allow the pinging of roles, users, or emotes.
+     * @param allowGroupMentions Whether the message should allow the pinging of roles, @here, or @everyone.
      */
     void sendMessage(final MessageType type, final String message, final boolean allowGroupMentions);
 

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -4,6 +4,7 @@ import club.minnced.discord.webhook.WebhookClient;
 import club.minnced.discord.webhook.WebhookClientBuilder;
 import club.minnced.discord.webhook.send.WebhookMessage;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
+import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.VersionUtil;
 import net.dv8tion.jda.api.JDA;
@@ -31,8 +32,10 @@ import net.essentialsx.discord.listeners.DiscordCommandDispatcher;
 import net.essentialsx.discord.listeners.DiscordListener;
 import net.essentialsx.discord.util.ConsoleInjector;
 import net.essentialsx.discord.util.DiscordUtil;
+import net.essentialsx.discord.util.MessageUtil;
 import org.apache.commons.lang.math.NumberUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.ServicePriority;
@@ -235,6 +238,24 @@ public class JDADiscordService implements DiscordService {
         } else {
             Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getPluginManager().callEvent(event));
         }
+    }
+
+    @Override
+    public void sendChatMessage(final Player player, final String chatMessage) {
+        final User user = getPlugin().getEss().getUser(player);
+
+        final String formattedMessage = MessageUtil.formatMessage(getSettings().getMcToDiscordFormat(player),
+                MessageUtil.sanitizeDiscordMarkdown(player.getName()),
+                MessageUtil.sanitizeDiscordMarkdown(player.getDisplayName()),
+                user.isAuthorized("essentials.discord.markdown") ? chatMessage : MessageUtil.sanitizeDiscordMarkdown(chatMessage),
+                MessageUtil.sanitizeDiscordMarkdown(player.getWorld().getName()),
+                MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(getPlugin().getEss().getPermissionsHandler().getPrefix(player))),
+                MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(getPlugin().getEss().getPermissionsHandler().getSuffix(player))));
+
+        final String avatarUrl = getSettings().isShowAvatar() ? getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()) : null;
+        final String name = getSettings().isShowName() ? player.getName() : (getSettings().isShowDisplayName() ? player.getDisplayName() : null);
+
+        DiscordUtil.dispatchDiscordMessage(this, MessageType.DefaultTypes.CHAT, formattedMessage, user.isAuthorized("essentials.discord.ping"), avatarUrl, name, player.getUniqueId());
     }
 
     @Override

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -2,7 +2,6 @@ package net.essentialsx.discord.listeners;
 
 import com.earth2me.essentials.Console;
 import com.earth2me.essentials.utils.DateUtil;
-import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.VersionUtil;
 import net.ess3.api.IUser;
 import net.ess3.api.events.AfkStatusChangeEvent;
@@ -91,18 +90,7 @@ public class BukkitListener implements Listener {
                 return;
             }
 
-            sendDiscordMessage(MessageType.DefaultTypes.CHAT,
-                    MessageUtil.formatMessage(jda.getSettings().getMcToDiscordFormat(player),
-                            MessageUtil.sanitizeDiscordMarkdown(player.getName()),
-                            MessageUtil.sanitizeDiscordMarkdown(player.getDisplayName()),
-                            player.hasPermission("essentials.discord.markdown") ? chatEvent.getMessage() : MessageUtil.sanitizeDiscordMarkdown(chatEvent.getMessage()),
-                            MessageUtil.sanitizeDiscordMarkdown(player.getWorld().getName()),
-                            MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(jda.getPlugin().getEss().getPermissionsHandler().getPrefix(player))),
-                            MessageUtil.sanitizeDiscordMarkdown(FormatUtil.stripEssentialsFormat(jda.getPlugin().getEss().getPermissionsHandler().getSuffix(player)))),
-                    player.hasPermission("essentials.discord.ping"),
-                    jda.getSettings().isShowAvatar() ? jda.getSettings().getAvatarURL().replace("{uuid}", player.getUniqueId().toString()) : null,
-                    jda.getSettings().isShowName() ? player.getName() : (jda.getSettings().isShowDisplayName() ? player.getDisplayName() : null),
-                    player.getUniqueId());
+            jda.sendChatMessage(player, chatEvent.getMessage());
         });
     }
 


### PR DESCRIPTION
Allows plugins to send messages to the chat channel via API using the format from our config