### PR TITLE
Fix NPE while syncing offline users for discord line module

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -1079,10 +1079,19 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             // Since we already call UserMap#getUser() above, we are already okay with adding the user to the cache,
             // so we need to manually add the user to the cache in order to avoid a memory leak and maintain behavior.
             userMap.addCachedUser(user);
-        } else {
+        } else if (base.getClass() != UUIDPlayer.class || user.getBase() == null) {
             user.update(base);
         }
         return user;
+    }
+
+    public boolean isPlayerOnline(UUID uuid) {
+        for (Player player : getOnlinePlayers()) {
+            if (player.getUniqueId().equals(uuid)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void handleCrash(final Throwable exception) {

--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -1085,15 +1085,6 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
         return user;
     }
 
-    public boolean isPlayerOnline(UUID uuid) {
-        for (Player player : getOnlinePlayers()) {
-            if (player.getUniqueId().equals(uuid)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private void handleCrash(final Throwable exception) {
         final PluginManager pm = getServer().getPluginManager();
         LOGGER.log(Level.SEVERE, exception.toString());

--- a/EssentialsDiscordLink/src/main/java/net/essentialsx/discordlink/rolesync/RoleSyncManager.java
+++ b/EssentialsDiscordLink/src/main/java/net/essentialsx/discordlink/rolesync/RoleSyncManager.java
@@ -64,7 +64,7 @@ public class RoleSyncManager implements Listener {
 
         if (member == null) {
             if (ess.getSettings().isUnlinkOnLeave()) {
-                ess.getLinkManager().removeAccount(ess.getEss().getUser(player.getUniqueId()), DiscordLinkStatusChangeEvent.Cause.UNSYNC_LEAVE);
+                ess.getLinkManager().removeAccount(ess.getEss().getUser(player), DiscordLinkStatusChangeEvent.Cause.UNSYNC_LEAVE);
             } else {
                 unSync(player.getUniqueId(), discordId);
             }


### PR DESCRIPTION
Only would happen for users who haven't joined
(or been loaded by different parts of the plugin)
since the last restart. This change first of all switches to a method to fetch users which will update the User base to the UUIDPlayer dummy base. Secondly, this change will not update the base of a User to a UUIDPlayer dummy unless the base is currently null (which would be the case in the condition described above).
