### PR TITLE
Some discord module nullability fixes

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -149,9 +149,9 @@ public class JDADiscordService implements DiscordService, IEssentialsModule {
     public void startup() throws LoginException, InterruptedException {
         shutdown();
 
+        invalidStartup = true;
         logger.log(Level.INFO, tl("discordLoggingIn"));
         if (plugin.getSettings().getBotToken().replace("INSERT-TOKEN-HERE", "").trim().isEmpty()) {
-            invalidStartup = true;
             throw new IllegalArgumentException(tl("discordErrorNoToken"));
         }
 
@@ -162,6 +162,7 @@ public class JDADiscordService implements DiscordService, IEssentialsModule {
                 .setContextEnabled(false)
                 .build()
                 .awaitReady();
+        invalidStartup = false;
         updatePresence();
         logger.log(Level.INFO, tl("discordLoggingInDone", jda.getSelfUser().getAsTag()));
 

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/util/DiscordUtil.java
@@ -79,7 +79,7 @@ public final class DiscordUtil {
         final CompletableFuture<Webhook> future = new CompletableFuture<>();
         channel.retrieveWebhooks().queue(webhooks -> {
             for (final Webhook webhook : webhooks) {
-                if (webhook.getName().equals(webhookName)) {
+                if (webhook.getName().equals(webhookName) && webhook.getToken() != null) {
                     ACTIVE_WEBHOOKS.addIfAbsent(webhook.getId());
                     future.complete(webhook);
                     return;


### PR DESCRIPTION
Fixes #4606

Note for the first commit, `invalidStartup` is set to `false` at the start of the method and `true` after the `jda` assignment because `awaitReady` can throw an exception so we should assure we correctly flag that as an invalid startup.