### PR TITLE
Fix Essentials' logger breaking on 1.8.8-1.12.2

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -205,7 +205,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     }
 
     public void setupForTesting(final Server server) throws IOException, InvalidDescriptionException {
-        LOGGER = new BaseLoggerProvider(BUKKIT_LOGGER);
+        LOGGER = new BaseLoggerProvider(this, BUKKIT_LOGGER);
         final File dataFolder = File.createTempFile("essentialstest", "");
         if (!dataFolder.delete()) {
             throw new IOException();
@@ -250,6 +250,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 BUKKIT_LOGGER.setParent(super.getLogger());
             }
             LOGGER = EssentialsLogger.getLoggerProvider(this);
+            EssentialsLogger.updatePluginLogger(this);
 
             execTimer = new ExecuteTimer();
             execTimer.start();
@@ -477,7 +478,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
             final String timeroutput = execTimer.end();
             if (getSettings().isDebug()) {
-                LOGGER.log(Level.INFO, "Essentials load {0}", timeroutput);
+                LOGGER.log(Level.INFO, "Essentials load " + timeroutput);
             }
         } catch (final NumberFormatException ex) {
             handleCrash(ex);
@@ -486,15 +487,6 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             throw ex;
         }
         getBackup().setPendingShutdown(false);
-    }
-
-    @Override
-    public Logger getLogger() {
-        if (LOGGER != null) {
-            return LOGGER;
-        }
-
-        return super.getLogger();
     }
 
     // Returns our provider logger if available
@@ -755,10 +747,10 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
             if (bSenderBlock != null) {
                 if (getSettings().logCommandBlockCommands()) {
-                    LOGGER.log(Level.INFO, "CommandBlock at {0},{1},{2} issued server command: /{3} {4}", new Object[] {bSenderBlock.getX(), bSenderBlock.getY(), bSenderBlock.getZ(), commandLabel, EssentialsCommand.getFinalArg(args, 0)});
+                    LOGGER.log(Level.INFO, "CommandBlock at " + bSenderBlock.getX() + "," + bSenderBlock.getY() + "," + bSenderBlock.getZ() + " issued server command: /" + commandLabel + " " + EssentialsCommand.getFinalArg(args, 0));
                 }
             } else if (user == null) {
-                LOGGER.log(Level.INFO, "{0} issued server command: /{1} {2}", new Object[] {cSender.getName(), commandLabel, EssentialsCommand.getFinalArg(args, 0)});
+                LOGGER.log(Level.INFO, cSender.getName()+ " issued server command: /" + commandLabel + " " + EssentialsCommand.getFinalArg(args, 0));
             }
 
             final CommandSource sender = new CommandSource(cSender);
