### PR TITLE
Fire SignChangeEvent on /editsign

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -67,12 +67,14 @@ import net.ess3.provider.ProviderListener;
 import net.ess3.provider.SerializationProvider;
 import net.ess3.provider.ServerStateProvider;
 import net.ess3.provider.SignDataProvider;
+import net.ess3.provider.SignUpdateProvider;
 import net.ess3.provider.SpawnEggProvider;
 import net.ess3.provider.SpawnerBlockProvider;
 import net.ess3.provider.SpawnerItemProvider;
 import net.ess3.provider.SyncCommandsProvider;
 import net.ess3.provider.WorldInfoProvider;
 import net.ess3.provider.providers.BasePotionDataProvider;
+import net.ess3.provider.providers.BaseSignUpdateProvider;
 import net.ess3.provider.providers.BlockMetaSpawnerItemProvider;
 import net.ess3.provider.providers.BukkitMaterialTagProvider;
 import net.ess3.provider.providers.BukkitSpawnerBlockProvider;
@@ -91,6 +93,7 @@ import net.ess3.provider.providers.PaperMaterialTagProvider;
 import net.ess3.provider.providers.PaperRecipeBookListener;
 import net.ess3.provider.providers.PaperSerializationProvider;
 import net.ess3.provider.providers.PaperServerStateProvider;
+import net.ess3.provider.providers.PaperSignUpdateProvider;
 import net.essentialsx.api.v2.services.BalanceTop;
 import net.essentialsx.api.v2.services.mail.MailService;
 import org.bukkit.Bukkit;
@@ -178,6 +181,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     private transient ItemUnbreakableProvider unbreakableProvider;
     private transient WorldInfoProvider worldInfoProvider;
     private transient SignDataProvider signDataProvider;
+    private transient SignUpdateProvider signUpdateProvider;
     private transient Kits kits;
     private transient RandomTeleport randomTeleport;
     private transient UpdateChecker updateChecker;
@@ -437,6 +441,12 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
             if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_14_4_R01)) {
                 signDataProvider = new ModernSignDataProvider(this);
+            }
+
+            if (PaperLib.isPaper()) {
+                signUpdateProvider = new PaperSignUpdateProvider();
+            } else {
+                signUpdateProvider = new BaseSignUpdateProvider();
             }
 
             execTimer.mark("Init(Providers)");
