### PR TITLE
Ensure translatable placeholders for gamemode in cantGamemode key

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandgamemode.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandgamemode.java
@@ -55,7 +55,7 @@ public class Commandgamemode extends EssentialsLoopCommand {
         }
 
         if (isProhibitedChange(user, gameMode)) {
-            user.sendTl("cantGamemode", gameMode.name());
+            user.sendTl("cantGamemode", user.playerTl(gameMode.toString().toLowerCase(Locale.ENGLISH)));
             return;
         }
 


### PR DESCRIPTION
### Information

This PR fixes #5763  

### Details

**Proposed fix:**    
Make gamemode placeholder translatable in [cantGamemode](https://github.com/EssentialsX/Essentials/blob/c60ed56190ef9992cc9d574157b4e52eed3ccaff/Essentials/src/main/resources/messages.properties#L123) key.


**Environments tested:**    


OS: Windows 11

Java version: OpenJDK Runtime Environment Corretto-21.0.2.13.1

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.20.4, git-Paper-496)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