@@ -1070,7 +1062,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
         if (user == null) {
             if (getSettings().isDebug()) {
-                LOGGER.log(Level.INFO, "Constructing new userfile from base player {0}", base.getName());
+                LOGGER.log(Level.INFO, "Constructing new userfile from base player " + base.getName());
             }
             user = new User(base, this);
         } else {

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsLogger.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsLogger.java
@@ -6,13 +6,29 @@ import net.ess3.provider.providers.BaseLoggerProvider;
 import net.ess3.provider.providers.PaperLoggerProvider;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public final class EssentialsLogger {
     private final static Map<String, LoggerProvider> loggerProviders = new HashMap<>();
+    private final static MethodHandle loggerFieldHandle;
+
+    static {
+        try {
+            final Field loggerField = ReflUtil.getFieldCached(JavaPlugin.class, "logger");
+            //noinspection ConstantConditions
+            loggerFieldHandle = MethodHandles.lookup().unreflectSetter(loggerField);
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to get logger field handle", t);
+        }
+    }
 
     private EssentialsLogger() {
     }
@@ -22,14 +38,26 @@ public final class EssentialsLogger {
             return loggerProviders.get(plugin.getName());
         }
 
+        final Logger parentLogger = Logger.getLogger(plugin.getName());
         final LoggerProvider provider;
         if (ReflUtil.getClassCached("io.papermc.paper.adventure.providers.ComponentLoggerProviderImpl") != null) {
             provider = new PaperLoggerProvider(plugin);
+            provider.setParent(parentLogger);
         } else {
-            provider = new BaseLoggerProvider(Logger.getLogger(plugin.getName()));
+            provider = new BaseLoggerProvider(plugin, parentLogger);
+            provider.setParent(parentLogger);
         }
         loggerProviders.put(plugin.getName(), provider);
         return provider;
+    }
+
+    public static void updatePluginLogger(final Plugin plugin) {
+        final LoggerProvider provider = getLoggerProvider(plugin);
+        try {
+            loggerFieldHandle.invoke(plugin, provider);
+        } catch (Throwable e) {
+            provider.log(Level.SEVERE, "Failed to update " + plugin.getName() + " logger", e);
+        }
     }
 
     public static LoggerProvider getLoggerProvider(final String pluginName) {

--- a/EssentialsAntiBuild/src/main/java/com/earth2me/essentials/antibuild/EssentialsAntiBuild.java
+++ b/EssentialsAntiBuild/src/main/java/com/earth2me/essentials/antibuild/EssentialsAntiBuild.java
@@ -10,7 +10,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 public class EssentialsAntiBuild extends JavaPlugin implements IAntiBuild {
     private final transient Map<AntiBuildConfig, Boolean> settingsBoolean = new EnumMap<>(AntiBuildConfig.class);
@@ -29,6 +28,7 @@ public class EssentialsAntiBuild extends JavaPlugin implements IAntiBuild {
         if (essPlugin == null || !essPlugin.isEnabled()) {
             return;
         }
+        EssentialsLogger.updatePluginLogger(this);
         ess = new EssentialsConnect(essPlugin, this);
 
         final EssentialsAntiBuildListener blockListener = new EssentialsAntiBuildListener(this);
@@ -36,16 +36,6 @@ public class EssentialsAntiBuild extends JavaPlugin implements IAntiBuild {
 
         if (metrics == null) {
             metrics = new MetricsWrapper(this, 3813, false);
-        }
-    }
-
-    @Override
-    public Logger getLogger() {
-        try {
-            return EssentialsLogger.getLoggerProvider(this);
-        } catch (Throwable ignored) {
-            // In case Essentials isn't installed/loaded
-            return super.getLogger();
         }
     }
 

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/EssentialsChat.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/EssentialsChat.java
@@ -13,7 +13,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static com.earth2me.essentials.I18n.tl;
 
@@ -23,6 +22,7 @@ public class EssentialsChat extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        EssentialsLogger.updatePluginLogger(this);
         final PluginManager pluginManager = getServer().getPluginManager();
         ess = (IEssentials) pluginManager.getPlugin("Essentials");
         if (!this.getDescription().getVersion().equals(ess.getDescription().getVersion())) {
@@ -44,16 +44,6 @@ public class EssentialsChat extends JavaPlugin {
 
         if (metrics == null) {
             metrics = new MetricsWrapper(this, 3814, false);
-        }
-    }
-
-    @Override
-    public Logger getLogger() {
-        try {
-            return EssentialsLogger.getLoggerProvider(this);
-        } catch (Throwable ignored) {
-            // In case Essentials isn't installed/loaded
-            return super.getLogger();
         }
     }
 

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/EssentialsDiscord.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/EssentialsDiscord.java
@@ -27,6 +27,7 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
 
     @Override
     public void onEnable() {
+        EssentialsLogger.updatePluginLogger(this);
         ess = (IEssentials) getServer().getPluginManager().getPlugin("Essentials");
         if (ess == null || !ess.isEnabled()) {
             setEnabled(false);
@@ -64,16 +65,6 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
                 }
                 jda.shutdown();
             }
-        }
-    }
-
-    @Override
-    public Logger getLogger() {
-        try {
-            return EssentialsLogger.getLoggerProvider(this);
-        } catch (Throwable ignored) {
-            // In case Essentials isn't installed/loaded
-            return super.getLogger();
         }
     }
 

--- a/EssentialsGeoIP/src/main/java/com/earth2me/essentials/geoip/EssentialsGeoIP.java
+++ b/EssentialsGeoIP/src/main/java/com/earth2me/essentials/geoip/EssentialsGeoIP.java
@@ -17,6 +17,7 @@ public class EssentialsGeoIP extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        EssentialsLogger.updatePluginLogger(this);
         final PluginManager pm = getServer().getPluginManager();
         final IEssentials ess = (IEssentials) pm.getPlugin("Essentials");
         if (!this.getDescription().getVersion().equals(ess.getDescription().getVersion())) {
@@ -36,16 +37,6 @@ public class EssentialsGeoIP extends JavaPlugin {
 
         if (metrics == null) {
             metrics = new MetricsWrapper(this, 3815, false);
-        }
-    }
-
-    @Override
-    public Logger getLogger() {
-        try {
-            return EssentialsLogger.getLoggerProvider(this);
-        } catch (Throwable ignored) {
-            // In case Essentials isn't installed/loaded
-            return super.getLogger();
         }
     }
 

--- a/EssentialsProtect/src/main/java/com/earth2me/essentials/protect/EssentialsProtect.java
+++ b/EssentialsProtect/src/main/java/com/earth2me/essentials/protect/EssentialsProtect.java
@@ -14,7 +14,6 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class EssentialsProtect extends JavaPlugin implements IProtect {
     private final Map<ProtectConfig, Boolean> settingsBoolean = new EnumMap<>(ProtectConfig.class);
@@ -26,6 +25,7 @@ public class EssentialsProtect extends JavaPlugin implements IProtect {
 
     @Override
     public void onEnable() {
+        EssentialsLogger.updatePluginLogger(this);
         final PluginManager pm = this.getServer().getPluginManager();
         final Plugin essPlugin = pm.getPlugin("Essentials");
         if (essPlugin == null || !essPlugin.isEnabled()) {
@@ -37,16 +37,6 @@ public class EssentialsProtect extends JavaPlugin implements IProtect {
 
         if (metrics == null) {
             metrics = new MetricsWrapper(this, 3816, false);
-        }
-    }
-
-    @Override
-    public Logger getLogger() {
-        try {
-            return EssentialsLogger.getLoggerProvider(this);
-        } catch (Throwable ignored) {
-            // In case Essentials isn't installed/loaded
-            return super.getLogger();
         }
     }
 

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawn.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawn.java
@@ -24,6 +24,7 @@ public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn {
 
     @Override
     public void onEnable() {
+        EssentialsLogger.updatePluginLogger(this);
         final PluginManager pluginManager = getServer().getPluginManager();
         ess = (IEssentials) pluginManager.getPlugin("Essentials");
         if (!this.getDescription().getVersion().equals(ess.getDescription().getVersion())) {
@@ -53,16 +54,6 @@ public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn {
 
         if (metrics == null) {
             metrics = new MetricsWrapper(this, 3817, true);
-        }
-    }
-
-    @Override
-    public Logger getLogger() {
-        try {
-            return EssentialsLogger.getLoggerProvider(this);
-        } catch (Throwable ignored) {
-            // In case Essentials isn't installed/loaded
-            return super.getLogger();
         }
     }
 

--- a/EssentialsXMPP/src/main/java/com/earth2me/essentials/xmpp/EssentialsXMPP.java
+++ b/EssentialsXMPP/src/main/java/com/earth2me/essentials/xmpp/EssentialsXMPP.java
@@ -35,6 +35,7 @@ public class EssentialsXMPP extends JavaPlugin implements IEssentialsXMPP {
 
     @Override
     public void onEnable() {
+        EssentialsLogger.updatePluginLogger(this);
         instance = this;
 
         final PluginManager pluginManager = getServer().getPluginManager();
@@ -59,16 +60,6 @@ public class EssentialsXMPP extends JavaPlugin implements IEssentialsXMPP {
         if (metrics == null) {
             metrics = new MetricsWrapper(this, 3818, true);
             metrics.addCustomChart(new SimplePie("config-valid", () -> xmpp.isConfigValid() ? "yes" : "no"));
-        }
-    }
-
-    @Override
-    public Logger getLogger() {
-        try {
-            return EssentialsLogger.getLoggerProvider(this);
-        } catch (Throwable ignored) {
-            // In case Essentials isn't installed/loaded
-            return super.getLogger();
         }
     }
 

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/LoggerProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/LoggerProvider.java
@@ -1,11 +1,14 @@
 package net.ess3.provider;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginLogger;
 
-public abstract class LoggerProvider extends Logger {
-    public LoggerProvider(final String name) {
-        super(name, null);
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+public abstract class LoggerProvider extends PluginLogger {
+    public LoggerProvider(final Plugin plugin) {
+        super(plugin);
     }
 
     protected abstract void doTheLog(Level level, String message, Throwable throwable);
@@ -20,6 +23,11 @@ public abstract class LoggerProvider extends Logger {
     @Override
     public void log(Level level, String msg, Throwable thrown) {
         doTheLog(level, msg, thrown);
+    }
+
+    @Override
+    public void log(LogRecord logRecord) {
+        doTheLog(logRecord.getLevel(), logRecord.getMessage(), logRecord.getThrown());
     }
 
     @Override

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BaseLoggerProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BaseLoggerProvider.java
@@ -1,6 +1,7 @@
 package net.ess3.provider.providers;
 
 import net.ess3.provider.LoggerProvider;
+import org.bukkit.plugin.Plugin;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -8,8 +9,8 @@ import java.util.logging.Logger;
 public class BaseLoggerProvider extends LoggerProvider {
     private final Logger logger;
 
-    public BaseLoggerProvider(final Logger logger) {
-        super(logger.getName());
+    public BaseLoggerProvider(final Plugin plugin, final Logger logger) {
+        super(plugin);
         this.logger = logger;
     }
 

--- a/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperLoggerProvider.java
+++ b/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperLoggerProvider.java
@@ -12,7 +12,7 @@ public class PaperLoggerProvider extends LoggerProvider {
     private final ComponentLogger logger;
 
     public PaperLoggerProvider(final Plugin plugin) {
-        super(plugin.getComponentLogger().getName());
+        super(plugin);
         this.logger = plugin.getComponentLogger();
     }
 


### PR DESCRIPTION
Fixes an issue with our new logger system that prevented loading on 1.8.8