### PR TITLE
Add Reserve support to latest base.

### DIFF
--- a/Essentials/build.gradle
+++ b/Essentials/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     }
     compileOnly 'net.luckperms:api:5.0'
 
-    compileOnly 'net.tnemc:Reserve:0.1.5.2'
+    compileOnly 'net.tnemc:Reserve:0.1.5.4'
 
     api 'io.papermc:paperlib:1.0.6'
 

--- a/Essentials/build.gradle
+++ b/Essentials/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     }
     compileOnly 'net.luckperms:api:5.0'
 
+    compileOnly 'net.tnemc:Reserve:0.1.5.2'
+
     api 'io.papermc:paperlib:1.0.6'
 
     api 'org.bstats:bstats-bukkit:2.2.1'

--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -24,6 +24,7 @@ import com.earth2me.essentials.commands.NotEnoughArgumentsException;
 import com.earth2me.essentials.commands.PlayerNotFoundException;
 import com.earth2me.essentials.commands.QuietAbortException;
 import com.earth2me.essentials.economy.EconomyLayers;
+import com.earth2me.essentials.economy.reserve.ReserveEconomyProvider;
 import com.earth2me.essentials.economy.vault.VaultEconomyProvider;
 import com.earth2me.essentials.items.AbstractItemDb;
 import com.earth2me.essentials.items.CustomItemResolver;
@@ -271,6 +272,10 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 if (plugin.getDescription().getName().startsWith("Essentials") && !plugin.getDescription().getVersion().equals(this.getDescription().getVersion()) && !plugin.getDescription().getName().equals("EssentialsAntiCheat")) {
                     getLogger().warning(tl("versionMismatch", plugin.getDescription().getName()));
                 }
+            }
+
+            if (pm.isPluginEnabled("Reserve")) {
+                ReserveEconomyProvider.register(this);
             }
 
             final EssentialsUpgrade upgrade = new EssentialsUpgrade(this);

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -54,6 +54,10 @@ public interface ISettings extends IConf {
 
     boolean isCurrencySymbolSuffixed();
 
+    String getCurrencySingular();
+
+    String getCurrencyPlural();
+
     int getOversizedStackSize();
 
     int getDefaultStackSize();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -891,6 +891,16 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getBoolean("currency-symbol-suffix", false);
     }
 
+    @Override
+    public String getCurrencySingular() {
+        return config.getString("currency-singular", "Dollar");
+    }
+
+    @Override
+    public String getCurrencyPlural() {
+        return config.getString("currency-plural", "Dollars");
+    }
+
     // #easteregg
     @Override
     @Deprecated

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/EconomyLayers.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/EconomyLayers.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.economy;
 
 import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.economy.layers.ReserveLayer;
 import com.earth2me.essentials.economy.layers.VaultLayer;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
@@ -28,6 +29,7 @@ public final class EconomyLayers {
             throw new IllegalStateException("Economy layers have already been registered!");
         }
 
+        registerLayer(new ReserveLayer());
         registerLayer(new VaultLayer());
     }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/layers/ReserveLayer.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/layers/ReserveLayer.java
