### PR TITLE
Opt-out of remapping on Paper 1.20.5+

### DIFF
--- a/build-logic/src/main/kotlin/essentials.base-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/essentials.base-conventions.gradle.kts
@@ -75,6 +75,9 @@ tasks {
     }
     withType<Jar> {
         archiveVersion.set(rootProject.ext["FULL_VERSION"] as String)
+        manifest {
+            attributes("paperweight-mappings-namespace" to "mojang")
+        }
     }
     withType<Sign> {
         onlyIf { project.hasProperty("forceSign") }


### PR DESCRIPTION
All of our NMS usage is through reflection.
