### PR TITLE
Add /ls as an alias of /list

### DIFF
--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -279,7 +279,7 @@ commands:
   list:
     description: List all online players.
     usage: /<command> [group]
-    aliases: [elist,online,eonline,playerlist,eplayerlist,plist,eplist,who,ewho]
+    aliases: [elist,online,eonline,playerlist,eplayerlist,plist,eplist,who,ewho,ls,els]
   loom:
     description: Opens up a loom.
     usage: /<command>


### PR DESCRIPTION
The common linux command `ls` as `/ls` in essentials would be nice for as a shorthand for `/list` in essentials
