### PR TITLE
Add spawnable boat variants

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/MobCompat.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/MobCompat.java
@@ -187,7 +187,7 @@ public final class MobCompat {
         } else {
             return;
         }
-        if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_19_1_R01)) {
+        if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_19_R01)) {
             //noinspection deprecation
             boat.setWoodType(TreeSpecies.valueOf(variant.getTreeSpecies()));
         } else {

--- a/Essentials/src/main/java/com/earth2me/essentials/MobCompat.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/MobCompat.java
@@ -3,7 +3,9 @@ package com.earth2me.essentials;
 import com.earth2me.essentials.utils.EnumUtil;
 import com.earth2me.essentials.utils.VersionUtil;
 import net.ess3.nms.refl.ReflUtil;
+import org.bukkit.TreeSpecies;
 import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Boat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Fox;
@@ -175,6 +177,24 @@ public final class MobCompat {
         }
     }
 
+    public static void setBoatVariant(final Entity entity, final BoatVariant variant) {
+        if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_9_R01)) {
+            return;
+        }
+        final Boat boat;
+        if (entity instanceof Boat) {
+            boat = (Boat) entity;
+        } else {
+            return;
+        }
+        if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_19_1_R01)) {
+            //noinspection deprecation
+            boat.setWoodType(TreeSpecies.valueOf(variant.getTreeSpecies()));
+        } else {
+            boat.setBoatType(Boat.Type.valueOf(variant.getBoatType()));
+        }
+    }
+
     public enum CatType {
         // These are (loosely) Mojang names for the cats
         SIAMESE("SIAMESE", "SIAMESE_CAT"),
@@ -239,4 +259,34 @@ public final class MobCompat {
         }
     }
 
+    public enum BoatVariant {
+        // Mappings for TreeSpecies names
+        ACACIA("ACACIA", "ACACIA"),
+        BIRCH("BIRCH", "BIRCH"),
+        DARKOAK("DARK_OAK", "DARK_OAK"),
+        GENERIC("GENERIC", "OAK"),
+        JUNGLE("JUNGLE", "JUNGLE"),
+        REDWOOD("REDWOOD", "SPRUCE"),
+        // Mappings for Boat.Type names (falling back to GENERIC where undefined)
+        OAK("GENERIC", "OAK"),
+        SPRUCE("REDWOOD", "SPRUCE"),
+        MANGROVE("GENERIC", "MANGROVE"),
+        ;
+
+        private final String treeSpecies;
+        private final String boatType;
+
+        BoatVariant(final String treeSpecies, final String boatType) {
+            this.treeSpecies = treeSpecies;
+            this.boatType = boatType;
+        }
+
+        public String getTreeSpecies() {
+            return treeSpecies;
+        }
+
+        public String getBoatType() {
+            return boatType;
+        }
+    }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/MobData.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/MobData.java
@@ -7,6 +7,7 @@ import com.earth2me.essentials.utils.VersionUtil;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Ageable;
+import org.bukkit.entity.Boat;
 import org.bukkit.entity.ChestedHorse;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.Entity;
@@ -199,6 +200,15 @@ public enum MobData {
     TEMPERATE_FROG("temperate", MobCompat.FROG, "frog:TEMPERATE", true),
     WARM_FROG("warm", MobCompat.FROG, "frog:WARM", true),
     COLD_FROG("cold", MobCompat.FROG, "frog:COLD", true),
+    ACACIA_BOAT("acacia", Boat.class, MobCompat.BoatVariant.ACACIA, true),
+    BIRCH_BOAT("birch", Boat.class, MobCompat.BoatVariant.BIRCH, true),
+    DARK_OAK_BOAT("darkoak", Boat.class, MobCompat.BoatVariant.DARKOAK, true),
+    GENERIC_BOAT("generic", Boat.class, MobCompat.BoatVariant.GENERIC, true),
+    JUNGLE_BOAT("jungle", Boat.class, MobCompat.BoatVariant.JUNGLE, true),
+    REDWOOD_BOAT("redwood", Boat.class, MobCompat.BoatVariant.REDWOOD, true),
+    MANGROVE_BOAT("mangrove", Boat.class, MobCompat.BoatVariant.MANGROVE, true),
+    OAK_BOAT("oak", Boat.class, MobCompat.BoatVariant.OAK, true),
+    SPRUCE_BOAT("spruce", Boat.class, MobCompat.BoatVariant.SPRUCE, true),
     ;
 
     final private String nickname;
@@ -377,6 +387,8 @@ public enum MobData {
             }
         } else if (this.value.equals(Data.GOAT_SCREAMING)) {
             ((Goat) spawned).setScreaming(true);
+        } else if (this.value instanceof MobCompat.BoatVariant) {
+            MobCompat.setBoatVariant(spawned, (MobCompat.BoatVariant) this.value);
         } else if (this.value instanceof String) {
             final String[] split = ((String) this.value).split(":");
             switch (split[0]) {
@@ -404,14 +416,12 @@ public enum MobData {
                 case "fox":
                     MobCompat.setFoxType(spawned, split[1]);
                     break;
-                case "axolotl": {
+                case "axolotl":
                     MobCompat.setAxolotlVariant(spawned, split[1]);
                     break;
-                }
-                case "frog": {
+                case "frog":
                     MobCompat.setFrogVariant(spawned, split[1]);
                     break;
-                }
             }
         } else {
             Essentials.getWrappedLogger().warning("Unknown mob data type: " + this.toString());


### PR DESCRIPTION
I was quickly looking over the new mobs in 1.19 to make sure we didn't miss anything new, and noticed that boat variants are not covered currently in MobCompat. Apparently this has been the case since 1.9 (when boat variants were added).

Additionally, 1.19 introduces a new enum `Boat.Type` and deprecates `TreeSpecies`. We will need to support both for backwards compatibility, but new variants (e.g. mangrove) are only supported using the new enum (in 1.19+). I added a new `BoatVariant` enum in MobCompat to map between the two (as we currently do for `CatType` and `VillagerProfession`).