### PR TITLE
Add essentials.seen.uuid permission to show uuids in seen

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandseen.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandseen.java
@@ -102,7 +102,9 @@ public class Commandseen extends EssentialsCommand {
 
         user.setDisplayNick();
         sender.sendMessage(tl("seenOnline", user.getDisplayName(), DateUtil.formatDateDiff(user.getLastLogin())));
-        sender.sendMessage(tl("whoisUuid", user.getBase().getUniqueId().toString()));
+        if (sender.isAuthorized("essentials.seen.uuid", ess)) {
+            sender.sendMessage(tl("whoisUuid", user.getBase().getUniqueId().toString()));
+        }
 
         final List<String> history = ess.getUserMap().getUserHistory(user.getBase().getUniqueId());
         if (history != null && history.size() > 1) {
@@ -136,7 +138,9 @@ public class Commandseen extends EssentialsCommand {
         user.setDisplayNick();
         if (user.getLastLogout() > 0) {
             sender.sendMessage(tl("seenOffline", user.getName(), DateUtil.formatDateDiff(user.getLastLogout())));
-            sender.sendMessage(tl("whoisUuid", user.getBase().getUniqueId()));
+            if (sender.isAuthorized("essentials.seen.uuid", ess)) {
+                sender.sendMessage(tl("whoisUuid", user.getBase().getUniqueId()));
+            }
         } else {
             sender.sendMessage(tl("userUnknown", user.getName()));
         }

--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -625,6 +625,7 @@ permissions:
     children:
       essentials.seen.ip: true
       essentials.seen.location: true
+      essentials.seen.uuid: true
   essentials.keepinv:
     default: false
     description: Controls whether players keep their inventory on death.


### PR DESCRIPTION
Adds `essentials.seen.uuid` permission requirement to show uuids in `/seen`. People were complaining this cluttered it so whatever. Also adds said permission to the `essentials.seen.extra` permission group.

Closes #4499