### PR TITLE
ESSX Discord: Added a check for announceAdvancements gamerule

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -195,6 +195,10 @@ public class BukkitListener implements Listener {
         if (isVanishHide(event.getPlayer())) {
             return;
         }
+        
+        if (event.getPlayer().getWorld().getGameRuleValue(GameRule.ANNOUNCE_ADVANCEMENTS) == false) { 
+            return;
+        }
 
         sendDiscordMessage(MessageType.DefaultTypes.ADVANCEMENT,
                 MessageUtil.formatMessage(jda.getSettings().getAdvancementFormat(event.getPlayer()),


### PR DESCRIPTION
### Information

This PR fixes #4865.

### Details

**Proposed fix:**    
Added a check for the player's current world's announceAdvancements gamerule in the advancements listener to prevent the message from being sent if that gamerule is disabled for the world.

**Environments tested:**    

OS:  Windows 10 for client, assuming some version of Ubuntu LTS for the server (server provider doesn't specify, so assuming the same as what they run for VPS services)

Java version:  Built on openjdk 17.0.1, ran on unknown version of Java 17 (server provider doesn't specify beyond 17)

- [x] Paper 1.18 (can upgrade server to test if necessary)
- [ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:** 
Before fix, while testing the gamerule 
(Only the first one should've been sent, the rest are erroneous from the advancement being automatically revoked)
![image](https://user-images.githubusercontent.com/4555773/159422880-5e1ce403-ff83-407b-9e4f-950de6752c33.png)
After fix, only one advancement sent, even after completing the criteria multiple times in a world with announceAdvancements disabled.
![image](https://user-images.githubusercontent.com/4555773/159423197-52b98bba-e6b4-4075-bddc-f6ff572555f8.png)
