### PR TITLE
Add support for local and global chats in Discord

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/events/discord/DiscordChatMessageEvent.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/events/discord/DiscordChatMessageEvent.java
@@ -1,5 +1,6 @@
 package net.essentialsx.api.v2.events.discord;
 
+import net.essentialsx.api.v2.ChatType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -14,6 +15,7 @@ public class DiscordChatMessageEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     private final Player player;
+    private final ChatType chatType;
     private String message;
     private boolean cancelled = false;
 
@@ -21,13 +23,14 @@ public class DiscordChatMessageEvent extends Event implements Cancellable {
      * @param player  The player which caused this event.
      * @param message The message of this event.
      */
-    public DiscordChatMessageEvent(Player player, String message) {
+    public DiscordChatMessageEvent(Player player, String message, ChatType chatType) {
         this.player = player;
         this.message = message;
+        this.chatType = chatType;
     }
 
     /**
-     * The player which which caused this chat message.
+     * The player which caused this chat message.
      * @return the player who caused the event.
      */
     public Player getPlayer() {
@@ -48,6 +51,14 @@ public class DiscordChatMessageEvent extends Event implements Cancellable {
      */
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    /**
+     * Type of chat of the original message.
+     * @return type of chat of the original message.
+     */
+    public ChatType getChatType() {
+        return chatType;
     }
 
     @Override

--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/DiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/DiscordService.java
@@ -1,5 +1,6 @@
 package net.essentialsx.api.v2.services.discord;
 
+import net.essentialsx.api.v2.ChatType;
 import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -20,7 +21,7 @@ public interface DiscordService {
     void sendMessage(final MessageType type, final String message, final boolean allowGroupMentions);
 
     /**
-     * Sends a chat messages to the {@link MessageType.DefaultTypes#CHAT default chat channel} with the same format
+     * Sends a chat message to the {@link MessageType.DefaultTypes#CHAT default chat channel} with the same format
      * used for regular chat messages specified in the EssentialsX Discord configuration.
      * <p>
      * Note: Messages sent with this method will not fire a {@link DiscordChatMessageEvent}.
@@ -28,6 +29,16 @@ public interface DiscordService {
      * @param chatMessage The chat message the player has sent.
      */
     void sendChatMessage(final Player player, final String chatMessage);
+
+    /**
+     * Sends a chat message to the appropriate chat channel depending on the chat type with the format specified
+     * for that type in the EssentialsX Discord configuration.
+     * <p>
+     * Note: Messages sent with this method will not fire a {@link DiscordChatMessageEvent}.
+     * @param player      The player who send the message.
+     * @param chatMessage The chat message the player has sent.
+     */
+    void sendChatMessage(final ChatType chatType, final Player player, final String chatMessage);
 
     /**
      * Checks if a {@link MessageType} by the given key is already registered.

--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
@@ -65,7 +65,10 @@ public final class MessageType {
         public final static MessageType SERVER_STOP = new MessageType("server-stop", false);
         public final static MessageType KICK = new MessageType("kick", false);
         public final static MessageType MUTE = new MessageType("mute", false);
-        private final static MessageType[] VALUES = new MessageType[]{JOIN, FIRST_JOIN, LEAVE, CHAT, DEATH, AFK, ADVANCEMENT, ACTION, SERVER_START, SERVER_STOP, KICK, MUTE};
+        public final static MessageType LOCAL = new MessageType("local", true);
+        public final static MessageType QUESTION = new MessageType("question", true);
+        public final static MessageType SHOUT = new MessageType("shout", true);
+        private final static MessageType[] VALUES = new MessageType[]{JOIN, FIRST_JOIN, LEAVE, CHAT, DEATH, AFK, ADVANCEMENT, ACTION, SERVER_START, SERVER_STOP, KICK, MUTE, LOCAL, QUESTION, SHOUT};
 
         /**
          * Gets an array of all the default {@link MessageType MessageTypes}.

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.config.EssentialsConfiguration;
 import com.earth2me.essentials.utils.FormatUtil;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
+import net.essentialsx.api.v2.ChatType;
 import org.apache.logging.log4j.Level;
 import org.bukkit.entity.Player;
 
@@ -105,6 +106,10 @@ public class DiscordSettings implements IConf {
 
     public boolean isAlwaysReceivePrimary() {
         return config.getBoolean("always-receive-primary", false);
+    }
+
+    public boolean isUseEssentialsEvents() {
+        return config.getBoolean("use-essentials-events", true);
     }
 
     public int getChatDiscordMaxLength() {
@@ -215,15 +220,45 @@ public class DiscordSettings implements IConf {
     }
 
     public MessageFormat getMcToDiscordFormat(Player player) {
-        final String format = getFormatString("mc-to-discord");
+        return getMcToDiscordFormat(player, ChatType.UNKNOWN);
+    }
+
+    public MessageFormat getMcToDiscordFormat(Player player, ChatType chatType) {
+        final String format = getFormatString(getMcToDiscordFormatKey(chatType));
         final String filled;
         if (plugin.isPAPI() && format != null) {
             filled = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, format);
         } else {
             filled = format;
         }
-        return generateMessageFormat(filled, "{displayname}: {message}", false,
+        return generateMessageFormat(filled, getMcToDiscordDefaultFormat(chatType), false,
                 "username", "displayname", "message", "world", "prefix", "suffix");
+    }
+
+    private String getMcToDiscordFormatKey(ChatType chatType) {
+        switch (chatType) {
+            case LOCAL:
+                return "mc-to-discord-local";
+            case QUESTION:
+                return "mc-to-discord-question";
+            case SHOUT:
+                return "mc-to-discord-shout";
+            default:
+                return "mc-to-discord";
+        }
+    }
+
+    private String getMcToDiscordDefaultFormat(ChatType chatType) {
+        switch (chatType) {
+            case LOCAL:
+                return "**[Local]** {displayname}: {message}";
+            case QUESTION:
+                return "**[Question]** {displayname}: {message}";
+            case SHOUT:
+                return "**[Shout]** {displayname}: {message}";
+            default:
+                return "{displayname}: {message}";
+        }
     }
 
     public String getLegacyNameFormat() {

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -109,7 +109,7 @@ public class DiscordSettings implements IConf {
     }
 
     public boolean isUseEssentialsEvents() {
-        return config.getBoolean("use-essentials-events", true);
+        return config.getBoolean("use-essentials-events", false);
     }
 
     public int getChatDiscordMaxLength() {

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/EssentialsDiscord.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/EssentialsDiscord.java
@@ -24,6 +24,7 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
     private JDADiscordService jda;
     private DiscordSettings settings;
     private boolean isPAPI = false;
+    private boolean isEssentialsChat = false;
 
     @Override
     public void onEnable() {
@@ -45,6 +46,8 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
         }
 
         isPAPI = getServer().getPluginManager().getPlugin("PlaceholderAPI") != null;
+
+        isEssentialsChat = getServer().getPluginManager().getPlugin("EssentialsChat") != null;
 
         settings = new DiscordSettings(this);
         ess.addReloadListener(settings);
@@ -79,6 +82,7 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
 
     public void onReload() {
         if (jda != null && !jda.isInvalidStartup()) {
+            jda.updateListener();
             jda.updatePresence();
             jda.updatePrimaryChannel();
             jda.updateConsoleRelay();
@@ -100,6 +104,10 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
 
     public boolean isPAPI() {
         return isPAPI;
+    }
+
+    public boolean isEssentialsChat() {
+        return isEssentialsChat;
     }
 
     @Override

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitChatListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitChatListener.java
@@ -1,0 +1,34 @@
+package net.essentialsx.discord.listeners;
+
+import net.essentialsx.api.v2.ChatType;
+import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
+import net.essentialsx.discord.JDADiscordService;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public class BukkitChatListener implements Listener {
+    private final JDADiscordService jda;
+
+    public BukkitChatListener(JDADiscordService jda) {
+        this.jda = jda;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onChat(AsyncPlayerChatEvent event) {
+        final Player player = event.getPlayer();
+        Bukkit.getScheduler().runTask(jda.getPlugin(), () -> {
+            final DiscordChatMessageEvent chatEvent = new DiscordChatMessageEvent(event.getPlayer(), event.getMessage(), ChatType.UNKNOWN);
+            chatEvent.setCancelled(!jda.getSettings().isShowAllChat() && !event.getRecipients().containsAll(Bukkit.getOnlinePlayers()));
+            Bukkit.getPluginManager().callEvent(chatEvent);
+            if (chatEvent.isCancelled()) {
+                return;
+            }
+
+            jda.sendChatMessage(player, chatEvent.getMessage());
+        });
+    }
+}

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -11,13 +11,11 @@ import net.ess3.api.events.VanishStatusChangeEvent;
 import net.ess3.provider.AbstractAchievementEvent;
 import net.essentialsx.api.v2.events.AsyncUserDataLoadEvent;
 import net.essentialsx.api.v2.events.UserActionEvent;
-import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
 import net.essentialsx.api.v2.events.discord.DiscordMessageEvent;
 import net.essentialsx.api.v2.services.discord.MessageType;
 import net.essentialsx.discord.JDADiscordService;
 import net.essentialsx.discord.util.DiscordUtil;
 import net.essentialsx.discord.util.MessageUtil;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
@@ -25,7 +23,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
@@ -79,21 +76,6 @@ public class BukkitListener implements Listener {
                             MessageUtil.sanitizeDiscordMarkdown(console ? Console.DISPLAY_NAME : event.getController().getDisplayName()),
                             MessageUtil.sanitizeDiscordMarkdown(event.getReason())));
         }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onChat(AsyncPlayerChatEvent event) {
-        final Player player = event.getPlayer();
-        Bukkit.getScheduler().runTask(jda.getPlugin(), () -> {
-            final DiscordChatMessageEvent chatEvent = new DiscordChatMessageEvent(event.getPlayer(), event.getMessage());
-            chatEvent.setCancelled(!jda.getSettings().isShowAllChat() && !event.getRecipients().containsAll(Bukkit.getOnlinePlayers()));
-            Bukkit.getPluginManager().callEvent(chatEvent);
-            if (chatEvent.isCancelled()) {
-                return;
-            }
-
-            jda.sendChatMessage(player, chatEvent.getMessage());
-        });
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/EssentialsChatListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/EssentialsChatListener.java
@@ -1,0 +1,43 @@
+package net.essentialsx.discord.listeners;
+
+import net.essentialsx.api.v2.events.chat.ChatEvent;
+import net.essentialsx.api.v2.events.chat.GlobalChatEvent;
+import net.essentialsx.api.v2.events.chat.LocalChatEvent;
+import net.essentialsx.api.v2.events.discord.DiscordChatMessageEvent;
+import net.essentialsx.discord.JDADiscordService;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class EssentialsChatListener implements Listener {
+    private final JDADiscordService jda;
+
+    public EssentialsChatListener(JDADiscordService jda) {
+        this.jda = jda;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onLocalChat(LocalChatEvent event) {
+        processChatEvent(event);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onGlobalChat(GlobalChatEvent event) {
+        processChatEvent(event);
+    }
+
+    private void processChatEvent(ChatEvent event) {
+        final Player player = event.getPlayer();
+
+        Bukkit.getScheduler().runTask(jda.getPlugin(), () -> {
+            final DiscordChatMessageEvent chatEvent = new DiscordChatMessageEvent(event.getPlayer(), event.getMessage(), event.getChatType());
+            Bukkit.getPluginManager().callEvent(chatEvent);
+
+            if (!chatEvent.isCancelled()) {
+                jda.sendChatMessage(event.getChatType(), player, chatEvent.getMessage());
+            }
+        });
+    }
+}

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -46,6 +46,10 @@ channels:
 # players the essentials.discord.receive.primary permission.
 always-receive-primary: false
 
+# Whether to use Essentials Chat events instead of normal chat event.
+# This allows you to filter chat by its type (local, question, shout).
+use-essentials-events: true
+
 # Chat relay settings
 # General settings for chat relays between Minecraft and Discord.
 # To configure the channel Minecraft chat is sent to, see the "message-types" section of the config.
@@ -138,6 +142,15 @@ message-types:
   kick: staff
   # Message sent when a player's mute state is changed on the Minecraft server.
   mute: staff
+  # Message sent when a player talks in local chat.
+  # use-essentials-events must be set to "true" for this to work.
+  local: none
+  # Message sent when a player asks a question in global chat.
+  # use-essentials-events must be set to "true" for this to work.
+  question: primary
+  # Message sent when a player talks in global chat.
+  # use-essentials-events must be set to "true" for this to work.
+  shout: primary
 
 # Whether or not player messages should show their avatar as the profile picture in Discord.
 # The bot will require the "Manage Webhooks" permission in the defined channels in order to use this feature.
@@ -268,6 +281,36 @@ messages:
   # - {botname}: Name of the Discord bot
   # ... PlaceholderAPI placeholders are also supported here too!
   mc-to-discord-name-format: "{botname}"
+  # This is the message that is used to relay minecraft local chat in Discord.
+  # The following placeholders can be used here:
+  # - {username}: The username of the player sending the message
+  # - {displayname}: The display name of the player sending the message (This would be their nickname)
+  # - {message}: The content of the message being sent
+  # - {world}: The name of the world the player sending the message is in
+  # - {prefix}: The prefix of the player sending the message
+  # - {suffix}: The suffix of the player sending the message
+  # ... PlaceholderAPI placeholders are also supported here too!
+  mc-to-discord-local: "**[Local]** {displayname}: {message}"
+  # This is the message that is used to relay questions from minecraft chat in Discord.
+  # The following placeholders can be used here:
+  # - {username}: The username of the player sending the message
+  # - {displayname}: The display name of the player sending the message (This would be their nickname)
+  # - {message}: The content of the message being sent
+  # - {world}: The name of the world the player sending the message is in
+  # - {prefix}: The prefix of the player sending the message
+  # - {suffix}: The suffix of the player sending the message
+  # ... PlaceholderAPI placeholders are also supported here too!
+  mc-to-discord-question: "**[Question]** {displayname}: {message}"
+  # This is the message that is used to relay minecraft global chat in Discord.
+  # The following placeholders can be used here:
+  # - {username}: The username of the player sending the message
+  # - {displayname}: The display name of the player sending the message (This would be their nickname)
+  # - {message}: The content of the message being sent
+  # - {world}: The name of the world the player sending the message is in
+  # - {prefix}: The prefix of the player sending the message
+  # - {suffix}: The suffix of the player sending the message
+  # ... PlaceholderAPI placeholders are also supported here too!
+  mc-to-discord-shout: "**[Shout]** {displayname}: {message}"
   # This is the message sent to Discord when a player is temporarily muted in minecraft.
   # The following placeholders can be used here:
   # - {username}: The username of the player being muted

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -48,7 +48,7 @@ always-receive-primary: false
 
 # Whether to use Essentials Chat events instead of normal chat event.
 # This allows you to filter chat by its type (local, question, shout).
-use-essentials-events: true
+use-essentials-events: false
 
 # Chat relay settings
 # General settings for chat relays between Minecraft and Discord.


### PR DESCRIPTION
**This pull request is a draft since it requires #4683 to be merged first.**

***

<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

×

### Details

**Proposed feature:**  
<!-- Type a description of your proposed feature below this line. -->
This change makes use of added separate events for local and global chats in , making it possible to change the formatting of messages sent from different chat types, as well as disable them altogether (for example, if you don't want to see local chat messages in Discord).

By default Essentials Discord will continue to use Bukkit chat events without any kind of separation, you must explicitly opt in to have new behaviour by changing use-essential-events to true.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 10 20H2.

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:
```
openjdk version "17" 2021-09-14 LTS
OpenJDK Runtime Environment Zulu17.28+13-CA (build 17+35-LTS)
OpenJDK 64-Bit Server VM Zulu17.28+13-CA (build 17+35-LTS, mixed mode, sharing)
```

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.18.1, git-Paper-71)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
![Screenshot of the Minecraft chat mirroring to Discord. Brawaru joins the server and says ‘hey’, it gets repeated to Discord as ‘Brawaru: hey’. Brawaru then says ‘now I will enable essentials events’. After enabling them Brawaru says ‘nothing has changed, since local chat is not enabled’, continued ‘I will now enable local chat’. Those messages were repeated to Discord as before. Brawaru then says ‘hello from local chat’, an ‘L’ appears at the beginning of his message, the message gets repeated in Discord as ‘[Local] Brawaru: hello from local chat’. Brawaru then uses question syntax and asks, ‘I am rather looking forward to this analysis, aren't you?’, it gives the message prefix ‘Question’, the same prefix appears in repeated Discord message. Brawaru then shouts ‘Agent Coomer, report to Topside Tactical Operations Center.’, it has ‘Shout’ prefix, the same prefix appears in Discord. In the end Brawaru says ‘now I set message-types.local to “none”, local chat is no longer visible in discord’; which is true and the message doesn't appear in Discord.](https://user-images.githubusercontent.com/10401817/145730615-94195eea-e882-4b9f-897d-049a1fbee6e4.png)

Fixed #4989