### PR TITLE
Chat messages to system messages

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -38,6 +38,8 @@ public interface ISettings extends IConf {
 
     String getWorldAlias(String world);
 
+    boolean isOnlySystemMessages();
+
     int getChatRadius();
 
     int getNearRadius();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -136,6 +136,7 @@ public class Settings implements net.ess3.api.ISettings {
     private double maxProjectileSpeed;
     private boolean removeEffectsOnHeal;
     private Map<String, String> worldAliases;
+    private boolean onlySystemMessages;
 
     public Settings(final IEssentials ess) {
         this.ess = ess;
@@ -610,6 +611,15 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     @Override
+    public boolean isOnlySystemMessages() {
+        return onlySystemMessages;
+    }
+
+    private boolean _isOnlySystemMessages() {
+        return config.getBoolean("chat.onlySystemMessages", false);
+    }
+
+    @Override
     public boolean getAnnounceNewPlayers() {
         return !config.getString("newbies.announce-format", "-").isEmpty();
     }
@@ -779,6 +789,7 @@ public class Settings implements net.ess3.api.ISettings {
         bindingItemPolicy = _getBindingItemsPolicy();
         currencySymbol = _getCurrencySymbol();
         worldAliases = _getWorldAliases();
+        onlySystemMessages = _isOnlySystemMessages();
 
         reloadCount.incrementAndGet();
     }

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -921,6 +921,9 @@ chat:
   #  plots: "&dP&r"
   #  creative: "&eC&r"
 
+  # Whether all messages sent by player be turned into system messages, stopping them from being used for reporting.
+  onlySystemMessages: false
+
   # Whether players should be placed into shout mode by default.
   shout-default: false
 

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -256,13 +256,15 @@ public abstract class AbstractChatHandler {
         cache.clearProcessedChat(event.getPlayer());
 
         // Stop message reporting
-        String message = event.getFormat()
-                .replace("%1$s", event.getPlayer().getDisplayName())
-                .replace("%2$s", event.getMessage());
-        for (Player player : event.getRecipients()) {
-            player.sendMessage(message);
+        if (ess.getSettings().isOnlySystemMessages()) {
+            String message = event.getFormat()
+                    .replace("%1$s", event.getPlayer().getDisplayName())
+                    .replace("%2$s", event.getMessage());
+            for (Player player : event.getRecipients()) {
+                player.sendMessage(message);
+            }
+            event.getRecipients().clear();
         }
-        event.getRecipients().clear();
     }
 
     boolean isAborted(final AsyncPlayerChatEvent event) {

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -254,6 +254,15 @@ public abstract class AbstractChatHandler {
         charge(event, cache.getProcessedChat(event.getPlayer()));
 
         cache.clearProcessedChat(event.getPlayer());
+
+        // Stop message reporting
+        String message = event.getFormat()
+                .replace("%1$s", event.getPlayer().getDisplayName())
+                .replace("%2$s", event.getMessage());
+        for (Player player : event.getRecipients()) {
+            player.sendMessage(message);
+        }
+        event.getRecipients().clear();
     }
 
     boolean isAborted(final AsyncPlayerChatEvent event) {


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

### Details

**Proposed feature:**  
<!-- Type a description of your proposed feature below this line. -->
The option to turn all messages sent by users to system messages to stop Microsoft's ability to ban players from chat reports for servers which want to moderate that themselves

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  Oracle OpenJDK version 17.0.2

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
When the config Item `chat.onlySystemMessages` is set too false, chat messages can be used in reporting as they aren't system messages:
![Chat message with orange edge](https://github.com/GreenJon902/Essentials/blob/images/images/messageorange.png?raw=true)
![Report menu](https://github.com/GreenJon902/Essentials/blob/images/images/menu.png?raw=true)

But when the option is turned on, reporting is now impossible:
![Chat message with grey edge](https://github.com/GreenJon902/Essentials/blob/images/images/messagegrewy.png?raw=true)
![Report menu with no new messages](https://github.com/GreenJon902/Essentials/blob/images/images/menuwihtoutmoreitems.png?raw=true)
