### PR TITLE
Normalize legacy text before deserializing

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 public final class AdventureUtil {
     private static final LegacyComponentSerializer LEGACY_SERIALIZER;
     private static final MiniMessage MINI_MESSAGE_NO_TAGS;
+    private static final char LEGACY_CHARACTER = '§';
     private static final String LOOKUP = "0123456789abcdefklmnor";
     private static final NamedTextColor[] COLORS = new NamedTextColor[]{NamedTextColor.BLACK, NamedTextColor.DARK_BLUE, NamedTextColor.DARK_GREEN, NamedTextColor.DARK_AQUA, NamedTextColor.DARK_RED, NamedTextColor.DARK_PURPLE, NamedTextColor.GOLD, NamedTextColor.GRAY, NamedTextColor.DARK_GRAY, NamedTextColor.BLUE, NamedTextColor.GREEN, NamedTextColor.AQUA, NamedTextColor.RED, NamedTextColor.LIGHT_PURPLE, NamedTextColor.YELLOW, NamedTextColor.WHITE};
     private static IEssentials ess;
@@ -85,12 +86,34 @@ public final class AdventureUtil {
      * @param useCustomTags true if gold and red colors should use primary and secondary tags instead.
      */
     public static String legacyToMini(String text, boolean useCustomTags) {
-        final Component deserializedText = LEGACY_SERIALIZER.deserialize(text);
+        final Component deserializedText = LEGACY_SERIALIZER.deserialize(normalizeLegacyText(text));
         if (useCustomTags) {
             return miniMessageInstance.serialize(deserializedText);
         } else {
             return MINI_MESSAGE_NO_TAGS.serialize(deserializedText);
         }
+    }
+
+    /**
+     * Normalizes formatting codes within a section sign legacy string
+     */
+    private static String normalizeLegacyText(String text) {
+        if (text == null) {
+            return null;
+        }
+        final int length = text.length();
+        final char[] chars = text.toCharArray();
+        final StringBuilder normalized = new StringBuilder();
+        for (int i = 0; i < length - 1; ++i) {
+            final char current = chars[i];
+            normalized.append(current);
+            if (current == LEGACY_CHARACTER) {
+                final char next = chars[i + 1];
+                normalized.append(Character.toLowerCase(next));
+                ++i;
+            }
+        }
+        return normalized.toString();
     }
 
     /**

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
@@ -98,7 +98,7 @@ public final class AdventureUtil {
      * Normalizes formatting codes within a section sign legacy string
      */
     private static String normalizeLegacyText(String text) {
-        if (text == null) {
+        if (text == null || text.isEmpty()) {
             return null;
         }
         final int length = text.length();
@@ -113,6 +113,7 @@ public final class AdventureUtil {
                 ++i;
             }
         }
+        normalized.append(chars[length - 1]);
         return normalized.toString();
     }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
@@ -104,16 +104,15 @@ public final class AdventureUtil {
         final int length = text.length();
         final char[] chars = text.toCharArray();
         final StringBuilder normalized = new StringBuilder();
-        for (int i = 0; i < length - 1; ++i) {
+        for (int i = 0; i < length; ++i) {
             final char current = chars[i];
             normalized.append(current);
-            if (current == LEGACY_CHARACTER) {
+            if (current == LEGACY_CHARACTER && i < length - 1) {
                 final char next = chars[i + 1];
                 normalized.append(Character.toLowerCase(next));
                 ++i;
             }
         }
-        normalized.append(chars[length - 1]);
         return normalized.toString();
     }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
@@ -99,7 +99,7 @@ public final class AdventureUtil {
      */
     private static String normalizeLegacyText(String text) {
         if (text == null || text.isEmpty()) {
-            return null;
+            return text;
         }
         final int length = text.length();
         final char[] chars = text.toCharArray();


### PR DESCRIPTION
Looks like Adventure's legacy deserializer does not like it when color codes are capitalized. Unfortunately this is quite common, and exposed to users (e.g. nicknames). Normalize this.

Ideally fixed in the serializer, but this should work fine as a hotfix.

Fixes #5708, #5709.