### PR TITLE
Fix keywords in kit commands not working

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/textreader/KeywordReplacer.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/textreader/KeywordReplacer.java
@@ -140,6 +140,13 @@ public class KeywordReplacer implements IText {
 
         for (int i = 0; i < input.getLines().size(); i++) {
             String line = input.getLines().get(i);
+
+            // Skip processing b64 encoded items, they will not have keywords in them.
+            if (line.charAt(0) == '@') {
+                replaced.add(line);
+                continue;
+            }
+
             final Matcher matcher = KEYWORD.matcher(line);
 
             while (matcher.find()) {
@@ -375,7 +382,10 @@ public class KeywordReplacer implements IText {
                 }
 
                 if (this.replaceSpacesWithUnderscores) {
-                    replacer = replacer.replace("_", "\\_").replaceAll("\\s", "_");
+                    // Don't replace spaces with underscores in command nor escape underscores.
+                    if (line.charAt(0) != '/') {
+                        replacer = replacer.replace("_", "\\_").replaceAll("\\s", "_");
+                    }
                 }
 
                 //If this is just a regular keyword, lets throw it into the cache


### PR DESCRIPTION
Don't process b64 item through keyword replacer
and don't replace spaces on command strings