### PR TITLE
Add setting to use usernames over display names for social spy

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -640,12 +640,13 @@ public class EssentialsPlayerListener implements Listener, FakeAccessor {
                 || (!pluginCommand.getName().equals("msg") && !pluginCommand.getName().equals("r"))) { // /msg and /r are handled in SimpleMessageRecipient
                 final User user = ess.getUser(player);
                 if (!user.isAuthorized("essentials.chat.spy.exempt")) {
+                    final String playerName = ess.getSettings().isSocialSpyDisplayNames() ? player.getDisplayName() : player.getName();
                     for (final User spyer : ess.getOnlineUsers()) {
                         if (spyer.isSocialSpyEnabled() && !player.equals(spyer.getBase())) {
                             final Component base = (user.isMuted() && ess.getSettings().getSocialSpyListenMutedPlayers())
                                     ? spyer.tlComponent("socialSpyMutedPrefix")
                                     : spyer.tlComponent("socialSpyPrefix");
-                            spyer.sendComponent(base.append(AdventureUtil.legacyToAdventure(player.getDisplayName())).append(Component.text(": " + event.getMessage())));
+                            spyer.sendComponent(base.append(AdventureUtil.legacyToAdventure(playerName)).append(Component.text(": " + event.getMessage())));
                         }
                     }
                 }

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -73,6 +73,8 @@ public interface ISettings extends IConf {
 
     boolean isSocialSpyMessages();
 
+    boolean isSocialSpyDisplayNames();
+
     Set<String> getMuteCommands();
 
     @Deprecated

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -454,6 +454,11 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getBoolean("socialspy-messages", true);
     }
 
+    @Override
+    public boolean isSocialSpyDisplayNames() {
+        return config.getBoolean("socialspy-uses-displaynames", true);
+    }
+
     private Set<String> _getMuteCommands() {
         final Set<String> muteCommands = new HashSet<>();
         if (config.isList("mute-commands")) {

--- a/Essentials/src/main/java/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
@@ -121,15 +121,17 @@ public class SimpleMessageRecipient implements IMessageRecipient {
                             // Dont spy on chats involving socialspy exempt players
                             && !senderUser.isAuthorized("essentials.chat.spy.exempt")
                             && recipientUser != null && !recipientUser.isAuthorized("essentials.chat.spy.exempt")) {
+                        final String senderName = ess.getSettings().isSocialSpyDisplayNames() ? getDisplayName() : getName();
+                        final String recipientName = ess.getSettings().isSocialSpyDisplayNames() ? recipient.getDisplayName() : recipient.getName();
                         for (final User onlineUser : ess.getOnlineUsers()) {
                             if (onlineUser.isSocialSpyEnabled()
                                     // Don't send socialspy messages to message sender/receiver to prevent spam
                                     && !onlineUser.equals(senderUser)
                                     && !onlineUser.equals(recipient)) {
                                 if (senderUser.isMuted() && ess.getSettings().getSocialSpyListenMutedPlayers()) {
-                                    onlineUser.sendComponent(AdventureUtil.miniMessage().deserialize(tlSender("socialSpyMutedPrefix") + tlLiteral("socialSpyMsgFormat", getDisplayName(), recipient.getDisplayName(), message)));
+                                    onlineUser.sendComponent(AdventureUtil.miniMessage().deserialize(tlSender("socialSpyMutedPrefix") + tlLiteral("socialSpyMsgFormat", senderName, recipientName, message)));
                                 } else {
-                                    onlineUser.sendComponent(AdventureUtil.miniMessage().deserialize(tlLiteral("socialSpyPrefix") + tlLiteral("socialSpyMsgFormat", getDisplayName(), recipient.getDisplayName(), message)));
+                                    onlineUser.sendComponent(AdventureUtil.miniMessage().deserialize(tlLiteral("socialSpyPrefix") + tlLiteral("socialSpyMsgFormat", senderName, recipientName, message)));
                                 }
                             }
                         }

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -213,6 +213,10 @@ socialspy-listen-muted-players: true
 # If false, social spy will only monitor commands from the list above.
 socialspy-messages: true
 
+# Whether social spy should use formatted display names which may include color.
+# If false, social spy will use only the actual player names.
+socialspy-uses-displaynames: true
+
 # The following settings listen for when a player changes worlds.
 # If you use another plugin to control speed and flight, you should change these to false.
 


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

This PR closes #1995 from 5 years and 8 months ago. 

### Details

**Proposed feature:**  
<!-- Type a description of your proposed feature below this line. -->
Add a config file option for Social Spy to use either display names (the default) or player names in its output.

~~Also fix a bug which has been present for 6+ years where `socialMutedSpyPrefix` should have been `socialSpyMutedPrefix`.~~
(This was fixed in 2.x with the Adventure changes.)


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Linux 4.15.0-213-generic

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  Oracle 17.0.8+9-LTS-211

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version git-Paper-381 (MC: 1.20.4)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Sample output with `socialspy-uses-displaynames: true` (the current behavior and default):

![SocialSpy1](https://github.com/EssentialsX/Essentials/assets/3617206/6219ad26-0ba8-43c0-800f-0c3b1739721d)

Sample output with `socialspy-uses-displaynames: false`:

![SocialSpy2](https://github.com/EssentialsX/Essentials/assets/3617206/666acf67-4e5d-4672-a36f-c827e1767d51)

I'll note that I find the second version to be much more readable.