@@ -1,0 +1,79 @@
+package com.earth2me.essentials.economy.layers;
+
+import com.earth2me.essentials.economy.EconomyLayer;
+import net.tnemc.core.Reserve;
+import net.tnemc.core.economy.EconomyAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.Plugin;
+
+import java.math.BigDecimal;
+
+public class ReserveLayer implements EconomyLayer {
+    private Plugin plugin;
+    private EconomyAPI adapter;
+
+    @Override
+    public boolean hasAccount(OfflinePlayer player) {
+        return adapter.hasAccount(player.getUniqueId());
+    }
+
+    @Override
+    public boolean createPlayerAccount(OfflinePlayer player) {
+        return adapter.createAccount(player.getUniqueId());
+    }
+
+    @Override
+    public BigDecimal getBalance(OfflinePlayer player) {
+        return adapter.getHoldings(player.getUniqueId());
+    }
+
+    @Override
+    public boolean deposit(OfflinePlayer player, BigDecimal amount) {
+        return adapter.addHoldings(player.getUniqueId(), amount);
+    }
+
+    @Override
+    public boolean withdraw(OfflinePlayer player, BigDecimal amount) {
+        return adapter.removeHoldings(player.getUniqueId(), amount);
+    }
+
+    @Override
+    public String getName() {
+        return "Reserve Compatibility Layer";
+    }
+
+    @Override
+    public String getBackendName() {
+        return adapter.name();
+    }
+
+    @Override
+    public void enable(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onServerLoad() {
+        if(Bukkit.getPluginManager().isPluginEnabled("Reserve")) {
+            this.adapter = Reserve.instance().economy();
+        }
+        return adapter != null && !adapter.name().equals("EssentialsX");
+    }
+
+    @Override
+    public void disable() {
+        this.plugin = null;
+        this.adapter = null;
+    }
+
+    @Override
+    public String getPluginName() {
+        return "Reserve";
+    }
+
+    @Override
+    public String getPluginVersion() {
+        return plugin == null ? null : plugin.getDescription().getVersion();
+    }
+}

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/reserve/ReserveEconomyProvider.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/reserve/ReserveEconomyProvider.java
@@ -1,0 +1,971 @@
+package com.earth2me.essentials.economy.reserve;
+
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
+import com.earth2me.essentials.api.Economy;
+import com.earth2me.essentials.api.NoLoanPermittedException;
+import com.earth2me.essentials.api.UserDoesNotExistException;
+import net.ess3.api.MaxMoneyException;
+import net.tnemc.core.Reserve;
+import net.tnemc.core.economy.EconomyAPI;
+import net.tnemc.core.economy.currency.Currency;
+import net.tnemc.core.economy.response.AccountResponse;
+import net.tnemc.core.economy.response.EconomyResponse;
+import net.tnemc.core.economy.response.GeneralResponse;
+import net.tnemc.core.economy.response.HoldingsResponse;
+import org.bukkit.World;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public class ReserveEconomyProvider implements EconomyAPI {
+
+    private final Essentials ess;
+
+    public ReserveEconomyProvider(Essentials plugin) {
+        this.ess = plugin;
+    }
+
+    public static void register(Essentials plugin) {
+        Reserve.instance().registerProvider(new ReserveEconomyProvider(plugin));
+    }
+
+    /**
+     * @return The name of the Economy implementation.
+     */
+    @Override
+    public String name() {
+        return "EssentialsX";
+    }
+
+    /**
+     * @return The version of Reserve the Economy implementation supports.
+     */
+    @Override
+    public String version() {
+        return "0.1.4.6";
+    }
+
+    //This is our method to convert UUID -> username for use with Essentials' create account methods.
+    private User getUser(String identifier) throws UserDoesNotExistException {
+        final User user = ess.getUser(identifier);
+
+        if(user == null) {
+            throw new UserDoesNotExistException(identifier);
+        }
+        return user;
+    }
+
+    /**
+     * @return Whether or not this implementation is enabled.
+     */
+    @Override
+    public boolean enabled() {
+        return true;
+    }
+
+    /**
+     * @return True if this implementation should override other economy implementations.
+     */
+    @Override
+    public boolean force() {
+        return false;
+    }
+
+    /**
+     * @return Whether or not this implementation should have a default Vault implementation.
+     */
+    @Override
+    public boolean vault() {
+        return false;
+    }
+
+    /**
+     * Used to get the plural name of the default currency.
+     * @return The plural name of the default currency.
+     */
+    @Override
+    public String currencyDefaultPlural() {
+        return ess.getSettings().getCurrencyPlural();
+    }
+
+    /**
+     * Used to get the singular name of the default currency.
+     * @return The plural name of the default currency.
+     */
+    @Override
+    public String currencyDefaultSingular() {
+        return ess.getSettings().getCurrencySingular();
+    }
+
+    /**
+     * Used to get the plural name of the default currency for a world.
+     * @param world The world to be used in this check.
+     * @return The plural name of the default currency.
+     */
+    @Override
+    public String currencyDefaultPlural(String world) {
+        return ess.getSettings().getCurrencyPlural();
+    }
+
+    /**
+     * Used to get the singular name of the default currency for a world.
+     * @param world The world to be used in this check.
+     * @return The plural name of the default currency.
+     */
+    @Override
+    public String currencyDefaultSingular(String world) {
+        return ess.getSettings().getCurrencySingular();
+    }
+
+    /**
+     * Checks to see if a {@link Currency} exists with this name.
+     * @param name The name of the {@link Currency} to search for.
+     * @return True if the currency exists, else false.
+     */
+    @Override
+    public boolean hasCurrency(String name) {
+        return name.equalsIgnoreCase(ess.getSettings().getCurrencySingular());
+    }
+
+    /**
+     * Checks to see if a {@link Currency} exists with this name.
+     * @param name The name of the {@link Currency} to search for.
+     * @param world The name of the {@link World} to check for this {@link Currency} in.
+     * @return True if the currency exists, else false.
+     */
+    @Override
+    public boolean hasCurrency(String name, String world) {
+        return name.equalsIgnoreCase(ess.getSettings().getCurrencySingular());
+    }
+
+    /**
+     * Checks to see if an account exists for this identifier. This method should be used for non-player accounts.
+     * @param identifier The identifier of the account.
+     * @return True if an account exists for this identifier, else false.
+     */
+    @Override
+    public EconomyResponse hasAccountDetail(String identifier) {
+        if (Economy.playerExists(identifier)) {
+            return GeneralResponse.SUCCESS;
+        }
+        return AccountResponse.DOESNT_EXIST;
+    }
+
+    /**
+     * Checks to see if an account exists for this identifier. This method should be used for player accounts.
+     * @param identifier The {@link UUID} of the account.
+     * @return True if an account exists for this identifier, else false.
+     */
+    @Override
+    public EconomyResponse hasAccountDetail(UUID identifier) {
+        return hasAccountDetail(identifier);
+    }
+
+    /**
+     * Attempts to create an account for this identifier. This method should be used for non-player accounts.
+     * @param identifier The identifier of the account.
+     * @return True if an account was created, else false.
+     */
+    @Override
+    public EconomyResponse createAccountDetail(String identifier) {
+        if (hasAccount(identifier)) return AccountResponse.ALREADY_EXISTS;
+        if (Economy.createNPC(identifier)) {
+            return AccountResponse.CREATED;
+        }
+        return GeneralResponse.FAILED;
+    }
+
+    /**
+     * Attempts to create an account for this identifier. This method should be used for player accounts.
+     * @param identifier The {@link UUID} of the account.
+     * @return True if an account was created, else false.
+     */
+    @Override
+    public EconomyResponse createAccountDetail(UUID identifier) {
+        return createAccountDetail(identifier);
+    }
+
+    /**
+     * Attempts to delete an account for this identifier. This method should be used for non-player accounts.
+     * @param identifier The identifier of the account.
+     * @return True if an account was deleted, else false.
+     */
+    @Override
+    public EconomyResponse deleteAccountDetail(String identifier) {
+        try {
+            Economy.resetBalance(getUser(identifier));
+        } catch (UserDoesNotExistException ignore) {
+            return AccountResponse.DOESNT_EXIST;
+        } catch (NoLoanPermittedException | MaxMoneyException ignore) {
+            return GeneralResponse.FAILED;
+        }
+        return GeneralResponse.SUCCESS;
+    }
+
+    /**
+     * Attempts to delete an account for this identifier. This method should be used for player accounts.
+     * @param identifier The {@link UUID} of the account.
+     * @return True if an account was deleted, else false.
+     */
+    @Override
+    public EconomyResponse deleteAccountDetail(UUID identifier) {
+        return deleteAccountDetail(identifier);
+    }
+
+    /**
+     * Determines whether or not a player is able to access this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return Whether or not the player is able to access this account.
+     */
+    @Override
+    public boolean isAccessor(String identifier, String accessor) {
+        return identifier.equals(accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to access this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return Whether or not the player is able to access this account.
+     */
+    @Override
+    public boolean isAccessor(String identifier, UUID accessor) {
+        return isAccessor(identifier, accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to access this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return Whether or not the player is able to access this account.
+     */
+    @Override
+    public boolean isAccessor(UUID identifier, String accessor) {
+        return isAccessor(identifier, accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to access this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return Whether or not the player is able to access this account.
+     */
+    @Override
+    public boolean isAccessor(UUID identifier, UUID accessor) {
+        return isAccessor(identifier, accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to withdraw holdings from this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canWithdrawDetail(String identifier, String accessor) {
+        if (identifier.equals(accessor)) {
+            return GeneralResponse.SUCCESS;
+        }
+        return GeneralResponse.FAILED;
+    }
+
+    /**
+     * Determines whether or not a player is able to withdraw holdings from this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canWithdrawDetail(String identifier, UUID accessor) {
+        return canWithdrawDetail(identifier, accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to withdraw holdings from this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canWithdrawDetail(UUID identifier, String accessor) {
+        return canWithdrawDetail(identifier, accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to withdraw holdings from this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canWithdrawDetail(UUID identifier, UUID accessor) {
+        return canWithdrawDetail(identifier, accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to deposit holdings into this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canDepositDetail(String identifier, String accessor) {
+        if (identifier.equals(accessor)) {
+            return GeneralResponse.SUCCESS;
+        }
+        return GeneralResponse.FAILED;
+    }
+
+    /**
+     * Determines whether or not a player is able to deposit holdings into this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canDepositDetail(String identifier, UUID accessor) {
+        return canDepositDetail(identifier, accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to deposit holdings into this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canDepositDetail(UUID identifier, String accessor) {
+        return canDepositDetail(identifier, accessor);
+    }
+
+    /**
+     * Determines whether or not a player is able to deposit holdings into this account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param accessor The identifier of the user attempting to access this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canDepositDetail(UUID identifier, UUID accessor) {
+        return canDepositDetail(identifier, accessor);
+    }
+
+    /**
+     * Used to get the balance of an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @return The balance of the account.
+     */
+    @Override
+    public BigDecimal getHoldings(String identifier) {
+        if (hasAccount(identifier)) {
+            try {
+
+                return Economy.getMoneyExact(getUser(identifier));
+            } catch (UserDoesNotExistException ignore) { }
+        }
+        return ess.getSettings().getStartingBalance();
+    }
+
+    /**
+     * Used to get the balance of an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @return The balance of the account.
+     */
+    @Override
+    public BigDecimal getHoldings(UUID identifier) {
+        if (hasAccount(identifier)) {
+            try {
+                return Economy.getMoneyExact(identifier);
+            } catch (UserDoesNotExistException ignore) { }
+        }
+        return ess.getSettings().getStartingBalance();
+    }
+
+    /**
+     * Used to get the balance of an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param world The name of the {@link World} associated with the balance.
+     * @return The balance of the account.
+     */
+    @Override
+    public BigDecimal getHoldings(String identifier, String world) {
+        return getHoldings(identifier);
+    }
+
+    /**
+     * Used to get the balance of an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param world The name of the {@link World} associated with the balance.
+     * @return The balance of the account.
+     */
+    @Override
+    public BigDecimal getHoldings(UUID identifier, String world) {
+        return getHoldings(identifier);
+    }
+
+    /**
+     * Used to get the balance of an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param world The name of the {@link World} associated with the balance.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The balance of the account.
+     */
+    @Override
+    public BigDecimal getHoldings(String identifier, String world, String currency) {
+        return getHoldings(identifier);
+    }
+
+    /**
+     * Used to get the balance of an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param world The name of the {@link World} associated with the balance.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The balance of the account.
+     */
+    @Override
+    public BigDecimal getHoldings(UUID identifier, String world, String currency) {
+        return getHoldings(identifier);
+    }
+
+    /**
+     * Used to determine if an account has at least an amount of funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to use for this check.
+     * @return True if the account has at least the specified amount of funds, otherwise false.
+     */
+    @Override
+    public boolean hasHoldings(String identifier, BigDecimal amount) {
+        try {
+            return Economy.hasEnough(getUser(identifier), amount);
+        } catch (UserDoesNotExistException ignore) {
+            return false;
+        }
+    }
+
+    /**
+     * Used to determine if an account has at least an amount of funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to use for this check.
+     * @return True if the account has at least the specified amount of funds, otherwise false.
+     */
+    @Override
+    public boolean hasHoldings(UUID identifier, BigDecimal amount) {
+        try {
+            return Economy.hasEnough(identifier, amount);
+        } catch (UserDoesNotExistException ignore) {
+            return false;
+        }
+    }
+
+    /**
+     * Used to determine if an account has at least an amount of funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to use for this check.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return True if the account has at least the specified amount of funds, otherwise false.
+     */
+    @Override
+    public boolean hasHoldings(String identifier, BigDecimal amount, String world) {
+        return hasHoldings(identifier, amount);
+    }
+
+    /**
+     * Used to determine if an account has at least an amount of funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to use for this check.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return True if the account has at least the specified amount of funds, otherwise false.
+     */
+    @Override
+    public boolean hasHoldings(UUID identifier, BigDecimal amount, String world) {
+        return hasHoldings(identifier, amount);
+    }
+
+    /**
+     * Used to determine if an account has at least an amount of funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to use for this check.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return True if the account has at least the specified amount of funds, otherwise false.
+     */
+    @Override
+    public boolean hasHoldings(String identifier, BigDecimal amount, String world, String currency) {
+        return hasHoldings(identifier, amount);
+    }
+
+    /**
+     * Used to determine if an account has at least an amount of funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to use for this check.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return True if the account has at least the specified amount of funds, otherwise false.
+     */
+    @Override
+    public boolean hasHoldings(UUID identifier, BigDecimal amount, String world, String currency) {
+        return hasHoldings(identifier, amount);
+    }
+
+    /**
+     * Used to set the funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to set this accounts's funds to.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse setHoldingsDetail(String identifier, BigDecimal amount) {
+        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
+        try {
+            Economy.setMoney(getUser(identifier), amount);
+            return GeneralResponse.SUCCESS;
+        } catch (UserDoesNotExistException ignore) {
+            return AccountResponse.DOESNT_EXIST;
+        } catch (NoLoanPermittedException | MaxMoneyException ignore) {
+            return GeneralResponse.FAILED;
+        }
+    }
+
+    /**
+     * Used to set the funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to set this accounts's funds to.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse setHoldingsDetail(UUID identifier, BigDecimal amount) {
+        return setHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to set the funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to set this accounts's funds to.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse setHoldingsDetail(String identifier, BigDecimal amount, String world) {
+        return setHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to set the funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to set this accounts's funds to.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse setHoldingsDetail(UUID identifier, BigDecimal amount, String world) {
+        return setHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to set the funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to set this accounts's funds to.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse setHoldingsDetail(String identifier, BigDecimal amount, String world, String currency) {
+        return setHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to set the funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to set this accounts's funds to.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse setHoldingsDetail(UUID identifier, BigDecimal amount, String world, String currency) {
+        return setHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to add funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse addHoldingsDetail(String identifier, BigDecimal amount) {
+        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
+        if (getHoldings(identifier).add(amount).compareTo(ess.getSettings().getMaxMoney()) > 0)
+            return HoldingsResponse.MAX_HOLDINGS;
+
+        try {
+            Economy.add(getUser(identifier), amount);
+            return GeneralResponse.SUCCESS;
+        } catch (UserDoesNotExistException ignore) {
+            return AccountResponse.DOESNT_EXIST;
+        } catch (NoLoanPermittedException | MaxMoneyException ignore) {
+            return GeneralResponse.FAILED;
+        }
+    }
+
+    /**
+     * Used to add funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse addHoldingsDetail(UUID identifier, BigDecimal amount) {
+        return addHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to add funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse addHoldingsDetail(String identifier, BigDecimal amount, String world) {
+        return addHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to add funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse addHoldingsDetail(UUID identifier, BigDecimal amount, String world) {
+        return addHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to add funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse addHoldingsDetail(String identifier, BigDecimal amount, String world, String currency) {
+        return addHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to add funds to an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse addHoldingsDetail(UUID identifier, BigDecimal amount, String world, String currency) {
+        return addHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding addHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canAddHoldingsDetail(String identifier, BigDecimal amount) {
+        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
+        if (getHoldings(identifier).add(amount).compareTo(ess.getSettings().getMaxMoney()) > 0)
+            return HoldingsResponse.MAX_HOLDINGS;
+        return GeneralResponse.SUCCESS;
+    }
+
+    /**
+     * Used to determine if a call to the corresponding addHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canAddHoldingsDetail(UUID identifier, BigDecimal amount) {
+        return canAddHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding addHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canAddHoldingsDetail(String identifier, BigDecimal amount, String world) {
+        return canAddHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding addHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canAddHoldingsDetail(UUID identifier, BigDecimal amount, String world) {
+        return canAddHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding addHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canAddHoldingsDetail(String identifier, BigDecimal amount, String world, String currency) {
+        return canAddHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding addHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to add to this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse canAddHoldingsDetail(UUID identifier, BigDecimal amount, String world, String currency) {
+        return canAddHoldingsDetail(identifier, amount);
+    }
+
+
+    /**
+     * Used to remove funds from an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse removeHoldingsDetail(String identifier, BigDecimal amount) {
+        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
+        if (getHoldings(identifier).subtract(amount).compareTo(ess.getSettings().getMinMoney()) < 0)
+            return HoldingsResponse.MIN_HOLDINGS;
+
+        try {
+            Economy.subtract(getUser(identifier), amount);
+            return GeneralResponse.SUCCESS;
+        } catch (UserDoesNotExistException ignore) {
+            return AccountResponse.DOESNT_EXIST;
+        } catch (NoLoanPermittedException | MaxMoneyException ignore) {
+            return GeneralResponse.FAILED;
+        }
+    }
+
+    /**
+     * Used to remove funds from an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse removeHoldingsDetail(UUID identifier, BigDecimal amount) {
+        return removeHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to remove funds from an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse removeHoldingsDetail(String identifier, BigDecimal amount, String world) {
+        return removeHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to remove funds from an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse removeHoldingsDetail(UUID identifier, BigDecimal amount, String world) {
+        return removeHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to remove funds from an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse removeHoldingsDetail(String identifier, BigDecimal amount, String world, String currency) {
+        return removeHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to remove funds from an account.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} for this action.
+     */
+    @Override
+    public EconomyResponse removeHoldingsDetail(UUID identifier, BigDecimal amount, String world, String currency) {
+        return removeHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding removeHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @return The {@link EconomyResponse} that would be returned with the corresponding removeHoldingsDetail method.
+     */
+    @Override
+    public EconomyResponse canRemoveHoldingsDetail(String identifier, BigDecimal amount) {
+        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
+        if (getHoldings(identifier).subtract(amount).compareTo(ess.getSettings().getMinMoney()) < 0)
+            return HoldingsResponse.MIN_HOLDINGS;
+        return GeneralResponse.SUCCESS;
+    }
+
+    /**
+     * Used to determine if a call to the corresponding removeHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @return The {@link EconomyResponse} that would be returned with the corresponding removeHoldingsDetail method.
+     */
+    @Override
+    public EconomyResponse canRemoveHoldingsDetail(UUID identifier, BigDecimal amount) {
+        return canRemoveHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding removeHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} that would be returned with the corresponding removeHoldingsDetail method.
+     */
+    @Override
+    public EconomyResponse canRemoveHoldingsDetail(String identifier, BigDecimal amount, String world) {
+        return canRemoveHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding removeHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @return The {@link EconomyResponse} that would be returned with the corresponding removeHoldingsDetail method.
+     */
+    @Override
+    public EconomyResponse canRemoveHoldingsDetail(UUID identifier, BigDecimal amount, String world) {
+        return canRemoveHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding removeHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} that would be returned with the corresponding removeHoldingsDetail method.
+     */
+    @Override
+    public EconomyResponse canRemoveHoldingsDetail(String identifier, BigDecimal amount, String world, String currency) {
+        return canRemoveHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Used to determine if a call to the corresponding removeHoldings method would be successful. This method does not
+     * affect an account's funds.
+     * @param identifier The identifier of the account that is associated with this call.
+     * @param amount The amount you wish to remove from this account.
+     * @param world The name of the {@link World} associated with the amount.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The {@link EconomyResponse} that would be returned with the corresponding removeHoldingsDetail method.
+     */
+    @Override
+    public EconomyResponse canRemoveHoldingsDetail(UUID identifier, BigDecimal amount, String world, String currency) {
+        return canRemoveHoldingsDetail(identifier, amount);
+    }
+
+    /**
+     * Formats a monetary amount into a more text-friendly version.
+     * @param amount The amount of currency to format.
+     * @return The formatted amount.
+     */
+    @Override
+    public String format(BigDecimal amount) {
+        return Economy.format(amount);
+    }
+
+    /**
+     * Formats a monetary amount into a more text-friendly version.
+     * @param amount The amount of currency to format.
+     * @param world The {@link World} in which this format operation is occurring.
+     * @return The formatted amount.
+     */
+    @Override
+    public String format(BigDecimal amount, String world) {
+        return Economy.format(amount);
+    }
+
+    /**
+     * Formats a monetary amount into a more text-friendly version.
+     * @param amount The amount of currency to format.
+     * @param world The {@link World} in which this format operation is occurring.
+     * @param currency The {@link Currency} associated with the balance.
+     * @return The formatted amount.
+     */
+    @Override
+    public String format(BigDecimal amount, String world, String currency) {
+        return Economy.format(amount);
+    }
+
+    /**
+     * Purges the database of accounts with the default balance.
+     * @return True if the purge was completed successfully.
+     */
+    @Override
+    public boolean purgeAccounts() {
+        return false;
+    }
+
+    /**
+     * Purges the database of accounts with a balance under the specified one.
+     * @param amount The amount that an account's balance has to be under in order to be removed.
+     * @return True if the purge was completed successfully.
+     */
+    @Override
+    public boolean purgeAccountsUnder(BigDecimal amount) {
+        return false;
+    }
+}

--- a/Essentials/src/main/java/com/earth2me/essentials/economy/reserve/ReserveEconomyProvider.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/economy/reserve/ReserveEconomyProvider.java
@@ -562,7 +562,10 @@ public class ReserveEconomyProvider implements EconomyAPI {
      */
     @Override
     public EconomyResponse setHoldingsDetail(String identifier, BigDecimal amount) {
-        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
+        if (!hasAccount(identifier) && !createAccount(identifier)) {
+            return AccountResponse.CREATION_FAILED;
+        }
+
         try {
             Economy.setMoney(getUser(identifier), amount);
             return GeneralResponse.SUCCESS;
@@ -581,7 +584,17 @@ public class ReserveEconomyProvider implements EconomyAPI {
      */
     @Override
     public EconomyResponse setHoldingsDetail(UUID identifier, BigDecimal amount) {
-        return setHoldingsDetail(identifier.toString(), amount);
+        if (!hasAccount(identifier) && !createAccount(identifier)) {
+            return AccountResponse.CREATION_FAILED;
+        }
+        try {
+            Economy.setMoney(identifier, amount);
+            return GeneralResponse.SUCCESS;
+        } catch (UserDoesNotExistException ignore) {
+            return AccountResponse.DOESNT_EXIST;
+        } catch (NoLoanPermittedException | MaxMoneyException ignore) {
+            return GeneralResponse.FAILED;
+        }
     }
 
     /**
@@ -642,9 +655,13 @@ public class ReserveEconomyProvider implements EconomyAPI {
      */
     @Override
     public EconomyResponse addHoldingsDetail(String identifier, BigDecimal amount) {
-        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
-        if (getHoldings(identifier).add(amount).compareTo(ess.getSettings().getMaxMoney()) > 0)
+        if (!hasAccount(identifier) && !createAccount(identifier)) {
+            return AccountResponse.CREATION_FAILED;
+        }
+
+        if (getHoldings(identifier).add(amount).compareTo(ess.getSettings().getMaxMoney()) > 0) {
             return HoldingsResponse.MAX_HOLDINGS;
+        }
 
         try {
             Economy.add(getUser(identifier), amount);
@@ -664,7 +681,22 @@ public class ReserveEconomyProvider implements EconomyAPI {
      */
     @Override
     public EconomyResponse addHoldingsDetail(UUID identifier, BigDecimal amount) {
-        return addHoldingsDetail(identifier.toString(), amount);
+        if (!hasAccount(identifier) && !createAccount(identifier)) {
+            return AccountResponse.CREATION_FAILED;
+        }
+
+        if (getHoldings(identifier).add(amount).compareTo(ess.getSettings().getMaxMoney()) > 0) {
+            return HoldingsResponse.MAX_HOLDINGS;
+        }
+
+        try {
+            Economy.add(identifier, amount);
+            return GeneralResponse.SUCCESS;
+        } catch (UserDoesNotExistException ignore) {
+            return AccountResponse.DOESNT_EXIST;
+        } catch (NoLoanPermittedException | MaxMoneyException ignore) {
+            return GeneralResponse.FAILED;
+        }
     }
 
     /**
@@ -727,8 +759,9 @@ public class ReserveEconomyProvider implements EconomyAPI {
     @Override
     public EconomyResponse canAddHoldingsDetail(String identifier, BigDecimal amount) {
         if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
-        if (getHoldings(identifier).add(amount).compareTo(ess.getSettings().getMaxMoney()) > 0)
+        if (getHoldings(identifier).add(amount).compareTo(ess.getSettings().getMaxMoney()) > 0) {
             return HoldingsResponse.MAX_HOLDINGS;
+        }
         return GeneralResponse.SUCCESS;
     }
 
@@ -741,7 +774,11 @@ public class ReserveEconomyProvider implements EconomyAPI {
      */
     @Override
     public EconomyResponse canAddHoldingsDetail(UUID identifier, BigDecimal amount) {
-        return canAddHoldingsDetail(identifier.toString(), amount);
+        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
+        if (getHoldings(identifier).add(amount).compareTo(ess.getSettings().getMaxMoney()) > 0) {
+            return HoldingsResponse.MAX_HOLDINGS;
+        }
+        return GeneralResponse.SUCCESS;
     }
 
     /**
@@ -807,9 +844,13 @@ public class ReserveEconomyProvider implements EconomyAPI {
      */
     @Override
     public EconomyResponse removeHoldingsDetail(String identifier, BigDecimal amount) {
-        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
-        if (getHoldings(identifier).subtract(amount).compareTo(ess.getSettings().getMinMoney()) < 0)
+        if (!hasAccount(identifier) && !createAccount(identifier)) {
+            return AccountResponse.CREATION_FAILED;
+        }
+
+        if (getHoldings(identifier).subtract(amount).compareTo(ess.getSettings().getMinMoney()) < 0) {
             return HoldingsResponse.MIN_HOLDINGS;
+        }
 
         try {
             Economy.subtract(getUser(identifier), amount);
@@ -829,7 +870,22 @@ public class ReserveEconomyProvider implements EconomyAPI {
      */
     @Override
     public EconomyResponse removeHoldingsDetail(UUID identifier, BigDecimal amount) {
-        return removeHoldingsDetail(identifier.toString(), amount);
+        if (!hasAccount(identifier) && !createAccount(identifier)) {
+            return AccountResponse.CREATION_FAILED;
+        }
+
+        if (getHoldings(identifier).subtract(amount).compareTo(ess.getSettings().getMinMoney()) < 0) {
+            return HoldingsResponse.MIN_HOLDINGS;
+        }
+
+        try {
+            Economy.subtract(identifier, amount);
+            return GeneralResponse.SUCCESS;
+        } catch (UserDoesNotExistException ignore) {
+            return AccountResponse.DOESNT_EXIST;
+        } catch (NoLoanPermittedException | MaxMoneyException ignore) {
+            return GeneralResponse.FAILED;
+        }
     }
 
     /**
@@ -892,8 +948,9 @@ public class ReserveEconomyProvider implements EconomyAPI {
     @Override
     public EconomyResponse canRemoveHoldingsDetail(String identifier, BigDecimal amount) {
         if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
-        if (getHoldings(identifier).subtract(amount).compareTo(ess.getSettings().getMinMoney()) < 0)
+        if (getHoldings(identifier).subtract(amount).compareTo(ess.getSettings().getMinMoney()) < 0) {
             return HoldingsResponse.MIN_HOLDINGS;
+        }
         return GeneralResponse.SUCCESS;
     }
 
@@ -906,7 +963,11 @@ public class ReserveEconomyProvider implements EconomyAPI {
      */
     @Override
     public EconomyResponse canRemoveHoldingsDetail(UUID identifier, BigDecimal amount) {
-        return canRemoveHoldingsDetail(identifier.toString(), amount);
+        if (!hasAccount(identifier) && !createAccount(identifier)) return AccountResponse.CREATION_FAILED;
+        if (getHoldings(identifier).subtract(amount).compareTo(ess.getSettings().getMinMoney()) < 0) {
+            return HoldingsResponse.MIN_HOLDINGS;
+        }
+        return GeneralResponse.SUCCESS;
     }
 
     /**

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -801,6 +801,12 @@ currency-symbol: '$'
 # For example, the euro symbol typically appears after the current amount.
 currency-symbol-suffix: false
 
+#Set this to the singular name of your currency.
+currency-singular: 'dollar'
+
+#Set this to the plural name of your currency
+currency-plural: 'dollars'
+
 # Set the maximum amount of money a player can have.
 # The amount is always limited to 10 trillion because of the limitations of a java double.
 max-money: 10000000000000

--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ main: com.earth2me.essentials.Essentials
 version: ${full.version}
 website: https://essentialsx.net/
 description: Provides an essential, core set of commands for Bukkit.
-softdepend: [Vault, LuckPerms]
+softdepend: [Vault, LuckPerms, Reserve]
 authors: [Zenexer, ementalo, Aelux, Brettflan, KimKandor, snowleo, ceulemans, Xeology, KHobbits, md_5, Iaccidentally, drtshock, vemacs, SupaHam, mdcfe, JRoy, pop4959]
 api-version: "1.13"
 commands:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,10 @@ dependencyResolutionManagement {
             content { includeGroup("com.github.milkbowl") }
         }
         maven("https://repo.codemc.org/repository/maven-public") {
-            content { includeGroup("org.bstats") }
+            content {
+                includeGroup("org.bstats")
+                includeGroup("net.tnemc")
+            }
         }
         maven("https://m2.dv8tion.net/releases/") {
             content { includeGroup("net.dv8tion") }


### PR DESCRIPTION
This is my updated PR from https://github.com/EssentialsX/Essentials/pull/2601.

As stated in the original:

Reserve is a new alternative to Vault, with modern functionality. Implemented the Economy API in this PR.

Main Advantages:

- BigDecimal usage instead of Double for more precise amounts.
- Support for multi-currency economies(not that this one, in particular, affects EssentialsX)
- Optional ExtendedAPI for even more functionality.
- Ability to add new currencies or denominations.
- Transaction API for third-party plugins to hook into economies that utilize the transaction API for transaction logging, and voiding.
- 
I mainly based this implementation off a quick glance off the vault layers, if there are any methods that seem like they are not implemented in the most efficient way just let me know.


For more information about contributing to EssentialsX, see CONTRIBUTING.md:
    https://github.com/EssentialsX/Essentials/blob/2.x/CONTRIBUTING.md
