### PR TITLE
Fix rgb color codes getting stripped in some cases

### DIFF
--- a/Essentials/build.gradle
+++ b/Essentials/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     }
 }
 
+test {
+    testLogging.showStandardStreams = true
+}
+
 shadowJar {
     dependencies {
         include (dependency('io.papermc:paperlib'))

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/FormatUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/FormatUtil.java
@@ -226,11 +226,11 @@ public final class FormatUtil {
         final EnumSet<ChatColor> strip = EnumSet.complementOf(supported);
 
         final boolean rgb = user.isAuthorized(permBase + ".rgb");
-        if (!supported.isEmpty() || rgb) {
-            message = replaceColor(message, supported, rgb);
-        }
         if (!strip.isEmpty()) {
             message = stripColor(message, strip);
+        }
+        if (!supported.isEmpty() || rgb) {
+            message = replaceColor(message, supported, rgb);
         }
         return message;
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/VersionUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/VersionUtil.java
@@ -192,7 +192,7 @@ public final class VersionUtil {
                 if (!Bukkit.getName().equals("Essentials Fake Server")) {
                     throw new IllegalArgumentException(string + " is not in valid version format. e.g. 1.8.8-R0.1");
                 }
-                matcher = VERSION_PATTERN.matcher(v1_14_R01.toString());
+                matcher = VERSION_PATTERN.matcher(v1_16_1_R01.toString());
                 Preconditions.checkArgument(matcher.matches(), string + " is not in valid version format. e.g. 1.8.8-R0.1");
             }
 

--- a/Essentials/src/test/java/com/earth2me/essentials/utils/FormatUtilTest.java
+++ b/Essentials/src/test/java/com/earth2me/essentials/utils/FormatUtilTest.java
@@ -19,6 +19,17 @@ public class FormatUtilTest {
     }
 
     @Test
+    public void testFormatHexColors() {
+        checkFormatPerms("&#ffffff", "&#ffffff");
+        checkFormatPerms("&#ffffff", "§x§f§f§f§f§f§f", "color", "rgb");
+        checkFormatPerms("&#ff0000test", "§x§f§f§0§0§0§0test", "rgb");
+        checkFormatPerms("&#ff0000test", "§x§f§f§0§0§0§0test", "rgb", "color");
+        checkFormatPerms("&#ff0000test", "§x§f§f§0§0§0§0test", "rgb", "white");
+        checkFormatPerms("&#ff0000test", "§x§f§f§0§0§0§0test", "rgb", "black");
+        checkFormatPerms("&#ff0000test", "§x§f§f§0§0§0§0test", "rgb", "black", "white");
+    }
+
+    @Test
     public void testFormatCategoryPerms() {
         checkFormatPerms("Test", "Test");
         checkFormatPerms("Test", "Test", "color", "format");


### PR DESCRIPTION
Fixes #5058

In cases where a user has `essentials.color.rgb` but not all color codes (`essentials.color.color`), the strip functionality in `FormatUtil#formatString` will sometimes strip rgb codes in the md_5 format. Moving the strip before the format maintains strip behavior as well as prevents this from happening.