### PR TITLE
Don't call PrivateMessageSentEvent if the message wasn't sent successfully

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
@@ -126,10 +126,13 @@ public class SimpleMessageRecipient implements IMessageRecipient {
                 }
                 break;
         }
-        // If the message was a success, set this sender's reply-recipient to the current recipient.
-        if (messageResponse.isSuccess()) {
-            setReplyRecipient(recipient);
+
+        if (!messageResponse.isSuccess()) {
+            return messageResponse;
         }
+
+        // If the message was a success, set this sender's reply-recipient to the current recipient.
+        setReplyRecipient(recipient);
 
         final PrivateMessageSentEvent sentEvent = new PrivateMessageSentEvent(parent, recipient, message, messageResponse);
         ess.getServer().getPluginManager().callEvent(sentEvent);


### PR DESCRIPTION
Don't call PrivateMessageSentEvent if the message wasn't sent successfully

<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->


### Information

PrivateMessageSentEvent is called even if the message wasn't actually sent (`/reply` command).

### Details

**Proposed fix:**    
<!-- Type a description of your proposed fix below this line. -->
Don't call PrivateMessageSentEvent if the message wasn't sent successfully.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 10 Home 64-bit (21H2, 19044.1865)

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: 18

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8
