### PR TITLE
Fix jail-online-time with offline players

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerExtension.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerExtension.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials;
 
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Server;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -30,5 +31,9 @@ public class PlayerExtension {
 
     public Location getLocation() {
         return base.getLocation();
+    }
+
+    public OfflinePlayer getOffline() {
+        return base.getServer().getOfflinePlayer(base.getUniqueId());
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerExtension.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerExtension.java
@@ -34,6 +34,9 @@ public class PlayerExtension {
     }
 
     public OfflinePlayer getOffline() {
-        return base.getServer().getOfflinePlayer(base.getUniqueId());
+        if (base instanceof OfflinePlayerStub) {
+            return ((OfflinePlayerStub) base).base;
+        }
+        return base;
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtogglejail.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtogglejail.java
@@ -121,7 +121,7 @@ public class Commandtogglejail extends EssentialsCommand {
             final long displayTimeDiff = DateUtil.parseDateDiff(unparsedTime, true);
             final long timeDiff = DateUtil.parseDateDiff(unparsedTime, true, ess.getSettings().isJailOnlineTime());
             player.setJailTimeout(timeDiff);
-            player.setOnlineJailedTime(ess.getSettings().isJailOnlineTime() ? ((player.getBase().getStatistic(PLAY_ONE_TICK)) + (timeDiff / 50)) : 0);
+            player.setOnlineJailedTime(ess.getSettings().isJailOnlineTime() ? ((player.getOffline().getStatistic(PLAY_ONE_TICK)) + (timeDiff / 50)) : 0);
             sender.sendTl("jailSentenceExtended", DateUtil.formatDateDiff(displayTimeDiff));
 
             final String tlKey = "jailNotifySentenceExtended";

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtogglejail.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtogglejail.java
@@ -83,7 +83,7 @@ public class Commandtogglejail extends EssentialsCommand {
                         if (args.length > 2) {
                             player.setJailTimeout(timeDiff);
                             // 50 MSPT (milliseconds per tick)
-                            player.setOnlineJailedTime(ess.getSettings().isJailOnlineTime() ? ((player.getBase().getStatistic(PLAY_ONE_TICK)) + (timeDiff / 50)) : 0);
+                            player.setOnlineJailedTime(ess.getSettings().isJailOnlineTime() ? ((player.getOffline().getStatistic(PLAY_ONE_TICK)) + (timeDiff / 50)) : 0);
                         }
 
                         final String tlKey;

--- a/providers/1_12Provider/src/main/java/com/earth2me/essentials/OfflinePlayerStub.java
+++ b/providers/1_12Provider/src/main/java/com/earth2me/essentials/OfflinePlayerStub.java
@@ -64,8 +64,8 @@ import java.util.Set;
 import java.util.UUID;
 
 public class OfflinePlayerStub implements Player {
+    protected final transient org.bukkit.OfflinePlayer base;
     private final transient Server server;
-    private final transient org.bukkit.OfflinePlayer base;
     private transient Location location = new Location(null, 0, 0, 0, 0, 0);
     private transient World world;
     private boolean allowFlight = false;


### PR DESCRIPTION
Fixes #5658

Apparently you cannot get statistics for players returned by getPlayer when they are offline. This may be an upstream bug, but regardless, an easy fix here is to simply allow getting an OfflinePlayer reference from the User base for this purpose.

Below is a demonstration of the issue.

```java
sender.sendMessage(String.valueOf(player.getBase().getStatistic(PLAY_ONE_TICK)));
sender.sendMessage(String.valueOf(ess.getServer().getOfflinePlayer(player.getBase().getUniqueId()).getStatistic(PLAY_ONE_TICK)));
sender.sendMessage(String.valueOf(timeDiff / 50));
```


![90fd0a3c-20fb-42e3-badf-372405fc50b6](https://github.com/EssentialsX/Essentials/assets/17698576/adb0fdd2-ec2b-4d9e-a404-28077254c2d4)

As you can see, the offline player returns the correct result, but the player base does not.