### PR TITLE
Fix economy usernames being unsanitized in some places

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserData.java
@@ -69,7 +69,7 @@ public abstract class UserData extends PlayerExtension implements IConf {
         if (config.getUsername() != null) {
             ess.getUserMap().removeUser(config.getUsername());
             if (isNPC()) {
-                final String uuid = UUID.nameUUIDFromBytes(("NPC:" + config.getUsername()).getBytes(Charsets.UTF_8)).toString();
+                final String uuid = UUID.nameUUIDFromBytes(("NPC:" + StringUtil.safeString(config.getUsername())).getBytes(Charsets.UTF_8)).toString();
                 ess.getUserMap().removeUserUUID(uuid);
             }
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
@@ -95,13 +95,13 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
     public User getUser(final String name) {
         final String sanitizedName = StringUtil.safeString(name);
         try {
-            ess.getLogger().warning("Looking up username " + name + "...");
+            ess.getLogger().warning("Looking up username " + name + " (" + sanitizedName + ") ...");
             if (names.containsKey(sanitizedName)) {
                 final UUID uuid = names.get(sanitizedName);
                 return getUser(uuid);
             }
 
-            ess.getLogger().warning(name + " has no known usermap entry");
+            ess.getLogger().warning(name + "(" + sanitizedName + ") has no known usermap entry");
 
             final File userFile = getUserFileFromString(sanitizedName);
             if (userFile.exists()) {

--- a/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
@@ -43,6 +43,7 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
     public UserMap(final IEssentials ess) {
         super();
         this.ess = ess;
+        ess.getLogger().info("Usermap debug logging build");
         uuidMap = new UUIDMap(ess);
         //RemovalListener<UUID, User> remListener = new UserMapRemovalListener();
         //users = CacheBuilder.newBuilder().maximumSize(ess.getSettings().getMaxUserCacheCount()).softValues().removalListener(remListener).build(this);
@@ -92,8 +93,8 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
     }
 
     public User getUser(final String name) {
+        final String sanitizedName = StringUtil.safeString(name);
         try {
-            final String sanitizedName = StringUtil.safeString(name);
             if (names.containsKey(sanitizedName)) {
                 final UUID uuid = names.get(sanitizedName);
                 return getUser(uuid);
@@ -108,6 +109,7 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
             }
             return null;
         } catch (final UncheckedExecutionException ex) {
+            ess.getLogger().log(Level.WARNING, ex, () -> String.format("Exception while getting user for %s (%s)", name, sanitizedName));
             return null;
         }
     }
@@ -120,6 +122,7 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
                 return legacyCacheGet(uuid);
             }
         } catch (final ExecutionException | UncheckedExecutionException ex) {
+            ess.getLogger().log(Level.WARNING, ex, () -> "Exception while getting user for " + uuid);
             return null;
         }
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
@@ -116,7 +116,9 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
             }
             return null;
         } catch (final UncheckedExecutionException ex) {
-            ess.getLogger().log(Level.WARNING, ex, () -> String.format("Exception while getting user for %s (%s)", name, sanitizedName));
+            if (ess.getSettings().isDebug()) {
+                ess.getLogger().log(Level.WARNING, ex, () -> String.format("Exception while getting user for %s (%s)", name, sanitizedName));
+            }
             return null;
         }
     }
@@ -129,7 +131,9 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
                 return legacyCacheGet(uuid);
             }
         } catch (final ExecutionException | UncheckedExecutionException ex) {
-            ess.getLogger().log(Level.WARNING, ex, () -> "Exception while getting user for " + uuid);
+            if (ess.getSettings().isDebug()) {
+                ess.getLogger().log(Level.WARNING, ex, () -> "Exception while getting user for " + uuid);
+            }
             return null;
         }
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
@@ -103,7 +103,9 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
                 return getUser(uuid);
             }
 
