### PR TITLE
Strict parsing for legacy converted placeholders

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/AdventureUtil.java
@@ -50,7 +50,7 @@ public final class AdventureUtil {
         }
         LEGACY_SERIALIZER = builder.build();
 
-        MINI_MESSAGE_NO_TAGS = MiniMessage.miniMessage();
+        MINI_MESSAGE_NO_TAGS = MiniMessage.builder().strict(true).build();
 
         miniMessageInstance = createMiniMessageInstance();
     }


### PR DESCRIPTION
This fixes issues where arguments converted implicitly from MiniMessage are prone to bleeding into the rest of the output.

The fix mostly works since `MINI_MESSAGE_NO_TAGS` is only used for legacy conversion, while `miniMessageInstance` is used in all other cases normally. If that were not the case, we would not want strict parsing everywhere since we don't enforce this in translations anyway.

Fixes #5729
Fixes #5730
Fixes #5732
Fixes #5735

Fixes #5720
Closes #5728