### PR TITLE
Bump down to 2.19.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To add EssentialsX to your build system, you should use the following artifacts:
 | Type           | Group ID          | Artifact ID   | Version           |
 |:---------------|:------------------|:--------------|:------------------|
 | Latest release | `net.essentialsx` | `EssentialsX` | `2.19.4`          |
-| Snapshots      | `net.essentialsx` | `EssentialsX` | `2.20.0-SNAPSHOT` |
+| Snapshots      | `net.essentialsx` | `EssentialsX` | `2.19.5-SNAPSHOT` |
 | Older releases | `net.ess3`        | `EssentialsX` | `2.18.2`          |
 
 Note: up until `2.18.2`, EssentialsX used the `net.ess3` group ID, but starting with `2.19.0` snapshots, the group ID is now `net.essentialsx`.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "net.essentialsx"
-version = "2.20.0-SNAPSHOT"
+version = "2.19.5-SNAPSHOT"
 
 project.ext {
     GIT_COMMIT = !indraGit.isPresent() ? "unknown" : indraGit.commit().abbreviate(7).name()


### PR DESCRIPTION
Mojang will be releasing 1.19 within two weeks and 2.20.0 is not ready
for that timeframe. We want to release 2.19.5 with 1.19 support before
that.