### PR TITLE
Added PowerRanks as valid Vault Permissions manager

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/perm/impl/ModernVaultHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/impl/ModernVaultHandler.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class ModernVaultHandler extends AbstractVaultHandler {
-    private final List<String> supportedPlugins = Arrays.asList("PermissionsEx", "LuckPerms");
+    private final List<String> supportedPlugins = Arrays.asList("PermissionsEx", "LuckPerms", "PowerRanks");
 
     @Override
     protected boolean emulateWildcards() {

--- a/Essentials/src/main/java/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
@@ -145,7 +145,7 @@ public class SuperpermsHandler implements IPermissionsHandler {
         String enabledPermsPlugin = null;
         final List<String> specialCasePlugins = Arrays.asList("PermissionsEx", "GroupManager",
             "SimplyPerms", "Privileges", "bPermissions", "zPermissions", "PermissionsBukkit",
-            "DroxPerms", "xPerms", "LuckPerms");
+            "DroxPerms", "xPerms", "LuckPerms", "PowerRanks");
         for (final Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
             if (specialCasePlugins.contains(plugin.getName())) {
                 enabledPermsPlugin = plugin.getName();


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

### Details

**Proposed feature:**  
<!-- Type a description of your proposed feature below this line. -->
This PR adds PowerRanks to the list as valid Vault Permissions manager for EssentialsX.


**Environments tested:**    
OS: Ubuntu 21.10
Java version:  java 16.0.2 2021-07-20
PowerRanks: v1.10.2 BETA (3486bc4)

- [x] Most recent Paper version (1.17.1, git-Paper-388)
- [x] CraftBukkit/Spigot/Paper 1.12.2
- [x] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Running EssentialsX, Vault and PowerRanks shows EssentialsX picking up PowerRanks as permissions manager.
`[Essentials] Using Vault based permissions (PowerRanks)`

`> vault-info`
`[15:49:32 INFO]: [Vault] Vault v1.7.3-b131 Information`
`[15:49:32 INFO]: [Vault] Economy: EssentialsX Economy [EssentialsX Economy, Essentials Economy]`
`[15:49:32 INFO]: [Vault] Permission: PowerRanks [PowerRanks, SuperPerms]`
`[15:49:32 INFO]: [Vault] Chat: PowerRanks [PowerRanks]`