### PR TITLE
Add 1.21 items to items.json

### DIFF
--- a/Essentials/src/main/resources/items.json
+++ b/Essentials/src/main/resources/items.json
@@ -3044,6 +3044,11 @@
   "chiseledshelf": "chiseled_bookshelf",
   "cshelfbook": "chiseled_bookshelf",
   "minecraft:chiseled_bookshelf": "chiseled_bookshelf",
+  "chiseled_copper": {
+    "material": "CHISELED_COPPER"
+  },
+  "chiseledcopper": "chiseled_copper",
+  "minecraft:chiseled_copper": "chiseled_copper",
   "chiseled_deepslate": {
     "material": "CHISELED_DEEPSLATE"
   },


### PR DESCRIPTION
### Information

This PR fixes #5816. 

### Details

**Proposed fix:**    
Add the suggested items to fix errors being thrown and the lack of presence of the materials in  the /give command


**Environments tested:**    
Inapplicable

**Demonstration:**    
Inapplicable

### To-do:
**Blocks with items**
- [x] Chiseled Copper
  - [ ] Add weathered variants
- [ ] Chiseled Tuff
- [ ] Copper Bulb
  - [ ] Add weathered variants
- [ ] Copper Door
  - [ ] Add weathered variants
- [ ] Copper Grate
  - [ ] Add weathered variants
- [ ] Copper Trapdoor
  - [ ] Add weathered variants
- [ ] Crafter
- [ ] Heavy Core
- [ ] Ominous Trial Spawner
- [ ] Ominous Vault
- [ ] Polished Tuff
- [ ] Trial Spawner
- [ ] Tuff Bricks
- [ ] Tuff Slab
- [ ] Tuff Stairs
- [ ] Tuff Wall
- [ ] Vault

**Item-only**
- [ ] Arrow of Infestation
- [ ] Arrow of Oozing
- [ ] Arrow of Weaving
- [ ] Arrow of Wind Charging
- [ ] Flow Banner Pattern
- [ ] Guster Banner Pattern
- [ ] Breeze Rod
- [ ] Mace
- [ ] Precipice Music Disc
- [ ] Creator Music Disc
- [ ] Creator (Music Box) Music Disc
- [ ] Ominous Bottle
- [ ] Ominous Trial Key
- [ ] Potion of Infestation
- [ ] Potion of Oozing
- [ ] Potion of Weaving
- [ ] Potion of Wind Charging
- [ ] Flow Pottery Sherd
- [ ] Guster Pottery Sherd
- [ ] Scrape Pottery Sherd
- [ ] Bolt Armor Trim
- [ ] Flow Armor Trim
- [ ] Bogged Spawn Egg
- [ ] Breeze Spawn Egg
- [ ] Trial Key
- [ ] Wind Charge
