### PR TITLE
Add essentials.itemname.allow-type.* and essentials.hat.allow-type.*

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commanditemname.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commanditemname.java
@@ -15,8 +15,9 @@ import java.util.List;
 import static com.earth2me.essentials.I18n.tl;
 
 public class Commanditemname extends EssentialsCommand {
-    public static final String PERM_PREFIX = "essentials.itemname.prevent-type.";
-
+    public static final String PREVENT_PERM_PREFIX = "essentials.itemname.prevent-type.";
+    public static final String ALLOW_PERM_PREFIX = "essentials.itemname.allow-type.";
+    
     public Commanditemname() {
         super("itemname");
     }
@@ -29,9 +30,12 @@ public class Commanditemname extends EssentialsCommand {
             return;
         }
 
-        final TriState wildcard = user.isAuthorizedExact(PERM_PREFIX + "*");
-        final TriState material = user.isAuthorizedExact(PERM_PREFIX + item.getType().name().toLowerCase());
-        if ((wildcard == TriState.TRUE && material != TriState.FALSE) || ((wildcard != TriState.TRUE) && material == TriState.TRUE)) {
+        final TriState wildcard = user.isAuthorizedExact(PREVENT_PERM_PREFIX + "*");
+        final TriState material = user.isAuthorizedExact(PREVENT_PERM_PREFIX + item.getType().name().toLowerCase());
+        final TriState wildcardAllowed = user.isAuthorizedExact(ALLOW_PERM_PREFIX + "*");
+        final TriState allowed = user.isAuthorizedExact(ALLOW_PERM_PREFIX + item.getType().name().toLowerCase());
+        if (((wildcard == TriState.TRUE && material != TriState.FALSE) || ((wildcard != TriState.TRUE) && material == TriState.TRUE))
+            && (allowed != TriState.TRUE && wildcardAllowed != TriState.TRUE)) {
             user.sendMessage(tl("itemnameInvalidItem"));
             return;
         }


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

This PR adds the permissions essentials.itemname.prevent-type.* and essentials.hat.prevent-type.*

### Details

**Proposed feature:**  
<!-- Type a description of your proposed feature below this line. -->
Add essentials.hat.allow-type.* and essentials.itemname.allow-type.* permission nodes

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Linux

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:
openjdk version "16.0.1" 2021-04-20
OpenJDK Runtime Environment (build 16.0.1+9-Ubuntu-120.04)
OpenJDK 64-Bit Server VM (build 16.0.1+9-Ubuntu-120.04, mixed mode, sharing)

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.17.1, git-Paper-388)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
LuckPerms permissions
![image](https://user-images.githubusercontent.com/67280050/143135065-2fef0596-509e-4375-bf05-6e9658d43076.png)
Sand (or any other item other than glass) for hat not allowed
![image](https://user-images.githubusercontent.com/67280050/143135318-f90147e2-3df5-4ed7-ade8-6bb0408b2b61.png)
Glass for hat allowed because essentials.hat.allow-type.glass is true
![image](https://user-images.githubusercontent.com/67280050/143135423-25f803c4-5d46-4429-a8a5-846e10f80190.png)
