### PR TITLE
Group teleport cooldowns

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
@@ -53,7 +53,8 @@ public class AsyncTeleport implements IAsyncTeleport {
         final Calendar time = new GregorianCalendar();
         if (teleportOwner.getLastTeleportTimestamp() > 0) {
             // Take the current time, and remove the delay from it.
-            final double cooldown = ess.getSettings().getTeleportCooldown();
+            final String group = teleportOwner.getGroup();
+            final double cooldown = ess.getSettings().getTeleportCooldown(group);
             final Calendar earliestTime = new GregorianCalendar();
             earliestTime.add(Calendar.SECOND, -(int) cooldown);
             earliestTime.add(Calendar.MILLISECOND, -(int) ((cooldown * 1000.0) % 1000.0));

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -123,7 +123,7 @@ public interface ISettings extends IConf {
 
     boolean isForcePassengerTeleport();
 
-    double getTeleportCooldown();
+    double getTeleportCooldown(String group);
 
     double getTeleportDelay();
 

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -473,8 +473,8 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     @Override
-    public double getTeleportCooldown() {
-        return config.getDouble("teleport-cooldown", 0);
+    public double getTeleportCooldown(String group) {
+        return config.getDouble("group-teleport-cooldowns." + (group == null ? "Default" : group),0);
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/Teleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Teleport.java
@@ -44,7 +44,8 @@ public class Teleport implements ITeleport {
         final Calendar time = new GregorianCalendar();
         if (teleportOwner.getLastTeleportTimestamp() > 0) {
             // Take the current time, and remove the delay from it.
-            final double cooldown = ess.getSettings().getTeleportCooldown();
+            final String group = teleportOwner.getGroup();
+            final double cooldown = ess.getSettings().getTeleportCooldown(group);
             final Calendar earliestTime = new GregorianCalendar();
             earliestTime.add(Calendar.SECOND, -(int) cooldown);
             earliestTime.add(Calendar.MILLISECOND, -(int) ((cooldown * 1000.0) % 1000.0));

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -96,8 +96,10 @@ group-teleport-cooldowns:
   default: 5
   admin: 3
 
-# The delay, in seconds, before a user actually teleports. If the user moves or gets attacked in this timeframe, the teleport is cancelled.
-teleport-delay: 0
+# The delay, in seconds, required between /home, /tp, etc.
+group-teleport-cooldowns:
+  default: 0
+  # admins: 3
 
 # The delay, in seconds, a player can't be attacked by other players after they have been teleported by a command.
 # This will also prevent the player attacking other players.

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -93,11 +93,6 @@ teleport-passenger-dismount: true
 
 # The delay, in seconds, required between /home, /tp, etc.
 group-teleport-cooldowns:
-  default: 5
-  admin: 3
-
-# The delay, in seconds, required between /home, /tp, etc.
-group-teleport-cooldowns:
   default: 0
   # admins: 3
 

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -92,7 +92,9 @@ force-safe-teleport-location: false
 teleport-passenger-dismount: true
 
 # The delay, in seconds, required between /home, /tp, etc.
-teleport-cooldown: 0
+group-teleport-cooldowns:
+  default: 5
+  admin: 3
 
 # The delay, in seconds, before a user actually teleports. If the user moves or gets attacked in this timeframe, the teleport is cancelled.
 teleport-delay: 0

--- a/Essentials/src/test/java/com/earth2me/essentials/TeleportationTest.java
+++ b/Essentials/src/test/java/com/earth2me/essentials/TeleportationTest.java
@@ -1,0 +1,68 @@
+package com.earth2me.essentials;
+
+import com.earth2me.essentials.commands.IEssentialsCommand;
+import com.earth2me.essentials.commands.NoChargeException;
+import org.bukkit.plugin.InvalidDescriptionException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class TeleportationTest {
+
+    private final OfflinePlayer base1;
+    private final Essentials ess;
+    private final FakeServer server;
+
+    public TeleportationTest() {
+        server = FakeServer.getServer();
+        ess = new Essentials(server);
+        try {
+            ess.setupForTesting(server);
+        } catch (final InvalidDescriptionException ex) {
+            fail("InvalidDescriptionException");
+        } catch (final IOException ex) {
+            fail("IOException");
+        }
+        base1 = server.createPlayer("testPlayer1");
+        server.addPlayer(base1);
+        ess.getUser(base1);
+    }
+
+    @Test
+    public void testTeleportationCooldownConfig() {
+        final User user1 = ess.getUser(base1);
+
+        final double defaultTeleportCooldown = ess.getSettings().getTeleportCooldown("default");
+        assertEquals(defaultTeleportCooldown, 0, 0.01);
+
+        boolean fail = false;
+        try {
+            // Test two home commands in quick succession; will work as long as config is properly set
+            runCommand("home", user1, "a");
+            runCommand("home", user1, "a");
+        } catch (Exception e) {
+            fail = true;
+        } finally {
+            assertEquals(fail, false);
+        }
+    }
+
+    private void runCommand(final String command, final User user, final String args) throws Exception {
+        runCommand(command, user, args.split("\\s+"));
+    }
+
+    private void runCommand(final String command, final User user, final String[] args) throws Exception {
+        final IEssentialsCommand cmd;
+
+        try {
+            cmd = (IEssentialsCommand) Essentials.class.getClassLoader()
+                    .loadClass("com.earth2me.essentials.commands.Command" + command).newInstance();
+            cmd.setEssentials(ess);
+            cmd.run(server, user, command, null, args);
+        } catch (final NoChargeException ignored) {
+        }
+    }
+}


### PR DESCRIPTION
Information
This PR closes https://github.com/EssentialsX/Essentials/issues/3509.

Details
Proposed feature:

Instead of a single, global teleportation cooldown, allow users to configure a distinct cooldown for each group. 
Potentially useful in order to have different cooldowns for regular players, moderators, admins, etc.

Environments tested:

OS: MacOS Ventura
Java(TM) SE Runtime Environment (build 17.0.1+12-LTS-39)
Spigot release 1.19.2