### PR TITLE
Improve uuid cache load times

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/userstorage/ModernUUIDCache.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/userstorage/ModernUUIDCache.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +41,7 @@ public class ModernUUIDCache {
      * caching the {@code last-account-name} value.
      */
     private final ConcurrentHashMap<String, UUID> nameToUuidMap = new ConcurrentHashMap<>();
-    private final CopyOnWriteArraySet<UUID> uuidCache = new CopyOnWriteArraySet<>();
+    private final Set<UUID> uuidCache = ConcurrentHashMap.newKeySet();
 
     private final ScheduledExecutorService writeExecutor = Executors.newSingleThreadScheduledExecutor();
     private final AtomicBoolean pendingNameWrite = new AtomicBoolean(false);


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes n/a 

### Details
Currently, the plugin can take a long time to load depending on the size of the uuids.bin file.

**Proposed fix:**    
<!-- Type a description of your proposed fix below this line. -->
Replace the set implementation used by the uuid cache with a concurrenthasthmap backed set.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Ubuntu 20.04

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  17.0.1

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Before
```
[18:29:28 INFO]: [Essentials] Enabling Essentials v2.20.0-dev+15-20011b9
[18:36:02 INFO]: [Essentials] Loaded 38132 items from items.json.
```
<details><summary>Jstack</summary>
"Server thread" prio=7 os_prio=0 cpu=254434.36ms elapsed=256.38s tid=0x00007f33c4503e10 nid=0x37616e runnable  [0x00007f33d81fa000]
   java.lang.Thread.State: RUNNABLE
        at java.util.concurrent.CopyOnWriteArrayList.indexOfRange(java.base@17.0.1/CopyOnWriteArrayList.java:193)
        at java.util.concurrent.CopyOnWriteArrayList.indexOf(java.base@17.0.1/CopyOnWriteArrayList.java:238)
        at java.util.concurrent.CopyOnWriteArrayList.contains(java.base@17.0.1/CopyOnWriteArrayList.java:230)
        at java.util.concurrent.CopyOnWriteArraySet.contains(java.base@17.0.1/CopyOnWriteArraySet.java:157)
        at com.earth2me.essentials.userstorage.ModernUUIDCache.loadCache(ModernUUIDCache.java:178)
        at com.earth2me.essentials.userstorage.ModernUUIDCache.<init>(ModernUUIDCache.java:57)
        at com.earth2me.essentials.userstorage.ModernUserMap.<init>(ModernUserMap.java:33)
        at com.earth2me.essentials.Essentials.onEnable(Essentials.java:313)
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264)
        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:370)
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:542)
        - locked <0x000000070a8aada0> (a org.bukkit.plugin.SimplePluginManager)
        at org.bukkit.craftbukkit.v1_19_R1.CraftServer.enablePlugin(CraftServer.java:565)
        at org.bukkit.craftbukkit.v1_19_R1.CraftServer.enablePlugins(CraftServer.java:479)
</details>

After
```
[18:53:41 INFO]: [Essentials] Enabling Essentials v2.20.0-dev+15-20011b9
[18:53:42 INFO]: [Essentials] Loaded 38132 items from items.json.
```