### PR TITLE
Use GitHub proxy fallback for update checker

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
@@ -23,11 +23,11 @@ public final class UpdateChecker {
     private static final String REPO = "EssentialsX/Essentials";
     private static final String BRANCH = "2.x";
 
+    private static final String LATEST_RELEASE_URL = "https://api.github.com/repos/" + REPO + "/releases/latest";
     private static final String LATEST_RELEASE_PROXY_URL = "https://webapi.essentialsx.net/api/v1/github/essx-v2/releases/latest";
-    private static final String LATEST_RELEASE_FALLBACK_URL = "https://api.github.com/repos/" + REPO + "/releases/latest";
     // 0 = base for comparison, 1 = head for comparison - *not* the same as what this class calls them
+    private static final String DISTANCE_URL = "https://api.github.com/repos/EssentialsX/Essentials/compare/{0}...{1}";
     private static final String DISTANCE_PROXY_URL = "https://webapi.essentialsx.net/api/v1/github/essx-v2/compare/{0}/{1}";
-    private static final String DISTANCE_FALLBACK_URL = "https://api.github.com/repos/EssentialsX/Essentials/compare/{0}...{1}";
 
     private final Essentials ess;
     private final String versionIdentifier;
@@ -95,7 +95,7 @@ public final class UpdateChecker {
             new Thread(() -> {
                 catchBlock:
                 try {
-                    final HttpURLConnection connection = tryRequestWithFallback(LATEST_RELEASE_PROXY_URL, LATEST_RELEASE_FALLBACK_URL);
+                    final HttpURLConnection connection = tryRequestWithFallback(LATEST_RELEASE_URL, LATEST_RELEASE_PROXY_URL);
 
                     if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                         // Locally built?
@@ -182,7 +182,7 @@ public final class UpdateChecker {
 
     private RemoteVersion fetchDistance(final String head, final String hash) {
         try {
-            final HttpURLConnection connection = tryRequestWithFallback(MessageFormat.format(DISTANCE_PROXY_URL, head, hash), MessageFormat.format(DISTANCE_FALLBACK_URL, head, hash));
+            final HttpURLConnection connection = tryRequestWithFallback(MessageFormat.format(DISTANCE_URL, head, hash), MessageFormat.format(DISTANCE_PROXY_URL, head, hash));
 
             if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                 // Locally built?

--- a/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
@@ -146,10 +146,13 @@ public final class UpdateChecker {
         HttpURLConnection connection = (HttpURLConnection) new URL(mainUrl).openConnection();
         try {
             connection.connect();
+            if (connection.getResponseCode() != HttpURLConnection.HTTP_INTERNAL_ERROR && connection.getResponseCode() != HttpURLConnection.HTTP_FORBIDDEN) {
+                return connection;
+            }
         } catch (IOException e) {
             connection = (HttpURLConnection) new URL(fallbackUrl).openConnection();
             connection.connect();
-            // If the fallback fails, let the exception bubble up
+            // If the fallback fails, let the failure bubble up
         }
         return connection;
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
@@ -150,12 +150,14 @@ public final class UpdateChecker {
                 // Connection succeeded without any errors from GitHub's side.
                 return connection;
             }
-        } catch (IOException e) {
-            // Connection failed, GitHub's down or we hit a ratelimit, so use the fallback URL
-            connection = (HttpURLConnection) new URL(fallbackUrl).openConnection();
-            connection.connect();
-            // If the fallback fails, let the failure bubble up
+        } catch (IOException ignored) {
         }
+
+        // Connection failed, GitHub's down or we hit a ratelimit, so use the fallback URL
+        // If the fallback fails, let the exception or error status bubble up
+        connection = (HttpURLConnection) new URL(fallbackUrl).openConnection();
+        connection.connect();
+
         return connection;
     }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
@@ -1,7 +1,6 @@
 package com.earth2me.essentials.updatecheck;
 
 import com.earth2me.essentials.Essentials;
-import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
@@ -13,6 +12,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -22,6 +22,12 @@ import static com.earth2me.essentials.I18n.tl;
 public final class UpdateChecker {
     private static final String REPO = "EssentialsX/Essentials";
     private static final String BRANCH = "2.x";
+
+    private static final String LATEST_RELEASE_PROXY_URL = "https://webapi.essentialsx.net/api/v1/github/essx-v2/releases/latest";
+    private static final String LATEST_RELEASE_FALLBACK_URL = "https://api.github.com/repos/" + REPO + "/releases/latest";
+    // 0 = base for comparison, 1 = head for comparison - *not* the same as what this class calls them
+    private static final String DISTANCE_PROXY_URL = "https://webapi.essentialsx.net/api/v1/github/essx-v2/compare/{0}/{1}";
+    private static final String DISTANCE_FALLBACK_URL = "https://api.github.com/repos/EssentialsX/Essentials/compare/{0}...{1}";
 
     private final Essentials ess;
     private final String versionIdentifier;
@@ -89,8 +95,7 @@ public final class UpdateChecker {
             new Thread(() -> {
                 catchBlock:
                 try {
-                    final HttpURLConnection connection = (HttpURLConnection) new URL("https://api.github.com/repos/" + REPO + "/releases/latest").openConnection();
-                    connection.connect();
+                    final HttpURLConnection connection = tryRequestWithFallback(LATEST_RELEASE_PROXY_URL, LATEST_RELEASE_FALLBACK_URL);
 
                     if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                         // Locally built?
@@ -102,7 +107,7 @@ public final class UpdateChecker {
                         break catchBlock;
                     }
 
-                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))) {
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
                         latestRelease = new Gson().fromJson(reader, JsonObject.class).get("tag_name").getAsString();
                         pendingReleaseFuture.complete(cachedRelease = fetchDistance(latestRelease, getVersionIdentifier()));
                     } catch (JsonSyntaxException | NumberFormatException e) {
@@ -137,10 +142,47 @@ public final class UpdateChecker {
         return latestRelease;
     }
 
+    private HttpURLConnection tryRequestWithFallback(final String mainUrl, final String fallbackUrl) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(mainUrl).openConnection();
+        try {
+            connection.connect();
+        } catch (IOException e) {
+            connection = (HttpURLConnection) new URL(fallbackUrl).openConnection();
+            connection.connect();
+            // If the fallback fails, let the exception bubble up
+        }
+        return connection;
+    }
+
+    private RemoteVersion tryProcessDistance(final HttpURLConnection connection) throws IOException {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+            final JsonObject obj = new Gson().fromJson(reader, JsonObject.class);
+            switch (obj.get("status").getAsString()) {
+                case "identical": {
+                    return new RemoteVersion(BranchStatus.IDENTICAL, 0);
+                }
+                case "ahead": {
+                    return new RemoteVersion(BranchStatus.AHEAD, 0);
+                }
+                case "behind": {
+                    return new RemoteVersion(BranchStatus.BEHIND, obj.get("behind_by").getAsInt());
+                }
+                case "diverged": {
+                    return new RemoteVersion(BranchStatus.DIVERGED, obj.get("behind_by").getAsInt());
+                }
+                default: {
+                    return new RemoteVersion(BranchStatus.UNKNOWN);
+                }
+            }
+        } catch (JsonSyntaxException | NumberFormatException e) {
+            e.printStackTrace();
+            return new RemoteVersion(BranchStatus.ERROR);
+        }
+    }
+
     private RemoteVersion fetchDistance(final String head, final String hash) {
         try {
-            final HttpURLConnection connection = (HttpURLConnection) new URL("https://api.github.com/repos/" + REPO + "/compare/" + head + "..." + hash).openConnection();
-            connection.connect();
+            final HttpURLConnection connection = tryRequestWithFallback(MessageFormat.format(DISTANCE_PROXY_URL, head, hash), MessageFormat.format(DISTANCE_FALLBACK_URL, head, hash));
 
             if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
                 // Locally built?
@@ -150,29 +192,7 @@ public final class UpdateChecker {
                 return new RemoteVersion(BranchStatus.ERROR);
             }
 
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))) {
-                final JsonObject obj = new Gson().fromJson(reader, JsonObject.class);
-                switch (obj.get("status").getAsString()) {
-                    case "identical": {
-                        return new RemoteVersion(BranchStatus.IDENTICAL, 0);
-                    }
-                    case "ahead": {
-                        return new RemoteVersion(BranchStatus.AHEAD, 0);
-                    }
-                    case "behind": {
-                        return new RemoteVersion(BranchStatus.BEHIND, obj.get("behind_by").getAsInt());
-                    }
-                    case "diverged": {
-                        return new RemoteVersion(BranchStatus.DIVERGED, obj.get("behind_by").getAsInt());
-                    }
-                    default: {
-                        return new RemoteVersion(BranchStatus.UNKNOWN);
-                    }
-                }
-            } catch (JsonSyntaxException | NumberFormatException e) {
-                e.printStackTrace();
-                return new RemoteVersion(BranchStatus.ERROR);
-            }
+            return tryProcessDistance(connection);
         } catch (IOException e) {
             e.printStackTrace();
             return new RemoteVersion(BranchStatus.ERROR);

--- a/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
@@ -142,14 +142,16 @@ public final class UpdateChecker {
         return latestRelease;
     }
 
-    private HttpURLConnection tryRequestWithFallback(final String mainUrl, final String fallbackUrl) throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) new URL(mainUrl).openConnection();
+    private HttpURLConnection tryRequestWithFallback(final String githubUrl, final String fallbackUrl) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(githubUrl).openConnection();
         try {
             connection.connect();
             if (connection.getResponseCode() != HttpURLConnection.HTTP_INTERNAL_ERROR && connection.getResponseCode() != HttpURLConnection.HTTP_FORBIDDEN) {
+                // Connection succeeded without any errors from GitHub's side.
                 return connection;
             }
         } catch (IOException e) {
+            // Connection failed, GitHub's down or we hit a ratelimit, so use the fallback URL
             connection = (HttpURLConnection) new URL(fallbackUrl).openConnection();
             connection.connect();
             // If the fallback fails, let the failure bubble up


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR properly addresses #4574, where users on many hosts encounter rate limits when EssentialsX checks for updates.

### Details

**Proposed fix:**    
Use a caching proxy service that wraps around GitHub's API to reduce the chance of GitHub ratelimits. The update checker will still use the GitHub API directly if the caching proxy is unavailable.


**Environments tested:**    

**TODO: test properly**

<!-- Type the OS you have used below. -->
OS: Windows 11, 22000.527

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: Eclipse Temurin 17.0.1+12

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] Most recent Paper version (1.18.1, git-Paper-215)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8
