### PR TITLE
Allow unicode characters as userdata file is now written in UTF-8

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserData.java
@@ -178,8 +178,6 @@ public abstract class UserData extends PlayerExtension implements IConf {
     }
 
     public void setHome(String name, final Location loc) {
-        //Invalid names will corrupt the yaml
-        name = StringUtil.safeString(name);
         holder.homes().put(name, LazyLocation.fromLocation(loc));
         config.save();
     }


### PR DESCRIPTION
### Information

This PR fixes #1742. 

### Details

**Proposed fix:**    
Allow unicode characters as userdata file is now encoded with UTF-8. (Remove `safeString` call)


**Environments tested:**    

OS: Windows 11

Java version:  Corretto-21.0.3.9.1

- [x] Most recent Paper version (1.21-40-master@b45d9b6)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**    
![image](https://github.com/EssentialsX/Essentials/assets/13144755/ff12c53c-ce55-4927-805e-6b150dce6954)


