### PR TITLE
Fix remaining offline visibility checks

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -1052,7 +1052,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             return true;
         }
 
-        return interactor.getBase().canSee(interactee.getBase());
+        return !interactee.isHiddenFrom(interactor.getBase());
     }
 
     //This will create a new user if there is not a match.

--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
@@ -55,9 +55,9 @@ public final class PlayerList {
         int playerHidden = 0;
         int hiddenCount = 0;
         for (final User onlinePlayer : ess.getOnlineUsers()) {
-            if (onlinePlayer.isHidden() || (user != null && !user.getBase().canSee(onlinePlayer.getBase()))) {
+            if (onlinePlayer.isHidden() || (user != null && onlinePlayer.isHiddenFrom(user.getBase()))) {
                 playerHidden++;
-                if (showHidden || user != null && user.getBase().canSee(onlinePlayer.getBase())) {
+                if (showHidden || user != null && !onlinePlayer.isHiddenFrom(user.getBase())) {
                     hiddenCount++;
                 }
             }
@@ -75,7 +75,7 @@ public final class PlayerList {
     public static Map<String, List<User>> getPlayerLists(final IEssentials ess, final IUser sender, final boolean showHidden) {
         final Map<String, List<User>> playerList = new HashMap<>();
         for (final User onlineUser : ess.getOnlineUsers()) {
-            if ((sender == null && !showHidden && onlineUser.isHidden()) || (sender != null && !showHidden && !sender.getBase().canSee(onlineUser.getBase()))) {
+            if ((sender == null && !showHidden && onlineUser.isHidden()) || (sender != null && !showHidden && onlineUser.isHiddenFrom(sender.getBase()))) {
                 continue;
             }
             final String group = FormatUtil.stripFormat(FormatUtil.stripEssentialsFormat(onlineUser.getGroup().toLowerCase()));

--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -709,7 +709,7 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
     }
 
     public boolean isHidden(final Player player) {
-        return hidden || !player.canSee(getBase());
+        return hidden || isHiddenFrom(player);
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkick.java
@@ -28,7 +28,7 @@ public class Commandkick extends EssentialsCommand {
         final User user = sender.isPlayer() ? ess.getUser(sender.getPlayer()) : null;
 
         if (user != null) {
-            if (target.isHidden(sender.getPlayer()) && !user.canInteractVanished() && !sender.getPlayer().canSee(target.getBase())) {
+            if (target.isHidden(sender.getPlayer()) && !user.canInteractVanished() && target.isHiddenFrom(sender.getPlayer())) {
                 throw new PlayerNotFoundException();
             }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandnear.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandnear.java
@@ -87,7 +87,7 @@ public class Commandnear extends EssentialsCommand {
         final Queue<User> nearbyPlayers = new PriorityQueue<>((o1, o2) -> (int) (o1.getLocation().distanceSquared(loc) - o2.getLocation().distanceSquared(loc)));
 
         for (final User player : ess.getOnlineUsers()) {
-            if (!player.equals(user) && !player.isAuthorized("essentials.near.exclude") && (!player.isHidden(user.getBase()) || showHidden || user.getBase().canSee(player.getBase()))) {
+            if (!player.equals(user) && !player.isAuthorized("essentials.near.exclude") && (!player.isHidden(user.getBase()) || showHidden || !player.isHiddenFrom(user.getBase()))) {
                 final Location playerLoc = player.getLocation();
                 if (playerLoc.getWorld() != world) {
                     continue;

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandrealname.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandrealname.java
@@ -25,7 +25,7 @@ public class Commandrealname extends EssentialsCommand {
         final boolean skipHidden = sender.isPlayer() && !ess.getUser(sender.getPlayer()).canInteractVanished();
         boolean foundUser = false;
         for (final User u : ess.getOnlineUsers()) {
-            if (skipHidden && u.isHidden(sender.getPlayer()) && !sender.getPlayer().canSee(u.getBase())) {
+            if (skipHidden && u.isHidden(sender.getPlayer()) && u.isHiddenFrom(sender.getPlayer())) {
                 continue;
             }
             u.setDisplayNick();

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandspeed.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandspeed.java
@@ -67,7 +67,7 @@ public class Commandspeed extends EssentialsCommand {
         final List<Player> matchedPlayers = server.matchPlayer(name);
         for (final Player matchPlayer : matchedPlayers) {
             final User player = ess.getUser(matchPlayer);
-            if (skipHidden && player.isHidden(sender.getPlayer()) && !sender.getPlayer().canSee(matchPlayer)) {
+            if (skipHidden && player.isHidden(sender.getPlayer()) && player.isHiddenFrom(sender.getPlayer())) {
                 continue;
             }
             foundUser = true;

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/EssentialsLoopCommand.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/EssentialsLoopCommand.java
@@ -44,7 +44,7 @@ public abstract class EssentialsLoopCommand extends EssentialsCommand {
         } else if (matchWildcards && searchTerm.contentEquals("*")) {
             final boolean skipHidden = sender.isPlayer() && !ess.getUser(sender.getPlayer()).canInteractVanished();
             for (final User onlineUser : ess.getOnlineUsers()) {
-                if (skipHidden && onlineUser.isHidden(sender.getPlayer()) && !sender.getPlayer().canSee(onlineUser.getBase())) {
+                if (skipHidden && onlineUser.isHidden(sender.getPlayer()) && onlineUser.isHiddenFrom(sender.getPlayer())) {
                     continue;
                 }
                 userConsumer.accept(onlineUser);
@@ -81,7 +81,7 @@ public abstract class EssentialsLoopCommand extends EssentialsCommand {
 
         if (matchWildcards && (searchTerm.contentEquals("**") || searchTerm.contentEquals("*"))) {
             for (final User onlineUser : ess.getOnlineUsers()) {
-                if (skipHidden && onlineUser.isHidden(sender.getPlayer()) && !sender.getPlayer().canSee(onlineUser.getBase())) {
+                if (skipHidden && onlineUser.isHidden(sender.getPlayer()) && onlineUser.isHiddenFrom(sender.getPlayer())) {
                     continue;
                 }
                 userConsumer.accept(onlineUser);
@@ -96,7 +96,7 @@ public abstract class EssentialsLoopCommand extends EssentialsCommand {
             if (matchedPlayers.isEmpty()) {
                 final String matchText = searchTerm.toLowerCase(Locale.ENGLISH);
                 for (final User player : ess.getOnlineUsers()) {
-                    if (skipHidden && player.isHidden(sender.getPlayer()) && !sender.getPlayer().canSee(player.getBase())) {
+                    if (skipHidden && player.isHidden(sender.getPlayer()) && player.isHiddenFrom(sender.getPlayer())) {
                         continue;
                     }
                     final String displayName = FormatUtil.stripFormat(player.getDisplayName()).toLowerCase(Locale.ENGLISH);
@@ -108,7 +108,7 @@ public abstract class EssentialsLoopCommand extends EssentialsCommand {
             } else {
                 for (final Player matchPlayer : matchedPlayers) {
                     final User player = ess.getUser(matchPlayer);
-                    if (skipHidden && player.isHidden(sender.getPlayer()) && !sender.getPlayer().canSee(matchPlayer)) {
+                    if (skipHidden && player.isHidden(sender.getPlayer()) && player.isHiddenFrom(sender.getPlayer())) {
                         continue;
                     }
                     foundUser = true;

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/EssentialsToggleCommand.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/EssentialsToggleCommand.java
@@ -51,7 +51,7 @@ public abstract class EssentialsToggleCommand extends EssentialsCommand {
         final List<Player> matchedPlayers = server.matchPlayer(args[0]);
         for (final Player matchPlayer : matchedPlayers) {
             final User player = ess.getUser(matchPlayer);
-            if (skipHidden && player.isHidden(sender.getPlayer()) && !sender.getPlayer().canSee(matchPlayer)) {
+            if (skipHidden && player.isHidden(sender.getPlayer()) && player.isHiddenFrom(sender.getPlayer())) {
                 continue;
             }
             foundUser = true;


### PR DESCRIPTION
Purpur added a new self-referencing method that
we don't implement with our stub class. This will
prevent Player#canSee from being called for offline players (it would be false anyway).

Mitigates #5318 and #5465
Continuation of a1fa1e38f8c27d7bce3bbbf32e39ea279d16a68c