### PR TITLE
Adds the ability to have per item transaction permissions

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandsell.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandsell.java
@@ -54,6 +54,15 @@ public class Commandsell extends EssentialsCommand {
                 }
             }
             try {
+                if (!user.isAuthorized("essentials.sell.item."+stack.getType().toString())){
+                    if (isBulk) {
+                        notSold.add(stack);
+                        continue;
+                    }
+                    user.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cError: &4You do not have sufficient permissions to sell " + stack.getType()));
+                    return;
+                }
+
                 if (stack.getAmount() > 0) {
                     totalWorth = totalWorth.add(sellItem(user, stack, args, isBulk));
                     stack = stack.clone();

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandsell.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandsell.java
@@ -54,7 +54,7 @@ public class Commandsell extends EssentialsCommand {
                 }
             }
             try {
-                if (!user.isAuthorized("essentials.sell.item."+stack.getType().toString())){
+                if (!user.isAuthorized("essentials.item.sell."+stack.getType().toString())){
                     if (isBulk) {
                         notSold.add(stack);
                         continue;

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignBuy.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignBuy.java
@@ -5,6 +5,7 @@ import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import net.ess3.api.IEssentials;
 import net.ess3.api.MaxMoneyException;
+import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemStack;
 
 import java.math.BigDecimal;
@@ -26,6 +27,10 @@ public class SignBuy extends EssentialsSign {
         Trade items = getTrade(sign, 1, 2, player, ess);
         Trade charge = getTrade(sign, 3, ess);
 
+        if (!player.isAuthorized("essentials.item.buy"+ items.getItemStack().getType())){
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cError: &4You do not have sufficient permissions to buy " + items.getItemStack().getType()));
+            return false;
+        }
         // Check if the player is trying to buy in bulk.
         if (ess.getSettings().isAllowBulkBuySell() && player.getBase().isSneaking()) {
             final ItemStack heldItem = player.getItemInHand();

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignFree.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignFree.java
@@ -3,6 +3,7 @@ package com.earth2me.essentials.signs;
 import com.earth2me.essentials.Trade;
 import com.earth2me.essentials.User;
 import net.ess3.api.IEssentials;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -33,6 +34,10 @@ public class SignFree extends EssentialsSign {
         ItemStack itemStack = getItemStack(sign.getLine(1), 1, ess);
         itemStack = getItemMeta(player.getSource(), itemStack, sign.getLine(2), ess);
         final ItemStack item = getItemMeta(player.getSource(), itemStack, sign.getLine(3), ess);
+        if (!player.isAuthorized("essentials.item.free."+ item.getType())){
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cError: &4You do not have sufficient permissions to get " + item.getType()));
+            return false;
+        }
 
         if (item.getType() == Material.AIR) {
             throw new SignException(tl("cantSpawnItem", "Air"));

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignSell.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignSell.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.Trade.OverflowType;
 import com.earth2me.essentials.User;
 import net.ess3.api.IEssentials;
 import net.ess3.api.MaxMoneyException;
+import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemStack;
 
 import java.math.BigDecimal;
@@ -26,6 +27,10 @@ public class SignSell extends EssentialsSign {
     protected boolean onSignInteract(final ISign sign, final User player, final String username, final IEssentials ess) throws SignException, ChargeException, MaxMoneyException {
         Trade charge = getTrade(sign, 1, 2, player, ess);
         Trade money = getTrade(sign, 3, ess);
+        if (!player.isAuthorized("essentials.sell.item."+ charge.getItemStack().getType())){
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cError: &4You do not have sufficient permissions to sell " + charge.getItemStack().getType()));
+            return false;
+        }
 
         // Check if the player is trying to sell in bulk.
         if (ess.getSettings().isAllowBulkBuySell() && player.getBase().isSneaking()) {

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignSell.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignSell.java
@@ -27,7 +27,7 @@ public class SignSell extends EssentialsSign {
     protected boolean onSignInteract(final ISign sign, final User player, final String username, final IEssentials ess) throws SignException, ChargeException, MaxMoneyException {
         Trade charge = getTrade(sign, 1, 2, player, ess);
         Trade money = getTrade(sign, 3, ess);
-        if (!player.isAuthorized("essentials.sell.item."+ charge.getItemStack().getType())){
+        if (!player.isAuthorized("essentials.item.sell."+ charge.getItemStack().getType())){
             player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cError: &4You do not have sufficient permissions to sell " + charge.getItemStack().getType()));
             return false;
         }


### PR DESCRIPTION
**Resolves**
#2212 

**Details**
Adds the permissions `essentials.item.<free|buy|sell>.<itemName>`.

Players still need the permissions `essentials.sell.<hand|inventory>` and `essentials.signs.<free|buy|sell>.use` depending on which method they sell their items.

**Example**
A player needs `essentials.item.sell.redstone` in order to sell redstone(sign or command).

**To keep existing behaviour**
Set permission to `essentials.item.<free|buy|sell>.*` to allow all types or items to be sold.
Not sure if this should be added into the config file for example as: `perItemTransactionPermissions: false` or if server admins could add the above permission into their permission manager.

OS: Windows

Java version: 17.0.9

Minecraft 1.20.2

Paper Version used `gradlew build :runServer`