### PR TITLE
Don't run AntiBuild checks on NPCs

### DIFF
--- a/EssentialsAntiBuild/src/main/java/com/earth2me/essentials/antibuild/EssentialsAntiBuildListener.java
+++ b/EssentialsAntiBuild/src/main/java/com/earth2me/essentials/antibuild/EssentialsAntiBuildListener.java
@@ -192,6 +192,10 @@ public class EssentialsAntiBuildListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onItemFrameInteract(final PlayerInteractEntityEvent event) {
+        if (event.getPlayer().hasMetadata("NPC")) {
+            return;
+        }
+
         final User user = ess.getUser(event.getPlayer());
 
         if (!(event.getRightClicked() instanceof ItemFrame)) {
@@ -221,6 +225,10 @@ public class EssentialsAntiBuildListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onArmorStandInteract(final PlayerInteractAtEntityEvent event) {
+        if (event.getPlayer().hasMetadata("NPC")) {
+            return;
+        }
+
         final User user = ess.getUser(event.getPlayer());
 
         if (!(event.getRightClicked() instanceof ArmorStand)) {
@@ -319,6 +327,10 @@ public class EssentialsAntiBuildListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW)
     public void onPlayerInteract(final PlayerInteractEvent event) {
+        if (event.getPlayer().hasMetadata("NPC")) {
+            return;
+        }
+
         // Do not return if cancelled, because the interact event has 2 cancelled states.
         final User user = ess.getUser(event.getPlayer());
         final ItemStack item = event.getItem();
@@ -415,6 +427,9 @@ public class EssentialsAntiBuildListener implements Listener {
     private class PlayerPickupItemListener implements Listener {
         @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
         public void onPlayerPickupItem(final PlayerPickupItemEvent event) {
+            if (event.getPlayer().hasMetadata("NPC")) {
+                return;
+            }
 
             final User user = ess.getUser(event.getPlayer());
             final ItemStack item = event.getItem().getItemStack();


### PR DESCRIPTION
Citizens pathfinding can trigger these events(!) and then cause LuckPerms to attempt an offline lookup which now raises an exception at runtime. DaFeels.

Fixes #5361