### PR TITLE
Run Actions builds for dev branches

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - 2.x
+    - dev/*
 
 jobs:
   build:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,6 +9,7 @@ on:
     branches:
     - 2.x
     - mc/*
+    - dev/*
 
 jobs:
   build:


### PR DESCRIPTION
Build `dev/*` branches and PRs made to those branches. Note that this won't deploy Javadocs or Maven artifacts, as we already check for the `2.x` branch.