### PR TITLE
Remove ignore teleport metadata

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -540,7 +540,7 @@ public class EssentialsPlayerListener implements Listener, FakeAccessor {
             return;
         }
         final User user = ess.getUser(player);
-        if (ess.getSettings().registerBackInListener() && user.isAuthorized("essentials.back.onteleport") && !player.hasMetadata("ess_ignore_teleport")) {
+        if (ess.getSettings().registerBackInListener() && user.isAuthorized("essentials.back.onteleport")) {
             user.setLastLocation();
         }
         if (ess.getSettings().isTeleportInvulnerability()) {


### PR DESCRIPTION
Plugins should use the API to set the last location if they need to rather than using metadata that potentially causes side effects for other plugins if not used properly.