### PR TITLE
Prevent players opening their own inventories in /invsee

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandinvsee.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandinvsee.java
@@ -8,6 +8,8 @@ import org.bukkit.inventory.Inventory;
 import java.util.Collections;
 import java.util.List;
 
+import static com.earth2me.essentials.I18n.tl;
+
 public class Commandinvsee extends EssentialsCommand {
     public Commandinvsee() {
         super("invsee");
@@ -21,6 +23,11 @@ public class Commandinvsee extends EssentialsCommand {
         }
 
         final User invUser = getPlayer(server, user, args, 0);
+        if (user == invUser) {
+            user.sendMessage(tl("invseeNoSelf"));
+            throw new NoChargeException();
+        }
+
         final Inventory inv;
 
         if (args.length > 1 && user.isAuthorized("essentials.invsee.equip")) {
@@ -40,7 +47,9 @@ public class Commandinvsee extends EssentialsCommand {
     @Override
     protected List<String> getTabCompleteOptions(final Server server, final User user, final String commandLabel, final String[] args) {
         if (args.length == 1) {
-            return getPlayers(server, user);
+            final List<String> suggestions = getPlayers(server, user);
+            suggestions.remove(user.getName());
+            return suggestions;
         } else {
             //if (args.length == 2) {
             //    return Lists.newArrayList("equipped");

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -534,6 +534,7 @@ invseeCommandDescription=See the inventory of other players.
 invseeCommandUsage=/<command> <player>
 invseeCommandUsage1=/<command> <player>
 invseeCommandUsage1Description=Opens the inventory of the specified player
+invseeNoSelf=\u00a7cYou can only view other players' inventories.
 is=is
 isIpBanned=\u00a76IP \u00a7c{0} \u00a76is banned.
 internalError=\u00a7cAn internal error occurred while attempting to perform this command.


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

This PR addresses an issue reported in private on Discord.

### Details

**Proposed fix:**    
Prevent players from running `/invsee` on themselves.


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 11 22H2

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: Eclipse Temurin 17.0.2+8 

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.19.2, git-Paper-129)
