### PR TITLE
Fix safelogin for 1.18 and above by using worldProvider minHeight

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
@@ -266,7 +266,7 @@ public final class LocationUtil {
         int y = (int) Math.round(loc.getY());
         final int z = loc.getBlockZ();
         int count = 0;
-        //Check whether more than 2 unsafe block are below player.
+        // Check whether more than 2 unsafe block are below player.
         while (LocationUtil.isBlockUnsafe(ess, world, x, y, z) && y >= ess.getWorldInfoProvider().getMinHeight(world)) {
             y--;
             count++;
@@ -275,7 +275,7 @@ public final class LocationUtil {
             }
         }
 
-        //If not then check if player is not in void
+        //If not then check if player is in the void
         return y < ess.getWorldInfoProvider().getMinHeight(world);
     }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
@@ -275,7 +275,7 @@ public final class LocationUtil {
             }
         }
 
-        //If not then check if player is in the void
+        // If not then check if player is in the void
         return y < ess.getWorldInfoProvider().getMinHeight(world);
     }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
@@ -266,6 +266,7 @@ public final class LocationUtil {
         int y = (int) Math.round(loc.getY());
         final int z = loc.getBlockZ();
         int count = 0;
+        //Check whether more than 2 unsafe block are below player.
         while (LocationUtil.isBlockUnsafe(ess, world, x, y, z) && y >= ess.getWorldInfoProvider().getMinHeight(world)) {
             y--;
             count++;
@@ -274,7 +275,8 @@ public final class LocationUtil {
             }
         }
 
-        return y < 0;
+        //If not then check if player is not in void
+        return y < ess.getWorldInfoProvider().getMinHeight(world);
     }
 
     public static class Vector3D {


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes #4665 . 

### Details

**Proposed fix:**    
<!-- Type a description of your proposed fix below this line. -->

There was already a partial fix for this (#4667) but the same improvement was missing for the else statement of the shouldFly function in LocationUtil.

We can now login below y=0 (tested with y=-63) and it does not enable fly mode if the player is actually in a safe location. It also fixed the safelogin when falling into the void for y <= -64 for versions >= 1.18.
It does not break backward compatibility for older versions of Minecraft.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Fedora 35

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  "17.0.1" 2021-10-19 LTS
<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8
- [x] Spigot 1.18.1 (CraftBukkit version 3368-Spigot-8965a50-2a2caa7 (MC: 1.18.1) (Implementing API version 1.18.1-R0.1-SNAPSHOT))

**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

As you can see we are no longer in fly mode just after logged in. (I ensure myself that fly mode was disabled before logging in back)

![2021-12-26_21 33 48](https://user-images.githubusercontent.com/22637850/147419416-cd56e9ff-8a28-47b8-9f47-70fa16043696.png)

![2021-12-26_21 34 05](https://user-images.githubusercontent.com/22637850/147419426-99dedb25-ae9c-4440-8795-51f9631b3f9f.png)

