### PR TITLE
Add first join message type for Discord

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
@@ -54,6 +54,7 @@ public final class MessageType {
      */
     public static final class DefaultTypes {
         public final static MessageType JOIN = new MessageType("join", true);
+        public final static MessageType FIRST_JOIN = new MessageType("first-join", true);
         public final static MessageType LEAVE = new MessageType("leave", true);
         public final static MessageType CHAT = new MessageType("chat", true);
         public final static MessageType DEATH = new MessageType("death", true);

--- a/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/api/v2/services/discord/MessageType.java
@@ -65,7 +65,7 @@ public final class MessageType {
         public final static MessageType SERVER_STOP = new MessageType("server-stop", false);
         public final static MessageType KICK = new MessageType("kick", false);
         public final static MessageType MUTE = new MessageType("mute", false);
-        private final static MessageType[] VALUES = new MessageType[]{JOIN, LEAVE, CHAT, DEATH, AFK, ADVANCEMENT, ACTION, SERVER_START, SERVER_STOP, KICK, MUTE};
+        private final static MessageType[] VALUES = new MessageType[]{JOIN, FIRST_JOIN, LEAVE, CHAT, DEATH, AFK, ADVANCEMENT, ACTION, SERVER_START, SERVER_STOP, KICK, MUTE};
 
         /**
          * Gets an array of all the default {@link MessageType MessageTypes}.

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -263,7 +263,7 @@ public class DiscordSettings implements IConf {
         } else {
             filled = format;
         }
-        return generateMessageFormat(filled, ":arrow_right: {displayname} has joined the server for the first time!", false,
+        return generateMessageFormat(filled, ":arrow_right: :first_place: {displayname} has joined the server for the first time!", false,
                 "username", "displayname", "joinmessage", "online", "unique");
     }
 

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -255,6 +255,18 @@ public class DiscordSettings implements IConf {
                 "username", "displayname", "joinmessage", "online", "unique");
     }
 
+    public MessageFormat getFirstJoinFormat(Player player) {
+        final String format = getFormatString("first-join");
+        final String filled;
+        if (plugin.isPAPI() && format != null) {
+            filled = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, format);
+        } else {
+            filled = format;
+        }
+        return generateMessageFormat(filled, ":arrow_right: {displayname} has joined the server for the first time!", false,
+                "username", "displayname", "joinmessage", "online", "unique");
+    }
+
     public MessageFormat getQuitFormat(Player player) {
         final String format = getFormatString("quit");
         final String filled;

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -158,7 +158,7 @@ public class BukkitListener implements Listener {
                         MessageUtil.sanitizeDiscordMarkdown(message),
                         jda.getPlugin().getEss().getOnlinePlayers().size(),
                         userCount),
-                player);
+                        player);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -317,7 +317,7 @@ messages:
   # - {online}: The amount of players online
   # - {unique}: The amount of unique players to ever join the server
   # ... PlaceholderAPI placeholders are also supported here too!
-  first-join: ":arrow_right: {displayname} has joined the server for the first time!"
+  first-join: ":arrow_right: :first_place: {displayname} has joined the server for the first time!"
   # This is the message sent to Discord when a player leaves the minecraft server.
   # The following placeholders can be used here:
   # - {username}: The name of the user leaving

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -116,7 +116,7 @@ console:
 message-types:
   # Join messages sent when a player joins the Minecraft server.
   join: primary
-  # Join messages sent when a player joins the Minecraft server for the first time.
+  # Join messages sent when a player joins the Minecraft server for the first time. This type is sent instead of the join type.
   first-join: primary
   # Leave messages sent when a player leaves the Minecraft server.
   leave: primary

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -116,6 +116,8 @@ console:
 message-types:
   # Join messages sent when a player joins the Minecraft server.
   join: primary
+  # Join messages sent when a player joins the Minecraft server for the first time.
+  first-join: primary
   # Leave messages sent when a player leaves the Minecraft server.
   leave: primary
   # Chat messages sent when a player chats on the Minecraft server.

--- a/EssentialsDiscord/src/main/resources/config.yml
+++ b/EssentialsDiscord/src/main/resources/config.yml
@@ -307,6 +307,15 @@ messages:
   # - {unique}: The amount of unique players to ever join the server
   # ... PlaceholderAPI placeholders are also supported here too!
   join: ":arrow_right: {displayname} has joined!"
+  # This is the message sent to Discord when a player joins the minecraft server for the first time.
+  # The following placeholders can be used here:
+  # - {username}: The name of the user joining
+  # - {displayname}: The display name of the user joining
+  # - {joinmessage}: The full default join message used in game
+  # - {online}: The amount of players online
+  # - {unique}: The amount of unique players to ever join the server
+  # ... PlaceholderAPI placeholders are also supported here too!
+  first-join: ":arrow_right: {displayname} has joined the server for the first time!"
   # This is the message sent to Discord when a player leaves the minecraft server.
   # The following placeholders can be used here:
   # - {username}: The name of the user leaving


### PR DESCRIPTION
### Information

This PR partially closes https://github.com/EssentialsX/Essentials/discussions/5155
### Details

**Proposed feature:**  
Add a new message type for when a player has joined for the first time.

This adds a new type `first-join` with the default placeholder `":arrow_right: {displayname} has joined the server for the first time!"`.


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Fedora 36

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  `17.0.5`

- [ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [x] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8
Don't see how this could differ on other server versions.

**Demonstration:**  
As an example here I have made it so that the first-join messages are sent to the staff channel. You would likely just want these in the primary channel though. 
```yaml
...
# To disable a message from showing, use 'none' as the channel name.
message-types:
  # Join messages sent when a player joins the Minecraft server.
  join: primary
  # Join messages sent when a player joins the Minecraft server for the first time.
  first-join: staff

...
  # This is the message sent to Discord when a player joins the minecraft server for the first time
  # The following placeholders can be used here:
  # - {username}: The name of the user joining
  # - {displayname}: The display name of the user joining
  # - {joinmessage}: The full default join message used in game
  # - {online}: The amount of players online
  # - {unique}: The amount of unique players to ever join the server
  # ... PlaceholderAPI placeholders are also supported here too!
  first-join: ":arrow_right:** {displayname} has joined the server for the first time!**"


```
![image](https://user-images.githubusercontent.com/56408488/202177934-4110b29a-8498-449c-912b-44400050f797.png)

