### PR TITLE
Prevent /editsign on waxed signs

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
@@ -79,7 +79,11 @@ public class Commandeditsign extends EssentialsCommand {
                     user.sendMessage(tl("editsignCommandClearLine", line + 1));
                 }
             } else if (args[0].equalsIgnoreCase("copy")) {
+                if (callSignEvent(sign, user.getBase(), sign.getLines())) {
+                    return;
+                }
 
+                final int line = args.length == 1 ? -1 : Integer.parseInt(args[1]) - 1;
                 if (line == -1) {
                     for (int i = 0; i < 4; i++) {
                         // We use unformat here to prevent players from copying signs with colors that they do not have permission to use.

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
@@ -122,7 +122,7 @@ public class Commandeditsign extends EssentialsCommand {
     private boolean callSignEvent(final ModifiableSign sign, final Player player, final String[] lines) {
         final SignChangeEvent event;
         if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_20_1_R01)) {
-            if (sign.sign.isWaxed() && !player.hasPermission("essentials.editsign.waxed.exempt")) {
+            if (sign.isWaxed() && !player.hasPermission("essentials.editsign.waxed.exempt")) {
                 return true;
             }
             event = new SignChangeEvent(sign.getBlock(), player, lines, sign.isFront() ? Side.FRONT : Side.BACK);
@@ -205,6 +205,11 @@ public class Commandeditsign extends EssentialsCommand {
                 boolean isFront() {
                     return side == Side.FRONT;
                 }
+
+                @Override
+                boolean isWaxed() {
+                    return sign.isWaxed();
+                }
             };
         }
         return new ModifiableSign(sign) {
@@ -227,6 +232,11 @@ public class Commandeditsign extends EssentialsCommand {
             boolean isFront() {
                 return true;
             }
+
+            @Override
+            boolean isWaxed() {
+                return false;
+            }
         };
     }
 
@@ -244,6 +254,8 @@ public class Commandeditsign extends EssentialsCommand {
         abstract void setLine(int line, String text);
 
         abstract boolean isFront();
+
+        abstract boolean isWaxed();
 
         Block getBlock() {
             return sign.getBlock();

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
@@ -79,7 +79,6 @@ public class Commandeditsign extends EssentialsCommand {
                     user.sendMessage(tl("editsignCommandClearLine", line + 1));
                 }
             } else if (args[0].equalsIgnoreCase("copy")) {
-                final int line = args.length == 1 ? -1 : Integer.parseInt(args[1]) - 1;
 
                 if (line == -1) {
                     for (int i = 0; i < 4; i++) {
@@ -119,6 +118,9 @@ public class Commandeditsign extends EssentialsCommand {
     private boolean callSignEvent(final ModifiableSign sign, final Player player, final String[] lines) {
         final SignChangeEvent event;
         if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_20_1_R01)) {
+            if (sign.sign.isWaxed() && !player.hasPermission("essentials.editsign.waxed.exempt")) {
+                return true;
+            }
             event = new SignChangeEvent(sign.getBlock(), player, lines, sign.isFront() ? Side.FRONT : Side.BACK);
         } else {
             //noinspection deprecation

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandeditsign.java
@@ -79,11 +79,8 @@ public class Commandeditsign extends EssentialsCommand {
                     user.sendMessage(tl("editsignCommandClearLine", line + 1));
                 }
             } else if (args[0].equalsIgnoreCase("copy")) {
-                if (callSignEvent(sign, user.getBase(), sign.getLines())) {
-                    return;
-                }
-
                 final int line = args.length == 1 ? -1 : Integer.parseInt(args[1]) - 1;
+
                 if (line == -1) {
                     for (int i = 0; i < 4; i++) {
                         // We use unformat here to prevent players from copying signs with colors that they do not have permission to use.

--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -714,6 +714,7 @@ permissions:
       essentials.sudo.exempt: true
       essentials.tempban.exempt: true
       essentials.exempt.protect: true
+      essentials.editsign.waxed.exempt: true
   essentials.nick.hideprefix:
     default: false
     description: Players with this permission will not have the nickname prefix applied to them


### PR DESCRIPTION
Information
This PR closes #5473 

Details
Proposed feature: 
- Do not allow editing signs if it has been waxed with bypass permission `essentials.editsign.waxed.exempt`
- ~Calling the SignEditEvent when copying a sign with `/editsign copy`~

Environments tested:

OS: Windows

Java version: 17

 Most recent Paper version (1.20.1, git-Purpur-2044)
Demonstration: