### PR TITLE
Close any open inventories before showing shapeless recipes

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandrecipe.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandrecipe.java
@@ -155,6 +155,7 @@ public class Commandrecipe extends EssentialsCommand {
         final List<ItemStack> ingredients = recipe.getIngredientList();
         if (showWindow) {
             final User user = ess.getUser(sender.getPlayer());
+            user.getBase().closeInventory();
             user.setRecipeSee(true);
             final InventoryView view = user.getBase().openWorkbench(null, true);
             for (int i = 0; i < ingredients.size(); i++) {


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

Fixes an oversight in eb222545642ccf31aabe346f30d2cbe47f5d10a9 which left old crafting inventories open, causing old ItemStacks to be retained in memory in some rare cases.

### Details

**Proposed fix:**    
Close any prior open inventories before opening the crafting inventory.


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 11

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: 17.0.1+12 (Temurin)

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.19.2, git-Paper-191)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8
