### PR TITLE
Fix #5720: color from /nick transfers into balance on /baltop

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
@@ -47,7 +47,8 @@ public class BalanceTopImpl implements BalanceTop {
                     } else {
                         name = user.getDisplayName();
                     }
-                    entries.add(new BalanceTop.Entry(user.getUUID(), name, userMoney));
+                    final String nameColorLimiter = "§f";
+                    entries.add(new BalanceTop.Entry(user.getUUID(), name + nameColorLimiter, userMoney));
                 }
             }
         }


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes #5720 . 

### Details

**Proposed fix:**    
<!-- Type a description of your proposed fix below this line. -->

My fix consists in storing the name of the player with a color reseting string at the end. By doing this everytime a /balancetop command is executed the colors in the player name don't spread to the following part of the line.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 11

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  17.0.9

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.20.4, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Before:
When the command /balancetop was executed the colors from the name of a player would spread to the money amount text, as the following screenshot shows.

![image](https://github.com/EssentialsX/Essentials/assets/42421954/eb9bbefa-e849-4d24-bd44-e28dbdd16556)

After:
I fixed this bug by storing the player's name with a color format reseting string at the end. By doing this I was able to avoid the bug. Other way to solve this would be by adding the color format reseting string after getting the entries from the BalanceTop but it would not solve the case where the entries are used to other things different from showing the balance top to a player.

![image](https://github.com/EssentialsX/Essentials/assets/42421954/4fd4cc57-c3d4-4555-a9ab-eed74d052d78)
