### PR TITLE
Don't progress playtime for vanished users

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -92,6 +92,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
     private long lastHomeConfirmationTimestamp;
     private Boolean toggleShout;
     private transient final List<String> signCopy = Lists.newArrayList("", "", "", "");
+    private transient long lastVanishTime = System.currentTimeMillis();
 
     public User(final Player base, final IEssentials ess) {
         super(base, ess);
@@ -964,6 +965,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
                 }
             }
             setHidden(true);
+            lastVanishTime = System.currentTimeMillis();
             ess.getVanishedPlayersNew().add(getName());
             this.getBase().setMetadata("vanished", new FixedMetadataValue(ess, true));
             if (isAuthorized("essentials.vanish.effect")) {
@@ -1188,6 +1190,10 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             return exempt;
         }
         return isBaltopExcludeCache();
+    }
+
+    public long getLastVanishTime() {
+        return lastVanishTime;
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandplaytime.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandplaytime.java
@@ -44,7 +44,7 @@ public class Commandplaytime extends EssentialsCommand {
                 displayName = user.getName(); // Vanished players will have their name as their display name
                 playtime = Bukkit.getOfflinePlayer(user.getBase().getUniqueId()).getStatistic(PLAY_ONE_TICK);
                 if (user.getBase().isOnline() && user.isVanished()) {
-                    playtime = playtime - ((System.currentTimeMillis() - user.getLastLogin()) / 50L);
+                    playtime = playtime - ((System.currentTimeMillis() - user.getLastVanishTime()) / 50L);
                 }
             }
             key = "playtimeOther";

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandplaytime.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandplaytime.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
+import com.earth2me.essentials.User;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.EnumUtil;
 import com.earth2me.essentials.utils.VersionUtil;
@@ -39,9 +40,12 @@ public class Commandplaytime extends EssentialsCommand {
                 if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_15_2_R01)) {
                     throw e;
                 }
-                final IUser user = getPlayer(server, sender, args, 0, true);
-                displayName = user.getName();
+                final User user = getPlayer(server, args, 0, true, true);
+                displayName = user.getName(); // Vanished players will have their name as their display name
                 playtime = Bukkit.getOfflinePlayer(user.getBase().getUniqueId()).getStatistic(PLAY_ONE_TICK);
+                if (user.getBase().isOnline() && user.isVanished()) {
+                    playtime = playtime - ((System.currentTimeMillis() - user.getLastLogin()) / 50L);
+                }
             }
             key = "playtimeOther";
         } else if (sender.isPlayer()) {


### PR DESCRIPTION
Shows the ticks played since last login for vanished players. This will only affect users who cannot see the vanished player.

Fixes #4917