### PR TITLE
Change warp saving format

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Warps.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Warps.java
@@ -9,6 +9,8 @@ import net.ess3.api.InvalidWorldException;
 import org.bukkit.Location;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -87,6 +89,7 @@ public class Warps implements IConf, net.ess3.api.IWarps {
             conf.setProperty("lastowner", user.getBase().getUniqueId().toString());
         }
         conf.save();
+        refreshIndex();
     }
 
     @Override
@@ -114,6 +117,7 @@ public class Warps implements IConf, net.ess3.api.IWarps {
             throw new Exception(tl("warpDeleteError"));
         }
         warpPoints.remove(uuid);
+        refreshIndex();
     }
 
     @Override
@@ -148,7 +152,27 @@ public class Warps implements IConf, net.ess3.api.IWarps {
                     }
                 }
             }
+
+            refreshIndex();
         }
+    }
+
+    /**
+     * Method used to refresh the index.txt inside the warp folder
+     */
+    public void refreshIndex(){
+        final File indexFile = new File(warpsFolder, "index.txt");
+        indexFile.delete();
+        try (final FileWriter writer = new FileWriter(indexFile)) {
+            for (final Map.Entry<String, UUID> entry : nameUUIDConversion.entrySet()) {
+                final String name = entry.getKey();
+                final UUID uuid = entry.getValue();
+                writer.append(name).append(' ').append(uuid.toString()).append('\n');
+            }
+        } catch (IOException ex){
+            Essentials.getWrappedLogger().log(Level.WARNING, tl("refreshWarpIndexError"), ex);
+        }
+
     }
 
     /**

--- a/Essentials/src/main/java/com/earth2me/essentials/Warps.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Warps.java
@@ -9,6 +9,7 @@ import net.ess3.api.InvalidWorldException;
 import org.bukkit.Location;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -120,11 +121,21 @@ public class Warps implements IConf, net.ess3.api.IWarps {
         warpPoints.clear();
         final File[] listOfFiles = warpsFolder.listFiles();
         if (listOfFiles.length >= 1) {
-            for (final File listOfFile : listOfFiles) {
+            for (File listOfFile : listOfFiles) {
                 final String filename = listOfFile.getName();
                 if (listOfFile.isFile() && filename.endsWith(".yml")) {
                     try {
-                        final UUID uuid = UUID.fromString(filename.substring(0, filename.length()-5));
+                        UUID uuid;
+                        try {
+                            uuid = UUID.fromString(filename.substring(0, filename.length()-5));
+                        } catch (Exception e) {
+                            Essentials.getWrappedLogger().log(Level.INFO, tl("loadDeprecatedWarp", filename));
+                            uuid = UUID.randomUUID();
+                            final File newFile = new File(warpsFolder, uuid + ".yml");
+                            Files.copy(listOfFile.toPath(), newFile.toPath());
+                            listOfFile.delete();
+                            listOfFile = newFile;
+                        }
                         final EssentialsConfiguration conf = new EssentialsConfiguration(listOfFile);
                         conf.load();
                         final String name = conf.getString("name", null);

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -703,6 +703,7 @@ listCommandUsage1Description=Lists all players on the server, or the given group
 listGroupTag=\u00a76{0}\u00a7r\: 
 listHiddenTag=\u00a77[HIDDEN]\u00a7r
 listRealName=({0})
+loadDeprecatedWarp=A warp with a deprecated file format was detected : {0}. He was converted to the newest one.
 loadWarpError=\u00a74Failed to load warp {0}.
 localFormat=\u00a73[L] \u00a7r<{0}> {1}
 localNoOne=

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -705,6 +705,7 @@ listHiddenTag=\u00a77[HIDDEN]\u00a7r
 listRealName=({0})
 loadDeprecatedWarp=A warp with a deprecated file format was detected : {0}. He was converted to the newest one.
 loadWarpError=\u00a74Failed to load warp {0}.
+refreshWarpIndexError=\u00a74Failed to generate warp index {0}.
 localFormat=\u00a73[L] \u00a7r<{0}> {1}
 localNoOne=
 loomCommandDescription=Opens up a loom.


### PR DESCRIPTION
In reply to #5267 with JRoy's idea

Saving warps using a uuid instead of the santized warp name that was causing problems with warps with similar names.
Added backwards conversion
Added generation of a warp index so that an administrator knows which file stores which warp

Note that no changes have been made to the api layer, so these changes should not affect existing bridges with plugins.  

Feel free to point out mistakes I've made, I'm still new to the pull request system and I'm trying to learn