### PR TITLE
Fix incorrect chat message length check for formatting

### DIFF
--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -96,7 +96,7 @@ public abstract class AbstractChatHandler {
         format = format.replace("{9}", nickname == null ? username : nickname);
 
         // Local, shout and question chat types are only enabled when there's a valid radius
-        if (chat.getRadius() > 0 && event.getMessage().length() > 1) {
+        if (chat.getRadius() > 0 && event.getMessage().length() > 0) {
             if (chat.getType().isEmpty()) {
                 if (user.isToggleShout() && event.getMessage().charAt(0) == ess.getSettings().getChatShout()) {
                     event.setMessage(event.getMessage().substring(1));
@@ -139,7 +139,7 @@ public abstract class AbstractChatHandler {
 
         final User user = chat.getUser();
 
-        if (event.getMessage().length() > 1) {
+        if (event.getMessage().length() > 0) {
             if (chat.getType().isEmpty()) {
                 if (!user.isAuthorized("essentials.chat.local")) {
                     user.sendMessage(tl("notAllowedToLocal"));


### PR DESCRIPTION
This little pull request fixes a small bug where any 1 character long message was never formatted.

For some reason, the formatting is allowed if the message length is greater than one, which is very strange, so I just changed 1 to 0.
It's not clear to me if this is a typo or intended behavior, so I opened this pull request.