### PR TITLE
Support custom biomes in random teleport excluded biome list

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -59,6 +59,7 @@ import net.ess3.nms.refl.providers.ReflServerStateProvider;
 import net.ess3.nms.refl.providers.ReflSpawnEggProvider;
 import net.ess3.nms.refl.providers.ReflSpawnerBlockProvider;
 import net.ess3.nms.refl.providers.ReflSyncCommandsProvider;
+import net.ess3.provider.BiomeKeyProvider;
 import net.ess3.provider.ContainerProvider;
 import net.ess3.provider.DamageEventProvider;
 import net.ess3.provider.FormattedCommandAliasProvider;
@@ -95,6 +96,7 @@ import net.ess3.provider.providers.ModernItemUnbreakableProvider;
 import net.ess3.provider.providers.ModernPersistentDataProvider;
 import net.ess3.provider.providers.ModernPlayerLocaleProvider;
 import net.ess3.provider.providers.ModernSignDataProvider;
+import net.ess3.provider.providers.PaperBiomeKeyProvider;
 import net.ess3.provider.providers.PaperContainerProvider;
 import net.ess3.provider.providers.PaperKnownCommandsProvider;
 import net.ess3.provider.providers.PaperMaterialTagProvider;
@@ -197,6 +199,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     private transient PlayerLocaleProvider playerLocaleProvider;
     private transient SignDataProvider signDataProvider;
     private transient DamageEventProvider damageEventProvider;
+    private transient BiomeKeyProvider biomeKeyProvider;
     private transient Kits kits;
     private transient RandomTeleport randomTeleport;
     private transient UpdateChecker updateChecker;
@@ -483,6 +486,10 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 damageEventProvider = new ModernDamageEventProvider();
             } else {
                 damageEventProvider = new LegacyDamageEventProvider();
+            }
+
+            if (PaperLib.isPaper() && VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_19_4_R01)) {
+                biomeKeyProvider = new PaperBiomeKeyProvider();
             }
 
             execTimer.mark("Init(Providers)");
@@ -1423,6 +1430,11 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
     @Override
     public DamageEventProvider getDamageEventProvider() {
         return damageEventProvider;
+    }
+
+    @Override
+    public BiomeKeyProvider getBiomeKeyProvider() {
+        return biomeKeyProvider;
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/IEssentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/IEssentials.java
@@ -9,6 +9,7 @@ import com.earth2me.essentials.perm.PermissionsHandler;
 import com.earth2me.essentials.updatecheck.UpdateChecker;
 import com.earth2me.essentials.userstorage.IUserMap;
 import net.ess3.nms.refl.providers.ReflOnlineModeProvider;
+import net.ess3.provider.BiomeKeyProvider;
 import net.ess3.provider.ContainerProvider;
 import net.ess3.provider.DamageEventProvider;
 import net.ess3.provider.FormattedCommandAliasProvider;
@@ -185,6 +186,8 @@ public interface IEssentials extends Plugin {
     PlayerLocaleProvider getPlayerLocaleProvider();
 
     DamageEventProvider getDamageEventProvider();
+
+    BiomeKeyProvider getBiomeKeyProvider();
 
     PluginCommand getPluginCommand(String cmd);
 }

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/BiomeKeyProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/BiomeKeyProvider.java
@@ -1,0 +1,8 @@
+package net.ess3.provider;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+
+public interface BiomeKeyProvider extends Provider {
+    NamespacedKey getBiomeKey(Block block);
+}

--- a/providers/PaperProvider/build.gradle
+++ b/providers/PaperProvider/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     implementation(project(':providers:BaseProviders')) {
         exclude(module: 'spigot-api')
     }
-    compileOnly 'io.papermc.paper:paper-api:1.18.2-R0.1-SNAPSHOT'
-    compileOnly 'io.papermc.paper:paper-mojangapi:1.18.2-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-mojangapi:1.20.4-R0.1-SNAPSHOT'
 }
 
 essentials {

--- a/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperBiomeKeyProvider.java
+++ b/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperBiomeKeyProvider.java
@@ -1,0 +1,19 @@
+package net.ess3.provider.providers;
+
+import net.ess3.provider.BiomeKeyProvider;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+
+@SuppressWarnings("deprecation")
+public class PaperBiomeKeyProvider implements BiomeKeyProvider {
+    @Override
+    public NamespacedKey getBiomeKey(final Block block) {
+        return Bukkit.getUnsafe().getBiomeKey(block.getWorld(), block.getX(), block.getY(), block.getZ());
+    }
+
+    @Override
+    public String getDescription() {
+        return "Paper Biome Key Provider";
+    }
+}


### PR DESCRIPTION
Fixes #5054.

Now possible via a provider. Unfortunately no better way of doing this, but at least this allows people to use custom biomes in their random teleport biome exclusions.

Would appreciate some further testing (I checked that the biome resolution works, and it *shouldn't explode* on old versions but I have not checked, not have I checked with a datapack).