### PR TITLE
Update build dependencies

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - 2.x
     - dev/*
+    - update-actions
 
 jobs:
   build:

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - 2.x
     - dev/*
-    - update-actions
 
 jobs:
   build:

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
     - name: Checkout Git repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0 #https://github.com/actions/checkout/releases
       with:
         fetch-depth: 0
 
     - name: Restore Gradle cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3.2.5 #https://github.com/actions/cache/releases
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
@@ -26,13 +26,13 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Set up JDK 16
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3.10.0 #https://github.com/actions/setup-java/releases
       with:
         distribution: 'adopt'
         java-version: 16
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@v1.0.5 #https://github.com/gradle/wrapper-validation-action/releases
 
     - name: Build with Gradle
       run: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
     - name: Checkout Git repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0 #https://github.com/actions/checkout/releases
       with:
         fetch-depth: 0
 
     - name: Restore Gradle cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3.2.5 #https://github.com/actions/cache/releases
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
@@ -31,13 +31,13 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Set up JDK 16
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3.10.0 #https://github.com/actions/setup-java/releases
       with:
         distribution: 'adopt'
         java-version: 16
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@v1.0.5 #https://github.com/gradle/wrapper-validation-action/releases
 
     - name: Build with Gradle
       run: |


### PR DESCRIPTION
I didn't select a PR template, as this is neither "Adding a feature" nor "Fixing a bug".

This PR updates the build dependencies to get rid of deprecation warnings in GitHub Actions (Example Image below).
Also added links to their release pages as a comment to easily find their latest version in the future.
![image](https://user-images.githubusercontent.com/65610536/218633445-c73c0f21-703a-4425-8a05-8aa99459f23d.png)
Builds successfully without the warnings. [My Test Build](https://github.com/Chris6ix/Essentials/actions/runs/4170166356).
