### PR TITLE
Allow auto equip in nbt serialized kits

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Kit.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Kit.java
@@ -188,31 +188,33 @@ public class Kit {
                     continue;
                 }
 
+                final ItemStack stack;
+
                 if (kitItem.startsWith("@")) {
                     if (ess.getSerializationProvider() == null) {
-                        ess.getLogger().log(Level.WARNING, tl("kitError3", kitName, user.getName()));
+                        ess.getLogger().log(Level.WARNING, () -> tl("kitError3", kitName, user.getName()));
                         continue;
                     }
-                    itemList.add(ess.getSerializationProvider().deserializeItem(Base64Coder.decodeLines(kitItem.substring(1))));
-                    continue;
-                }
+                    stack = ess.getSerializationProvider().deserializeItem(Base64Coder.decodeLines(kitItem.substring(1)));
+                } else {
+                    final String[] parts = kitItem.split(" +");
+                    final ItemStack parseStack = ess.getItemDb().get(parts[0], parts.length > 1 ? Integer.parseInt(parts[1]) : 1);
 
-                final String[] parts = kitItem.split(" +");
-                final ItemStack parseStack = ess.getItemDb().get(parts[0], parts.length > 1 ? Integer.parseInt(parts[1]) : 1);
+                    if (parseStack.getType() == Material.AIR) {
+                        continue;
+                    }
 
-                if (parseStack.getType() == Material.AIR) {
-                    continue;
-                }
+                    final MetaItemStack metaStack = new MetaItemStack(parseStack);
 
-                final MetaItemStack metaStack = new MetaItemStack(parseStack);
+                    if (parts.length > 2) {
+                        // We pass a null sender here because kits should not do perm checks
+                        metaStack.parseStringMeta(null, allowUnsafe, parts, 2, ess);
+                    }
 
-                if (parts.length > 2) {
-                    // We pass a null sender here because kits should not do perm checks
-                    metaStack.parseStringMeta(null, allowUnsafe, parts, 2, ess);
+                    stack = metaStack.getItemStack();
                 }
 
                 if (autoEquip) {
-                    final ItemStack stack = metaStack.getItemStack();
                     final Material material = stack.getType();
                     final PlayerInventory inventory = user.getBase().getInventory();
                     if (MaterialUtil.isHelmet(material) && isEmptyStack(inventory.getHelmet())) {
@@ -230,7 +232,7 @@ public class Kit {
                     }
                 }
 
-                itemList.add(metaStack.getItemStack());
+                itemList.add(stack);
             }
 
             final Map<Integer, ItemStack> overfilled;

--- a/Essentials/src/main/java/com/earth2me/essentials/Kit.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Kit.java
@@ -192,7 +192,7 @@ public class Kit {
 
                 if (kitItem.startsWith("@")) {
                     if (ess.getSerializationProvider() == null) {
-                        ess.getLogger().log(Level.WARNING, () -> tl("kitError3", kitName, user.getName()));
+                        ess.getLogger().log(Level.WARNING, tl("kitError3", kitName, user.getName()));
                         continue;
                     }
                     stack = ess.getSerializationProvider().deserializeItem(Base64Coder.decodeLines(kitItem.substring(1)));


### PR DESCRIPTION
This is a simple fix to make sure nbt serialized items in kits follow through with any additional logic (notably auto equip) instead of returning early (which is done with money and commands, but shouldn't for items).

Bug reported and discovered on Discord by shackhurst, Evident, and @triagonal: https://discord.com/channels/390942438061113344/426460575971672064/881012312549502997