### PR TITLE
Add action message type

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandme.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandme.java
@@ -4,6 +4,7 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.FormatUtil;
+import net.essentialsx.api.v2.events.UserActionEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
@@ -44,6 +45,7 @@ public class Commandme extends EssentialsCommand {
         final String toSend = tl("action", user.getDisplayName(), message);
         if (radius < 1) {
             ess.broadcastMessage(user, toSend);
+            ess.getServer().getPluginManager().callEvent(new UserActionEvent(user, message, Collections.unmodifiableCollection(ess.getServer().getOnlinePlayers())));
             return;
         }
         radius *= radius;
@@ -86,6 +88,7 @@ public class Commandme extends EssentialsCommand {
         for (final Player onlinePlayer : outList) {
             onlinePlayer.sendMessage(toSend);
         }
+        ess.getServer().getPluginManager().callEvent(new UserActionEvent(user, message, Collections.unmodifiableCollection(outList)));
     }
 
     @Override

--- a/Essentials/src/main/java/net/essentialsx/api/v2/events/UserActionEvent.java
+++ b/Essentials/src/main/java/net/essentialsx/api/v2/events/UserActionEvent.java
@@ -8,7 +8,7 @@ import org.bukkit.event.HandlerList;
 import java.util.Collection;
 
 /**
- * Called when a user run's the /me command.
+ * Called when a user runs the /me command.
  */
 public class UserActionEvent extends Event {
     private static final HandlerList handlers = new HandlerList();

--- a/Essentials/src/main/java/net/essentialsx/api/v2/events/UserActionEvent.java
+++ b/Essentials/src/main/java/net/essentialsx/api/v2/events/UserActionEvent.java
@@ -1,0 +1,46 @@
+package net.essentialsx.api.v2.events;
+
+import net.ess3.api.IUser;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.Collection;
+
+/**
+ * Called when a user run's the /me command.
+ */
+public class UserActionEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final IUser user;
+    private final String message;
+    private final Collection<Player> recipients;
+
+    public UserActionEvent(IUser user, String message, Collection<Player> recipients) {
+        this.user = user;
+        this.message = message;
+        this.recipients = recipients;
+    }
+
+    public IUser getUser() {
+        return user;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Collection<Player> getRecipients() {
+        return recipients;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
@@ -59,11 +59,12 @@ public final class MessageType {
         public final static MessageType DEATH = new MessageType("death", true);
         public final static MessageType AFK = new MessageType("afk", true);
         public final static MessageType ADVANCEMENT = new MessageType("advancement", true);
+        public final static MessageType ACTION = new MessageType("action", true);
         public final static MessageType SERVER_START = new MessageType("server-start", false);
         public final static MessageType SERVER_STOP = new MessageType("server-stop", false);
         public final static MessageType KICK = new MessageType("kick", false);
         public final static MessageType MUTE = new MessageType("mute", false);
-        private final static MessageType[] VALUES = new MessageType[]{JOIN, LEAVE, CHAT, DEATH, AFK, ADVANCEMENT, SERVER_START, SERVER_STOP, KICK, MUTE};
+        private final static MessageType[] VALUES = new MessageType[]{JOIN, LEAVE, CHAT, DEATH, AFK, ADVANCEMENT, ACTION, SERVER_START, SERVER_STOP, KICK, MUTE};
 
         /**
          * Gets an array of all the default {@link MessageType MessageTypes}.

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -301,6 +301,18 @@ public class DiscordSettings implements IConf {
                 "username", "displayname", "advancement");
     }
 
+    public MessageFormat getActionFormat(Player player) {
+        final String format = getFormatString("action");
+        final String filled;
+        if (plugin.isPAPI() && format != null) {
+            filled = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, format);
+        } else {
+            filled = format;
+        }
+        return generateMessageFormat(filled, ":person_biking: {displayname} *{action}*", false,
+                "username", "displayname", "action");
+    }
+
     public String getStartMessage() {
         return config.getString("messages.server-start", ":white_check_mark: The server has started!");
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -9,6 +9,7 @@ import net.ess3.api.events.MuteStatusChangeEvent;
 import net.ess3.api.events.VanishStatusChangeEvent;
 import net.ess3.provider.AbstractAchievementEvent;
 import net.essentialsx.api.v2.events.AsyncUserDataLoadEvent;
+import net.essentialsx.api.v2.events.UserActionEvent;
 import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
 import net.essentialsx.api.v2.events.discord.DiscordMessageEvent;
 import net.essentialsx.api.v2.services.discord.MessageType;
@@ -201,6 +202,20 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(event.getPlayer().getDisplayName()),
                         event.getName()),
                 event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onAction(UserActionEvent event) {
+        if (isVanishHide(event.getUser())) {
+            return;
+        }
+
+        sendDiscordMessage(MessageType.DefaultTypes.ACTION,
+                MessageUtil.formatMessage(jda.getSettings().getActionFormat(event.getUser().getBase()),
+                        MessageUtil.sanitizeDiscordMarkdown(event.getUser().getName()),
+                        MessageUtil.sanitizeDiscordMarkdown(event.getUser().getDisplayName()),
+                        event.getMessage()),
+                event.getUser().getBase());
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -119,6 +119,8 @@ message-types:
   afk: primary
   # Achievement/advancement messages sent when a player is awarded an achievement/advancement.
   advancement: primary
+  # Action messages sent when a player runs the /me or /action commands.
+  action: primary
   # Message sent when the server starts up.
   server-start: primary
   # Message sent when the server shuts down.
@@ -332,6 +334,13 @@ messages:
   # - {advancement}: The name of the advancement.
   # ... PlaceholderAPI placeholders are also supported here too!
   advancement: ":medal: {displayname} has completed the advancement **{advancement}**!"
+  # This is the message sent to Discord when a player runs the /me or /action command.
+  # The following placeholders can be used here:
+  # - {username}: The name of the user who ran the command
+  # - {displayname}: The display name of the user who ran the command
+  # - {action}: The action (message) the user used in the command.
+  # ... PlaceholderAPI placeholders are also supported here too!
+  action: ":person_biking: {displayname} *{action}*"
   # This is the message sent to Discord when the server starts.
   server-start: ":white_check_mark: The server has started!"
   # This is the message sent to Discord when the server stops.


### PR DESCRIPTION
Adds a message type which will show when a player runs the /action (/me) command.

Message Type:
```yml
# Configure which Discord channels different messages will be sent to.
# You can either use the names of the channels listed above or just the id of a channel.
# If an invalid channel is used, the primary channel will be used instead.
#
# To disable a message from showing, use 'none' as the channel name.
message-types:
  ...
  # Action messages sent when a player runs the /me or /action commands.
  action: primary
```

Message Format:
```yml
# The following entries allow you to customize the formatting of messages sent by the plugin.
# Each message has a description of how it is used along with placeholders that can be used.
messages:
  ...
  # This is the message sent to Discord when a player runs the /me or /action command.
  # The following placeholders can be used here:
  # - {username}: The name of the user who ran the command
  # - {displayname}: The display name of the user who ran the command
  # - {action}: The action (message) the user used in the command.
  # ... PlaceholderAPI placeholders are also supported here too!
  action: ":person_biking: {displayname} *{action}*"
```