### PR TITLE
Fix /broadcastworld sending in all worlds except the intended one

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcastworld.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcastworld.java
@@ -19,13 +19,13 @@ public class Commandbroadcastworld extends EssentialsCommand {
 
     @Override
     public void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
-        if (args.length == 0) {
+        if (args.length < 2) {
             throw new NotEnoughArgumentsException();
         }
 
         World world = user.getWorld();
         String message = getFinalArg(args, 0);
-        if (args.length > 1 && ess.getSettings().isAllowWorldInBroadcastworld()) {
+        if (ess.getSettings().isAllowWorldInBroadcastworld()) {
             final World argWorld = ess.getWorld(args[0]);
             if (argWorld != null) {
                 world = argWorld;
@@ -53,7 +53,7 @@ public class Commandbroadcastworld extends EssentialsCommand {
         if (message.isEmpty()) {
             throw new NotEnoughArgumentsException();
         }
-        ess.broadcastTl(null, u -> u.getBase().getWorld().equals(world), true, "broadcast", message, AdventureUtil.parsed(AdventureUtil.legacyToMini(name)));
+        ess.broadcastTl(null, u -> !u.getBase().getWorld().equals(world), true, "broadcast", message, AdventureUtil.parsed(AdventureUtil.legacyToMini(name)));
     }
 
     @Override


### PR DESCRIPTION
Fixes #5694

This issue was caused by the passed predicate being excludes rather than includes.

Also addresses a separate issue where no help output was given when no arguments were specified and the command was sent by a player.