### PR TITLE
Reduce user lookups for LuckPerms contexts

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/perm/IPermissionsHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/IPermissionsHandler.java
@@ -1,5 +1,7 @@
 package com.earth2me.essentials.perm;
 
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.TriState;
 import org.bukkit.entity.Player;
 
@@ -27,11 +29,11 @@ public interface IPermissionsHandler {
 
     String getSuffix(Player base);
 
-    void registerContext(String context, Function<Player, Iterable<String>> calculator, Supplier<Iterable<String>> suggestions);
+    void registerContext(String context, Function<User, Iterable<String>> calculator, Supplier<Iterable<String>> suggestions);
 
     void unregisterContexts();
 
     String getBackendName();
 
-    boolean tryProvider();
+    boolean tryProvider(Essentials ess);
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/perm/PermissionsHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/PermissionsHandler.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.perm;
 
 import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
 import com.earth2me.essentials.perm.impl.AbstractVaultHandler;
 import com.earth2me.essentials.perm.impl.ConfigPermissionsHandler;
 import com.earth2me.essentials.perm.impl.GenericVaultHandler;
@@ -105,7 +106,7 @@ public class PermissionsHandler implements IPermissionsHandler {
     }
 
     @Override
-    public void registerContext(final String context, final Function<Player, Iterable<String>> calculator, final Supplier<Iterable<String>> suggestions) {
+    public void registerContext(final String context, final Function<User, Iterable<String>> calculator, final Supplier<Iterable<String>> suggestions) {
         handler.registerContext(context, calculator, suggestions);
     }
 
@@ -120,7 +121,7 @@ public class PermissionsHandler implements IPermissionsHandler {
     }
 
     @Override
-    public boolean tryProvider() {
+    public boolean tryProvider(Essentials ess) {
         return true;
     }
 
@@ -135,7 +136,7 @@ public class PermissionsHandler implements IPermissionsHandler {
         for (final Class<? extends IPermissionsHandler> providerClass : providerClazz) {
             try {
                 final IPermissionsHandler provider = providerClass.newInstance();
-                if (provider.tryProvider()) {
+                if (provider.tryProvider(ess)) {
                     if (provider.getClass().isInstance(this.handler)) {
                         return;
                     }
@@ -170,7 +171,7 @@ public class PermissionsHandler implements IPermissionsHandler {
             if (enabledPermsPlugin == null) enabledPermsPlugin = "generic";
             ess.getLogger().info("Using Vault based permissions (" + enabledPermsPlugin + ")");
         } else if (handler.getClass() == SuperpermsHandler.class) {
-            if (handler.tryProvider()) {
+            if (handler.tryProvider(ess)) {
                 ess.getLogger().warning("Detected supported permissions plugin " +
                     ((SuperpermsHandler) handler).getEnabledPermsPlugin() + " without Vault installed.");
                 ess.getLogger().warning("Features such as chat prefixes/suffixes and group-related functionality will not " +
@@ -199,11 +200,11 @@ public class PermissionsHandler implements IPermissionsHandler {
     }
 
     private void initContexts() {
-        registerContext("essentials:afk", player -> Collections.singleton(String.valueOf(ess.getUser(player).isAfk())), () -> ImmutableSet.of("true", "false"));
-        registerContext("essentials:muted", player -> Collections.singleton(String.valueOf(ess.getUser(player).isMuted())), () -> ImmutableSet.of("true", "false"));
-        registerContext("essentials:vanished", player -> Collections.singleton(String.valueOf(ess.getUser(player).isHidden())), () -> ImmutableSet.of("true", "false"));
-        registerContext("essentials:jailed", player -> Collections.singleton(String.valueOf(ess.getUser(player).isJailed())), () -> ImmutableSet.of("true", "false"));
-        registerContext("essentials:jail", player -> Optional.ofNullable(ess.getUser(player).getJail()).map(Arrays::asList).orElse(Collections.emptyList()), () -> {
+        registerContext("essentials:afk", user -> Collections.singleton(String.valueOf(user.isAfk())), () -> ImmutableSet.of("true", "false"));
+        registerContext("essentials:muted", user -> Collections.singleton(String.valueOf(user.isMuted())), () -> ImmutableSet.of("true", "false"));
+        registerContext("essentials:vanished", user -> Collections.singleton(String.valueOf(user.isHidden())), () -> ImmutableSet.of("true", "false"));
+        registerContext("essentials:jailed", user -> Collections.singleton(String.valueOf(user.isJailed())), () -> ImmutableSet.of("true", "false"));
+        registerContext("essentials:jail", user -> Optional.ofNullable(user.getJail()).map(Arrays::asList).orElse(Collections.emptyList()), () -> {
             try {
                 return ess.getJails().getList();
             } catch (final Exception e) {

--- a/Essentials/src/main/java/com/earth2me/essentials/perm/impl/ConfigPermissionsHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/impl/ConfigPermissionsHandler.java
@@ -1,5 +1,6 @@
 package com.earth2me.essentials.perm.impl;
 
+import com.earth2me.essentials.Essentials;
 import com.earth2me.essentials.utils.TriState;
 import net.ess3.api.IEssentials;
 import org.bukkit.entity.Player;
@@ -35,7 +36,7 @@ public class ConfigPermissionsHandler extends SuperpermsHandler {
     }
 
     @Override
-    public boolean tryProvider() {
+    public boolean tryProvider(Essentials ess) {
         return true;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/perm/impl/GenericVaultHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/impl/GenericVaultHandler.java
@@ -1,8 +1,10 @@
 package com.earth2me.essentials.perm.impl;
 
+import com.earth2me.essentials.Essentials;
+
 public class GenericVaultHandler extends AbstractVaultHandler {
     @Override
-    public boolean tryProvider() {
+    public boolean tryProvider(Essentials ess) {
         return super.canLoad();
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/perm/impl/LuckPermsHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/impl/LuckPermsHandler.java
@@ -1,5 +1,8 @@
 package com.earth2me.essentials.perm.impl;
 
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
+
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.context.ContextCalculator;
 import net.luckperms.api.context.ContextConsumer;
@@ -16,40 +19,75 @@ import java.util.function.Supplier;
 
 public class LuckPermsHandler extends ModernVaultHandler {
     private LuckPerms luckPerms;
-    private Set<ContextCalculator<Player>> contextCalculators;
+    private Essentials ess;
+    private CombinedCalculator calculator;
 
     @Override
-    public void registerContext(final String context, final Function<Player, Iterable<String>> calculator, final Supplier<Iterable<String>> suggestions) {
-        final ContextCalculator<Player> contextCalculator = new ContextCalculator<Player>() {
-            @Override
-            public void calculate(final Player target, final ContextConsumer consumer) {
-                calculator.apply(target).forEach(value -> consumer.accept(context, value));
-            }
-
-            @Override
-            public ContextSet estimatePotentialContexts() {
-                final ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
-                suggestions.get().forEach(value -> builder.add(context, value));
-                return builder.build();
-            }
-        };
-        luckPerms.getContextManager().registerCalculator(contextCalculator);
-        contextCalculators.add(contextCalculator);
+    public void registerContext(final String context, final Function<User, Iterable<String>> calculator, final Supplier<Iterable<String>> suggestions) {
+        if (this.calculator == null) {
+            this.calculator = new CombinedCalculator();
+            this.luckPerms.getContextManager().registerCalculator(this.calculator);
+        }
+        this.calculator.calculators.add(new Calculator(context, calculator, suggestions));
     }
 
     @Override
     public void unregisterContexts() {
-        contextCalculators.forEach(contextCalculator -> luckPerms.getContextManager().unregisterCalculator(contextCalculator));
-        contextCalculators.clear();
+        if (this.calculator != null) {
+            this.luckPerms.getContextManager().unregisterCalculator(this.calculator);
+            this.calculator = null;
+        }
     }
 
     @Override
-    public boolean tryProvider() {
+    public boolean tryProvider(Essentials ess) {
         final RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
         if (provider != null) {
-            luckPerms = provider.getProvider();
-            contextCalculators = new HashSet<>();
+            this.luckPerms = provider.getProvider();
+            this.ess = ess;
         }
-        return luckPerms != null && super.tryProvider();
+        return luckPerms != null && super.tryProvider(ess);
+    }
+
+    private static final class Calculator {
+        private final String id;
+        private final Function<User, Iterable<String>> function;
+        private final Supplier<Iterable<String>> suggestions;
+
+        private Calculator(String id, Function<User, Iterable<String>> function, Supplier<Iterable<String>> suggestions) {
+            this.id = id;
+            this.function = function;
+            this.suggestions = suggestions;
+        }
+    }
+
+    // By combining all calculators into one, we only need to make one call to ess.getUser().
+    private class CombinedCalculator implements ContextCalculator<Player> {
+        private final Set<Calculator> calculators = new HashSet<>();
+
+        @Override
+        public void calculate(final Player target, final ContextConsumer consumer) {
+            // If the player doesn't exist in the UserMap, just skip
+            // Ess will cause performance problems for permissions checks if it attempts to
+            // perform i/o to load the user data otherwise.
+            if (!ess.getUserMap().userExists(target.getUniqueId())) {
+                return;
+            }
+
+            final User user = ess.getUser(target);
+            for (Calculator calculator : this.calculators) {
+                calculator.function.apply(user).forEach(value -> consumer.accept(calculator.id, value));
+            }
+        }
+
+        @Override
+        public ContextSet estimatePotentialContexts() {
+            final ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
+            for (Calculator calculator : this.calculators) {
+                calculator.suggestions.get().forEach(value -> builder.add(calculator.id, value));
+            }
+
+            return builder.build();
+        }
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/perm/impl/ModernVaultHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/impl/ModernVaultHandler.java
@@ -1,5 +1,7 @@
 package com.earth2me.essentials.perm.impl;
 
+import com.earth2me.essentials.Essentials;
+
 import org.bukkit.entity.Player;
 
 import java.util.Arrays;
@@ -21,7 +23,7 @@ public class ModernVaultHandler extends AbstractVaultHandler {
     }
 
     @Override
-    public boolean tryProvider() {
+    public boolean tryProvider(Essentials ess) {
         return super.canLoad() && supportedPlugins.contains(getEnabledPermsPlugin());
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/perm/impl/SuperpermsHandler.java
@@ -1,5 +1,7 @@
 package com.earth2me.essentials.perm.impl;
 
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
 import com.earth2me.essentials.perm.IPermissionsHandler;
 import com.earth2me.essentials.utils.TriState;
 import org.bukkit.Bukkit;
@@ -124,7 +126,7 @@ public class SuperpermsHandler implements IPermissionsHandler {
     }
 
     @Override
-    public void registerContext(final String context, final Function<Player, Iterable<String>> calculator, final Supplier<Iterable<String>> suggestions) {
+    public void registerContext(final String context, final Function<User, Iterable<String>> calculator, final Supplier<Iterable<String>> suggestions) {
     }
 
     @Override
@@ -137,7 +139,7 @@ public class SuperpermsHandler implements IPermissionsHandler {
     }
 
     @Override
-    public boolean tryProvider() {
+    public boolean tryProvider(Essentials ess) {
         return getEnabledPermsPlugin() != null;
     }
 


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

Resolves some performance issues with Essentials permission contexts.

Apologies, I have misplaced the profiles, but was prompted to fix these issues by https://github.com/LuckPerms/LuckPerms/issues/3346

The issues stem from the call to `ess.getUser()` and the usermap.

Firstly, this call is repeated multiple times - once for each context. I have refactored so it is only called once, and the context functions accept a User instead.

Secondly, in some edge cases, it seems that Ess will not have a User object cached in memory, and the call to ess.getUser will result in i/o as the config file has to be queried.

This is a big issue, the calculators are called very frequently and often in hot code paths in the server/game.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: macos

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: 
```
openjdk version "17" 2021-09-14
OpenJDK Runtime Environment Temurin-17+35 (build 17+35)
OpenJDK 64-Bit Server VM Temurin-17+35 (build 17+35, mixed mode)
```

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8

```
[21:29:52 INFO]: This server is running Paper version git-Paper-225 (MC: 1.18.2) (Implementing API version 1.18.2-R0.1-SNAPSHOT) (Git: 1d7a6a0)
```


**Demonstration:**    
```
[21:27:47 INFO]: Done (5.669s)! For help, type "help"
[21:27:47 INFO]: Timings Reset
[21:27:47 INFO]: [Vault] Checking for Updates ...
[21:27:47 INFO]: [Vault] No new version available
[21:27:47 WARN]: [Essentials] You're running an up to date experimental EssentialsX build!
[21:27:47 WARN]: [Essentials] Feature Branch: fix/contexts.
[21:28:15 INFO]: UUID of player Luck is c1d60c50-70b5-4722-8057-87767557e50d
[21:28:16 INFO]: Luck joined the game
[21:28:16 INFO]: Luck[/127.0.0.1:56192] logged in with entity id 21 at ([world]2363.0061320688446, 63.0, 5452.636999732005)
[21:28:16 WARN]: [Essentials] File motd.txt does not exist. Creating one for you.
> lp user Luck info
[21:28:28 INFO]: [LP] > User Info: luck
[21:28:28 INFO]: [LP] - UUID: c1d60c50-70b5-4722-8057-87767557e50d
[21:28:28 INFO]: [LP]     (type: official)
[21:28:28 INFO]: [LP] - Status: Online
[21:28:28 INFO]: [LP] - Parent Groups:
[21:28:28 INFO]: [LP]     > default
[21:28:28 INFO]: [LP] - Contextual Data: (mode: active player)
[21:28:28 INFO]: [LP]     Contexts: (dimension-type=overworld) (essentials:afk=false) (essentials:jailed=false) (essentials:muted=false) (essentials:vanished=false) (gamemode=creative) (world=world)
[21:28:28 INFO]: [LP]     Prefix: None
[21:28:28 INFO]: [LP]     Suffix: None
[21:28:28 INFO]: [LP]     Primary Group: default
[21:28:28 INFO]: [LP]     Meta: (primarygroup=default)
```

