### PR TITLE
Make usermap non-player warnings configurable

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/userstorage/ModernUserMap.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/userstorage/ModernUserMap.java
@@ -2,6 +2,7 @@ package com.earth2me.essentials.userstorage;
 
 import com.earth2me.essentials.OfflinePlayer;
 import com.earth2me.essentials.User;
+import com.earth2me.essentials.utils.NumberUtil;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -12,13 +13,20 @@ import java.io.File;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 public class ModernUserMap extends CacheLoader<UUID, User> implements IUserMap {
     private final transient IEssentials ess;
     private final transient ModernUUIDCache uuidCache;
     private final transient LoadingCache<UUID, User> userCache;
+
+    private final boolean debugPrintStackWithWarn;
+    private final long debugMaxWarnsPerType;
+    private final ConcurrentMap<String, AtomicLong> debugNonPlayerWarnCounts;
 
     public ModernUserMap(final IEssentials ess) {
         this.ess = ess;
@@ -27,6 +35,15 @@ public class ModernUserMap extends CacheLoader<UUID, User> implements IUserMap {
                 .maximumSize(ess.getSettings().getMaxUserCacheCount())
                 .softValues()
                 .build(this);
+
+        // -Dnet.essentialsx.usermap.print-stack=true
+        final String printStackProperty = System.getProperty("net.essentialsx.usermap.print-stack", "false");
+        // -Dnet.essentialsx.usermap.max-warns=20
+        final String maxWarnProperty = System.getProperty("net.essentialsx.usermap.max-warns", "100");
+
+        this.debugMaxWarnsPerType = NumberUtil.isLong(maxWarnProperty) ? Long.parseLong(maxWarnProperty) : -1;
+        this.debugPrintStackWithWarn = Boolean.parseBoolean(printStackProperty);
+        this.debugNonPlayerWarnCounts = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -111,7 +128,7 @@ public class ModernUserMap extends CacheLoader<UUID, User> implements IUserMap {
 
         User user = getUser(base.getUniqueId());
         if (user == null) {
-            ess.getLogger().log(Level.INFO, "Essentials created a User for " + base.getName() + " (" + base.getUniqueId() + ") for non Bukkit type: " + base.getClass().getName());
+            debugLogUncachedNonPlayer(base);
             user = new User(base, ess);
         } else if (!base.equals(user.getBase())) {
             ess.getLogger().log(Level.INFO, "Essentials updated the underlying Player object for " + user.getUUID());
@@ -173,5 +190,17 @@ public class ModernUserMap extends CacheLoader<UUID, User> implements IUserMap {
 
     public void shutdown() {
         uuidCache.shutdown();
+    }
+
+    private void debugLogUncachedNonPlayer(final Player base) {
+        final String typeName = base.getClass().getName();
+        final long count = debugNonPlayerWarnCounts.computeIfAbsent(typeName, name -> new AtomicLong(0)).getAndIncrement();
+        if (debugMaxWarnsPerType < 0 || count <= debugMaxWarnsPerType) {
+            final Throwable throwable = debugPrintStackWithWarn ? new Throwable() : null;
+            ess.getLogger().log(Level.INFO, "Created a User for " + base.getName() + " (" + base.getUniqueId() + ") for non Bukkit type: " + typeName, throwable);
+            if (count == debugMaxWarnsPerType) {
+                ess.getLogger().log(Level.WARNING, "Essentials will not log any more warnings for " + typeName + ". Please report this to the EssentialsX team.");
+            }
+        }
     }
 }


### PR DESCRIPTION
### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

Adds system properties to control the non-player usermap warnings.

### Details

**Proposed fix:**    
`-Dnet.essentialsx.usermap.max-warns=N` (default: 100) limits how many warnings EssentialsX will print per non-real Player type.

`-Dnet.essentialsx.usermap.print-stack=true` (default: false) enables printing stack traces with the warning message.


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 11 22H2

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: 17.0.4.1+1 (Temurin)

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.19.2, git-Paper-196)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

```
[11:29:54 INFO]: [Essentials] Created a User for PaperMC (5ee25fa6-3072-2c3a-b0a4-f08e9b6b350a) for non Bukkit type: net.citizensnpcs.nms.v1_19_R1.entity.EntityHumanNPC$PlayerNPC
java.lang.Throwable: null
	at com.earth2me.essentials.userstorage.ModernUserMap.debugLogUncachedNonPlayer(ModernUserMap.java:199) ~[EssentialsX-2.20.0-dev+7-f7cbc7b.jar:?]
	at com.earth2me.essentials.userstorage.ModernUserMap.loadUncachedUser(ModernUserMap.java:131) ~[EssentialsX-2.20.0-dev+7-f7cbc7b.jar:?]
	at com.earth2me.essentials.Essentials.getUser(Essentials.java:1076) ~[EssentialsX-2.20.0-dev+7-f7cbc7b.jar:?]
	at com.earth2me.essentials.EssentialsEntityListener.onEntityDamage(EssentialsEntityListener.java:126) ~[EssentialsX-2.20.0-dev+7-f7cbc7b.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor78.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:75) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:git-Paper-196]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:670) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.callEvent(CraftEventFactory.java:249) ~[paper-1.19.2.jar:git-Paper-196]
	at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.callEntityDamageEvent(CraftEventFactory.java:1142) ~[paper-1.19.2.jar:git-Paper-196]
	at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.handleEntityDamageEvent(CraftEventFactory.java:1001) ~[paper-1.19.2.jar:git-Paper-196]
	at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.handleEntityDamageEvent(CraftEventFactory.java:953) ~[paper-1.19.2.jar:git-Paper-196]
	at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.handleLivingEntityDamageEvent(CraftEventFactory.java:1176) ~[paper-1.19.2.jar:git-Paper-196]
	at net.minecraft.world.entity.LivingEntity.damageEntity0(LivingEntity.java:2122) ~[?:?]
	at net.minecraft.world.entity.player.Player.damageEntity0(Player.java:1075) ~[?:?]
	at net.minecraft.world.entity.LivingEntity.hurt(LivingEntity.java:1369) ~[?:?]
	at net.minecraft.world.entity.player.Player.hurt(Player.java:982) ~[?:?]
	at net.minecraft.server.level.ServerPlayer.hurt(ServerPlayer.java:1025) ~[?:?]
	at net.citizensnpcs.nms.v1_19_R1.entity.EntityHumanNPC.a(EntityHumanNPC.java:292) ~[Citizens-2.0.30-b2705.jar:?]
	at net.minecraft.world.entity.player.Player.attack(Player.java:1322) ~[?:?]
	at net.minecraft.server.level.ServerPlayer.attack(ServerPlayer.java:2053) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl$5.a(ServerGamePacketListenerImpl.java:2983) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundInteractPacket$1.dispatch(ServerboundInteractPacket.java:24) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundInteractPacket.dispatch(ServerboundInteractPacket.java:80) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleInteract(ServerGamePacketListenerImpl.java:2905) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundInteractPacket.handle(ServerboundInteractPacket.java:67) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundInteractPacket.handle(ServerboundInteractPacket.java:12) ~[?:?]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.19.2.jar:git-Paper-196]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1341) ~[paper-1.19.2.jar:git-Paper-196]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:185) ~[paper-1.19.2.jar:git-Paper-196]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1318) ~[paper-1.19.2.jar:git-Paper-196]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1311) ~[paper-1.19.2.jar:git-Paper-196]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1289) ~[paper-1.19.2.jar:git-Paper-196]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1177) ~[paper-1.19.2.jar:git-Paper-196]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:305) ~[paper-1.19.2.jar:git-Paper-196]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
[11:29:54 WARN]: [Essentials] Essentials will not log any more warnings for net.citizensnpcs.nms.v1_19_R1.entity.EntityHumanNPC$PlayerNPC. Please report this to the EssentialsX team.
```