### PR TITLE
EssentialsSigns that are dark oak will now have white text

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/signs/EssentialsSign.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/EssentialsSign.java
@@ -25,6 +25,7 @@ import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -104,6 +105,7 @@ public class EssentialsSign {
             return true;
         }
         sign.setLine(0, tl("signFormatFail", this.signName));
+        changeLineColour(sign, new String[] {"DARK_OAK"}, ChatColor.WHITE);
 
         final SignCreateEvent signEvent = new SignCreateEvent(sign, this, user);
         ess.getServer().getPluginManager().callEvent(signEvent);
@@ -495,6 +497,35 @@ public class EssentialsSign {
         ess.showError(sender, exception, "\\ sign: " + signName);
     }
 
+    protected final void changeLineColour(ISign sign, String[] woodTypes, ChatColor colour, int lineId){
+        if (woodTypes == null){
+            final String line = sign.getLine(lineId);
+            sign.setLine(lineId, colour + line);
+            return;
+        }
+
+        final String signName = sign.getBlock().getType().toString();
+        final ArrayList<String> blockNames = new ArrayList<>();
+        for (String woodType : woodTypes) {
+            blockNames.add(woodType + "_WALL_SIGN");
+            blockNames.add(woodType + "_SIGN");
+            blockNames.add(woodType + "_WALL_HANGING_SIGN");
+        }
+        for (String blockName : blockNames) {
+            if (signName.equals(blockName)) {
+                final String line = sign.getLine(lineId);
+                sign.setLine(lineId, colour + line.toUpperCase());
+            }
+        }
+
+    }
+
+    protected final void changeLineColour(ISign sign, String[] woodTypes, ChatColor colour){
+        for (int i = 1; i < 4; i++){
+            changeLineColour(sign, woodTypes, colour, i);
+        }
+    }
+
     public interface ISign {
         String getLine(final int index);
 
@@ -524,15 +555,19 @@ public class EssentialsSign {
                     builder.append(c);
                 }
             }
-            return builder.toString();
+            return ChatColor.stripColor(builder.toString());
             //return event.getLine(index); // Above code can be removed and replaced with this line when https://github.com/Bukkit/Bukkit/pull/982 is merged.
         }
 
         @Override
         public final void setLine(final int index, final String text) {
-            event.setLine(index, text);
-            sign.setLine(index, text);
+            event.setLine(index, getSignColor(sign, index) + text);
+            sign.setLine(index, getSignColor(sign, index) + text);
             updateSign();
+        }
+
+        protected String getSignColor(final Sign sign, final int lineNumber) {
+            return ChatColor.getLastColors(sign.getLine(lineNumber).trim());
         }
 
         @Override
@@ -562,14 +597,18 @@ public class EssentialsSign {
                     builder.append(c);
                 }
             }
-            return builder.toString();
+            return ChatColor.stripColor(builder.toString());
             //return event.getLine(index); // Above code can be removed and replaced with this line when https://github.com/Bukkit/Bukkit/pull/982 is merged.
         }
 
         @Override
         public final void setLine(final int index, final String text) {
-            getSign().setLine(index, text);
+            getSign().setLine(index, getSignColor(getSign(), index) + text);
             updateSign();
+        }
+
+        protected String getSignColor(final Sign sign, final int lineNumber) {
+            return ChatColor.getLastColors(sign.getLine(lineNumber).trim());
         }
 
         @Override


### PR DESCRIPTION
**Information**
This PR closes https://github.com/EssentialsX/Essentials/issues/5528.

### **Details**
Dark oak EssentialsSigns have white text to make it easier to read.

Colour set in line 108:
````
changeLineColour(sign, new String[] {"DARK_OAK"}, ChatColor.WHITE);
````
Only dark oak is set to white. Other wood types may need setting to different colours. If `String[]` is `null` then all wood types' text would be set to the specified colour.

OS: Windows

Java version: 17.0.9

Minecraft 1.20.2

Paper Version used `gradlew build :runServer`

**Example**
![image](https://github.com/EssentialsX/Essentials/assets/93071157/0385b9b2-26c1-4060-a8c0-cb7b883f09fa)