@@ -1316,6 +1326,11 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     @Override
     public SignDataProvider getSignDataProvider() {
         return signDataProvider;
+    }
+
+    @Override
+    public SignUpdateProvider getSignUpdateProvider() {
+        return signUpdateProvider;
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/IEssentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/IEssentials.java
@@ -17,6 +17,7 @@ import net.ess3.provider.PersistentDataProvider;
 import net.ess3.provider.SerializationProvider;
 import net.ess3.provider.ServerStateProvider;
 import net.ess3.provider.SignDataProvider;
+import net.ess3.provider.SignUpdateProvider;
 import net.ess3.provider.SpawnerBlockProvider;
 import net.ess3.provider.SpawnerItemProvider;
 import net.ess3.provider.SyncCommandsProvider;
@@ -167,6 +168,8 @@ public interface IEssentials extends Plugin {
     WorldInfoProvider getWorldInfoProvider();
 
     SignDataProvider getSignDataProvider();
+
+    SignUpdateProvider getSignUpdateProvider();
 
     PluginCommand getPluginCommand(String cmd);
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -390,6 +390,8 @@ public interface ISettings extends IConf {
 
     double getMaxProjectileSpeed();
 
+    boolean isSignEditSideEffects();
+
     boolean isRemovingEffectsOnHeal();
 
     boolean isSpawnIfNoHome();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -136,6 +136,7 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean logCommandBlockCommands;
     private Set<Predicate<String>> nickBlacklist;
     private double maxProjectileSpeed;
+    private boolean signEditSideEffects;
     private boolean removeEffectsOnHeal;
     private Map<String, String> worldAliases;
 
@@ -776,6 +777,7 @@ public class Settings implements net.ess3.api.ISettings {
         logCommandBlockCommands = _logCommandBlockCommands();
         nickBlacklist = _getNickBlacklist();
         maxProjectileSpeed = _getMaxProjectileSpeed();
+        signEditSideEffects = _isSignEditSideEffects();
         removeEffectsOnHeal = _isRemovingEffectsOnHeal();
         vanishingItemPolicy = _getVanishingItemsPolicy();
         bindingItemPolicy = _getBindingItemsPolicy();
@@ -1899,6 +1901,15 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public double getMaxProjectileSpeed() {
         return maxProjectileSpeed;
+    }
+
+    private boolean _isSignEditSideEffects() {
+        return config.getBoolean("sign-edit-side-effects", true);
+    }
+
+    @Override
+    public boolean isSignEditSideEffects() {
+        return signEditSideEffects;
     }
 
     private boolean _isRemovingEffectsOnHeal() {

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
@@ -1,9 +1,11 @@
 package com.earth2me.essentials.commands;
 
+import com.earth2me.essentials.IEssentials;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.NumberUtil;
 import com.google.common.collect.Lists;
+import net.ess3.provider.SignUpdateProvider;
 import org.bukkit.ChatColor;
 import org.bukkit.Server;
 import org.bukkit.block.Block;
@@ -38,19 +40,19 @@ public class Commandeditsign extends EssentialsCommand {
                     throw new Exception(tl("editsignCommandLimit"));
                 }
                 sign.setLine(line, text);
-                sign.update();
+                updateSign(sign, user);
                 user.sendMessage(tl("editsignCommandSetSuccess", line + 1, text));
             } else if (args[0].equalsIgnoreCase("clear")) {
                 if (args.length == 1) {
                     for (int i = 0; i < 4; i++) { // A whole one line of line savings!
                         sign.setLine(i, "");
                     }
-                    sign.update();
+                    updateSign(sign, user);
                     user.sendMessage(tl("editsignCommandClear"));
                 } else {
                     final int line = Integer.parseInt(args[1]) - 1;
                     sign.setLine(line, "");
-                    sign.update();
+                    updateSign(sign, user);
                     user.sendMessage(tl("editsignCommandClearLine", line + 1));
                 }
             } else if (args[0].equalsIgnoreCase("copy") || args[0].equalsIgnoreCase("paste")) {
@@ -67,10 +69,6 @@ public class Commandeditsign extends EssentialsCommand {
                     processSignCopyPaste(user, sign, line, copy);
                     user.sendMessage(tl(tlPrefix + "Line", line + 1, commandLabel));
                 }
-
-                if (!copy) {
-                    sign.update();
-                }
             } else {
                 throw new NotEnoughArgumentsException();
             }
@@ -79,7 +77,7 @@ public class Commandeditsign extends EssentialsCommand {
         }
     }
 
-    private void processSignCopyPaste(final User user, final Sign sign, final int index, final boolean copy) {
+    private void processSignCopyPaste(final User user, final Sign sign, final int index, final boolean copy) throws Exception {
         if (copy) {
             // We use unformat here to prevent players from copying signs with colors that they do not have permission to use.
             user.getSignCopy().set(index, FormatUtil.unformatString(user, "essentials.editsign", sign.getLine(index)));
@@ -88,6 +86,21 @@ public class Commandeditsign extends EssentialsCommand {
 
         final String line = FormatUtil.formatString(user, "essentials.editsign", user.getSignCopy().get(index));
         sign.setLine(index, line == null ? "" : line);
+        updateSign(sign, user);
+    }
+
+    private void updateSign(final Sign sign, final User user) throws Exception {
+        final IEssentials essentials = user.getEssentials();
+        final SignUpdateProvider provider = essentials.getSignUpdateProvider();
+
+        if (!essentials.getSettings().isSignEditSideEffects()) {
+            sign.update();
+            return;
+        }
+
+        if (!provider.updateSign(sign, user.getBase(), sign.getLines())) {
+            throw new Exception(tl("editsignCommandEventCancelled"));
+        }
     }
 
     @Override

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -730,6 +730,10 @@ log-command-block-commands: true
 # Set the maximum speed for projectiles spawned with /fireball.
 max-projectile-speed: 8
 
+# Should essentials notify other plugins when editing signs through the /editsign command.
+# Setting this to true also allows users to create essentials signs by using /editsign.
+sign-edit-side-effects: true
+
 # Should EssentialsX check for updates?
 # If set to true, EssentialsX will show notifications when a new version is available.
 # This uses the public GitHub API and no identifying information is sent or stored.

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -1128,6 +1128,7 @@ showkitCommandUsage1Description=Displays a summary of the items in the specified
 editsignCommandDescription=Edits a sign in the world.
 editsignCommandLimit=\u00a74Your provided text is too big to fit on the target sign.
 editsignCommandNoLine=\u00a74You must enter a line number between \u00a7c1-4\u00a74.
+editsignCommandEventCancelled=\u00a74The operation was cancelled by another plugin.
 editsignCommandSetSuccess=\u00a76Set line\u00a7c {0}\u00a76 to "\u00a7c{1}\u00a76".
 editsignCommandTarget=\u00a74You must be looking at a sign to edit its text.
 editsignCopy=\u00a76Sign copied! Paste it with \u00a7c/{0} paste\u00a76.

--- a/Essentials/src/main/resources/messages_en.properties
+++ b/Essentials/src/main/resources/messages_en.properties
@@ -1127,6 +1127,7 @@ showkitCommandUsage1Description=Displays a summary of the items in the specified
 editsignCommandDescription=Edits a sign in the world.
 editsignCommandLimit=§4Your provided text is too big to fit on the target sign.
 editsignCommandNoLine=§4You must enter a line number between §c1-4§4.
+editsignCommandEventCancelled=\u00a74The operation was cancelled by another plugin.
 editsignCommandSetSuccess=§6Set line§c {0}§6 to "§c{1}§6".
 editsignCommandTarget=§4You must be looking at a sign to edit its text.
 editsignCopy=§6Sign copied\! Paste it with §c/{0} paste§6.

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/SignUpdateProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/SignUpdateProvider.java
@@ -1,0 +1,8 @@
+package net.ess3.provider;
+
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+
+public interface SignUpdateProvider {
+    boolean updateSign(Sign sign, Player player, String[] lines);
+}

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BaseSignUpdateProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BaseSignUpdateProvider.java
@@ -1,0 +1,26 @@
+package net.ess3.provider.providers;
+
+import net.ess3.provider.SignUpdateProvider;
+import org.bukkit.Bukkit;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.SignChangeEvent;
+
+public class BaseSignUpdateProvider implements SignUpdateProvider {
+    @Override
+    public boolean updateSign(final Sign sign, final Player player, final String[] lines) {
+        final SignChangeEvent event = new SignChangeEvent(sign.getBlock(), player, lines);
+        Bukkit.getPluginManager().callEvent(event);
+
+        if (event.isCancelled()) {
+            return false;
+        }
+
+        for (int i = 0; i < lines.length; i++) {
+            sign.setLine(i, lines[i]);
+        }
+
+        sign.update();
+        return true;
+    }
+}

--- a/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperSignUpdateProvider.java
+++ b/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperSignUpdateProvider.java
@@ -1,0 +1,40 @@
+package net.ess3.provider.providers;
+
+import io.papermc.paper.text.PaperComponents;
+import net.ess3.provider.SignUpdateProvider;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.SignChangeEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PaperSignUpdateProvider implements SignUpdateProvider {
+    private final PlainTextComponentSerializer serializer = PaperComponents.plainTextSerializer();
+
+    @Override
+    public boolean updateSign(final Sign sign, final Player player, final String[] lines) {
+        final List<Component> components = new ArrayList<>();
+
+        for (String line : lines) {
+            components.add(serializer.deserialize(line));
+        }
+
+        final SignChangeEvent event = new SignChangeEvent(sign.getBlock(), player, components);
+        Bukkit.getPluginManager().callEvent(event);
+
+        if (event.isCancelled()) {
+            return false;
+        }
+
+        for (int i = 0; i < components.size(); i++) {
+            sign.line(i, components.get(i));
+        }
+
+        sign.update();
+        return true;
+    }
+}


### PR DESCRIPTION
### Information

This lets the ``/editsign`` command fire a ``SignChangeEvent`` when it's being executed, based on a new config option. It also contains a new translation key for when a plugin cancels the event.

### Details

**Proposed feature:**  
Currently essentials doesn't allow the ``/editsign`` command to interface with functional signs of other plugins like Craftbook, because they use the ``SignChangeEvent`` for recognizing when a sign is created. This adds a config option to let essentials fire this event and make other plugins aware of the change on the sign.

**Environments tested:**    

OS: Windows
Java version:  OpenJdk 17

- [x] Most recent Paper version (1.18.1, git-Paper-216)
- [x] CraftBukkit/Spigot 1.12.2
- [x] CraftBukkit 1.8.8

**Demonstration:**  
**_Test setup_**
I wrote a small plugin that has a 50% probability of cancelling the ``SignChangeEvent`` and that prints the lines that the event is trying to write in chat.

**_Tests_**
With the config option set to true and the event being let through:
![2022-03-01_19 28 55](https://user-images.githubusercontent.com/36546810/156228018-ffebcf26-5401-47df-9593-d297ec027930.png)

With the config option set to true and the event being cancelled ("cancelling event" message is from the test plugin): 
![2022-03-01_19 29 19](https://user-images.githubusercontent.com/36546810/156228322-c1c93cfe-f146-4176-b8db-357fc44875f8.png)

With the config option set to false:
![2022-03-01_19 31 45](https://user-images.githubusercontent.com/36546810/156228352-a2b8c787-7325-4d8d-83dc-f4e8484c8b81.png)

(sorry that the essentials locale is set to german in the test setup)