### PR TITLE
Fix teleport permission bypass exploit

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
@@ -475,6 +475,10 @@ public class AsyncTeleport implements IAsyncTeleport {
         timedTeleport = new AsyncTimedTeleport(teleportOwner, ess, this, delay, future, teleportUser, target, chargeFor, cause, respawn);
     }
 
+    public TeleportType getTpType() {
+        return tpType;
+    }
+
     public enum TeleportType {
         TPA,
         BACK,

--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerTarget.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerTarget.java
@@ -17,4 +17,9 @@ public class PlayerTarget implements ITarget {
     public Location getLocation() {
         return Bukkit.getPlayer(uuid).getLocation();
     }
+
+    public UUID getUUID() {
+        return uuid;
+    }
+
 }


### PR DESCRIPTION
**Information**
This PR fixes https://github.com/EssentialsX/Essentials/issues/5237

**Details**
Players can bypass the "tpaccept" permission check when teleport delay is enabled. This can be done by an exploiter getting the target to /tpa to them, then, the exploiter starts a teleport timer to a location where they do not have "tpaccept" and then typing /tpaccept before that timer finishes. This will cause the first timer to teleport the exploiter to the location where they do not have "tpaccept" and then the timer for the target player will finish, resulting in the target teleporting to the exploiters location.

Proposed fix:
Check if the target is a player, if so, check if the player has permission to accept teleports.

Environments tested:
OS: Windows 10

Java version: OpenJDK Runtime Environment Temurin-17.0.3+7 (build 17.0.3+7)

- [X] Most recent Paper version (MC: 1.19.3)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8