### PR TITLE
Fix discord permission issues with link module

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -198,7 +198,10 @@ public class DiscordSettings implements IConf {
     }
 
     public List<String> getCommandSnowflakes(String command) {
-        return config.getList("commands." + command + ".allowed-roles", String.class);
+        if (config.isList("commands." + command + ".allowed-roles")) {
+            return config.getList("commands." + command + ".allowed-roles", String.class);
+        }
+        return null;
     }
 
     public List<String> getCommandAdminSnowflakes(String command) {

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/interactions/InteractionControllerImpl.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/interactions/InteractionControllerImpl.java
@@ -56,7 +56,8 @@ public class InteractionControllerImpl extends ListenerAdapter implements Intera
         event.deferReply(command.isEphemeral()).queue(null, failure -> logger.log(Level.SEVERE, "Error while deferring Discord command", failure));
 
         final InteractionEvent interactionEvent = new InteractionEventImpl(event);
-        if (!DiscordUtil.hasRoles(event.getMember(), jda.getSettings().getCommandSnowflakes(command.getName()))) {
+        final List<String> commandSnowflakes = jda.getSettings().getCommandSnowflakes(command.getName());
+        if (commandSnowflakes != null && !DiscordUtil.hasRoles(event.getMember(), commandSnowflakes)) {
             interactionEvent.reply(tl("noAccessCommand"));
             return;
         }


### PR DESCRIPTION
Later, we're going to need to persist interaction commands between restarts (have a command/delay to remove them?) as well as well as deprecate our internal permissions manager in favor of discord's (having certain commands default behind admin permissions).