### PR TITLE
Add translation for /list real name

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
@@ -42,7 +42,7 @@ public final class PlayerList {
 
             final String strippedNick = FormatUtil.stripFormat(user.getNickname());
             if (ess.getSettings().realNamesOnList() && strippedNick != null && !strippedNick.equals(user.getName())) {
-                groupString.append(" (").append(user.getName()).append(")");
+                groupString.append(" ").append(tl("listRealName",user.getName()));
             }
             groupString.append(ChatColor.WHITE.toString());
         }

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -662,6 +662,7 @@ listCommandUsage1=/<command> [group]
 listCommandUsage1Description=Lists all players on the server, or the given group if specified
 listGroupTag=\u00a76{0}\u00a7r\: 
 listHiddenTag=\u00a77[HIDDEN]\u00a7r
+listRealName=({0})
 loadWarpError=\u00a74Failed to load warp {0}.
 localFormat=[L]<{0}> {1}
 localNoOne=


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

This PR closes #4611 . 

### Details

**Proposed feature:**  
<!-- Type a description of your proposed feature below this line. -->
When a player has a nickname, the output of the /list command includes the player's real name in parenthesis, in white. However, that cannot be customized to use different colors or for that matter something other than parentheses.

This PR allows server owners to customize the (playername) part of the /list command output.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Linux and Windows 10

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  
Linux: Java(TM) SE Runtime Environment 16.0.2+7-67
Windows: Java(TM) SE Runtime Environment (build 16.0.2+7-67)

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Here is the 'before' output of the /list command (current behavior):

![list_output](https://user-images.githubusercontent.com/3617206/140576778-3366b841-9949-4744-96b6-3284160e6767.png)

_This PR does not change the default format,_ so it will look the same by default (yes, I tested that). But here is the output when I set the messages_en.properties to include the line `listRealName=\u00A77({0})`. Note that the real name part of the output is in grey, as specified by the color code:

![list_output2](https://user-images.githubusercontent.com/3617206/140576804-ec58b0d5-27d4-40b2-8dba-7ca0f07fcf64.png)