-            ess.getLogger().warning(name + "(" + sanitizedName + ") has no known usermap entry");
+            if (ess.getSettings().isDebug()) {
+                ess.getLogger().warning(name + "(" + sanitizedName + ") has no known usermap entry");
+            }
 
             final File userFile = getUserFileFromString(sanitizedName);
             if (userFile.exists()) {

--- a/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
@@ -43,7 +43,6 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
     public UserMap(final IEssentials ess) {
         super();
         this.ess = ess;
-        ess.getLogger().info("Usermap debug logging build");
         uuidMap = new UUIDMap(ess);
         //RemovalListener<UUID, User> remListener = new UserMapRemovalListener();
         //users = CacheBuilder.newBuilder().maximumSize(ess.getSettings().getMaxUserCacheCount()).softValues().removalListener(remListener).build(this);
@@ -95,7 +94,10 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
     public User getUser(final String name) {
         final String sanitizedName = StringUtil.safeString(name);
         try {
-            ess.getLogger().warning("Looking up username " + name + " (" + sanitizedName + ") ...");
+            if (ess.getSettings().isDebug()) {
+                ess.getLogger().warning("Looking up username " + name + " (" + sanitizedName + ") ...");
+            }
+
             if (names.containsKey(sanitizedName)) {
                 final UUID uuid = names.get(sanitizedName);
                 return getUser(uuid);
@@ -125,16 +127,6 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
                 return legacyCacheGet(uuid);
             }
         } catch (final ExecutionException | UncheckedExecutionException ex) {
-            if (uuid.version() == 2) { // Citizens
-                return null;
-            }
-
-            for (StackTraceElement element : ex.getStackTrace()) {
-                if (element.getClassName().contains("extendedclip")) { // PAPI
-                    return null;
-                }
-            }
-
             ess.getLogger().log(Level.WARNING, ex, () -> "Exception while getting user for " + uuid);
             return null;
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
@@ -95,10 +95,13 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
     public User getUser(final String name) {
         final String sanitizedName = StringUtil.safeString(name);
         try {
+            ess.getLogger().warning("Looking up username " + name + "...");
             if (names.containsKey(sanitizedName)) {
                 final UUID uuid = names.get(sanitizedName);
                 return getUser(uuid);
             }
+
+            ess.getLogger().warning(name + " has no known usermap entry");
 
             final File userFile = getUserFileFromString(sanitizedName);
             if (userFile.exists()) {

--- a/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserMap.java
@@ -122,6 +122,16 @@ public class UserMap extends CacheLoader<String, User> implements IConf {
                 return legacyCacheGet(uuid);
             }
         } catch (final ExecutionException | UncheckedExecutionException ex) {
+            if (uuid.version() == 2) { // Citizens
+                return null;
+            }
+
+            for (StackTraceElement element : ex.getStackTrace()) {
+                if (element.getClassName().contains("extendedclip")) { // PAPI
+                    return null;
+                }
+            }
+
             ess.getLogger().log(Level.WARNING, ex, () -> "Exception while getting user for " + uuid);
             return null;
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java
@@ -60,7 +60,7 @@ public class Economy {
         final EssentialsUserConfiguration npcConfig = new EssentialsUserConfiguration(name, npcUUID, npcFile);
         npcConfig.load();
         npcConfig.setProperty("npc", true);
-        npcConfig.setProperty("lastAccountName", name);
+        npcConfig.setProperty("last-account-name", name);
         npcConfig.setProperty("money", ess.getSettings().getStartingBalance());
         npcConfig.blockingSave();
         ess.getUserMap().trackUUID(npcUUID, name, false);

--- a/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java
@@ -52,7 +52,7 @@ public class Economy {
             }
         }
         final UUID npcUUID = UUID.nameUUIDFromBytes(("NPC:" + name).getBytes(Charsets.UTF_8));
-        final File npcFile = new File(folder, npcUUID.toString() + ".yml");
+        final File npcFile = new File(folder, npcUUID + ".yml");
         if (npcFile.exists()) {
             LOGGER.log(Level.SEVERE, MessageFormat.format(WARN_NPC_RECREATE_1, name, npcUUID.toString()), new RuntimeException());
             LOGGER.log(Level.SEVERE, WARN_NPC_RECREATE_2);
@@ -96,7 +96,7 @@ public class Economy {
         }
 
         if (user == null) {
-            user = getUserByUUID(UUID.nameUUIDFromBytes(("NPC:" + name).getBytes(Charsets.UTF_8)));
+            user = getUserByUUID(UUID.nameUUIDFromBytes(("NPC:" + StringUtil.safeString(name)).getBytes(Charsets.UTF_8)));
         }
 
         return user;

--- a/Essentials/src/main/java/com/earth2me/essentials/config/EssentialsUserConfiguration.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/config/EssentialsUserConfiguration.java
@@ -46,7 +46,7 @@ public class EssentialsUserConfiguration extends EssentialsConfiguration {
             LOGGER.log(Level.WARNING, "Failed to migrate user: " + username, ex);
         }
 
-        setProperty("lastAccountName", username);
+        setProperty("last-account-name", username);
     }
 
     private File getAltFile() {

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/vault/VaultEconomyProvider.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/vault/VaultEconomyProvider.java
@@ -5,6 +5,7 @@ import com.earth2me.essentials.api.NoLoanPermittedException;
 import com.earth2me.essentials.api.UserDoesNotExistException;
 import com.earth2me.essentials.config.EssentialsUserConfiguration;
 import com.earth2me.essentials.utils.NumberUtil;
+import com.earth2me.essentials.utils.StringUtil;
 import com.google.common.base.Charsets;
 import net.ess3.api.MaxMoneyException;
 import net.milkbowl.vault.economy.Economy;
@@ -80,7 +81,7 @@ public class VaultEconomyProvider implements Economy {
             return true;
         }
         // We may not have the player name in the usermap, let's double check an NPC account with this name doesn't exist.
-        return com.earth2me.essentials.api.Economy.playerExists(UUID.nameUUIDFromBytes(("NPC:" + playerName).getBytes(Charsets.UTF_8)));
+        return com.earth2me.essentials.api.Economy.playerExists(UUID.nameUUIDFromBytes(("NPC:" + StringUtil.safeString(playerName)).getBytes(Charsets.UTF_8)));
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/vault/VaultEconomyProvider.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/vault/VaultEconomyProvider.java
@@ -307,7 +307,7 @@ public class VaultEconomyProvider implements Economy {
             final EssentialsUserConfiguration npcConfig = new EssentialsUserConfiguration(player.getName(), player.getUniqueId(), npcFile);
             npcConfig.load();
             npcConfig.setProperty("npc", true);
-            npcConfig.setProperty("lastAccountName", player.getName());
+            npcConfig.setProperty("last-account-name", player.getName());
             npcConfig.setProperty("money", ess.getSettings().getStartingBalance());
             npcConfig.blockingSave();
             ess.getUserMap().trackUUID(player.getUniqueId(), player.getName(), false);

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "net.essentialsx"
-version = "2.19.0-SNAPSHOT"
+version = "2.19.0-debug-SNAPSHOT"
 
 project.ext {
     GIT_COMMIT = !indraGit.isPresent() ? "unknown" : indraGit.commit().abbreviate(7).name()

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "net.essentialsx"
-version = "2.19.0-debug-SNAPSHOT"
+version = "2.19.0-SNAPSHOT"
 
 project.ext {
     GIT_COMMIT = !indraGit.isPresent() ? "unknown" : indraGit.commit().abbreviate(7).name()


### PR DESCRIPTION
Pretty sure this caused the last of our economy woes.

**PEOPLE WHO GET THOSE "FOUND NEW UUID BUT NOT REPLACING ERRORS" NEED TO DELETE THE FILE IN USERDATA ASSOCIATED WITH THE FIRST UUID IN THAT MESSAGE. THOSE WERE GENERATED NPC ACCOUNTS FROM THE LEGACY SYSTEM AND GET LOADED INTO THE USERMAP WHEN WE DO getUniqueUsers IF THEY HAVE ONLY `npc:true` AND `money: 0` AND A `last-account-name` YOU CAN SAFELY DELETE THEM WHEN THE SERVER STOPS AND THE WARNING WILL GO AWAY.**

ignore that ^ lol because #4490 is a thing

also adds some more logging for debug mode
