### PR TITLE
Fix incompatibility with AlternativeCommandsHandler & Paper API

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/AlternativeCommandsHandler.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/AlternativeCommandsHandler.java
@@ -25,6 +25,14 @@ public class AlternativeCommandsHandler {
                 addPlugin(plugin);
             }
         }
+        ess.scheduleSyncDelayedTask(() -> {
+            // add plugins again in case they registered commands with the new API
+            for (final Plugin plugin : ess.getServer().getPluginManager().getPlugins()) {
+                if (plugin.isEnabled()) {
+                    ess.getAlternativeCommandsHandler().addPlugin(plugin);
+                }
+            }
+        });
     }
 
     public final void addPlugin(final Plugin plugin) {

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -23,7 +23,6 @@ import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.Plugin;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 
 import java.io.File;
@@ -724,10 +723,6 @@ public class Settings implements net.ess3.api.ISettings {
                     // This is 2 because Settings are reloaded twice in the startup lifecycle
                     if (reloadCount.get() < 2) {
                         ess.scheduleSyncDelayedTask(() -> {
-                            for (Plugin plugin : ess.getServer().getPluginManager().getPlugins()) {
-                                // add plugins again in case they registered commands with the new API
-                                ess.getAlternativeCommandsHandler().addPlugin(plugin);
-                            }
                             _addAlternativeCommand(effectiveAlias, toDisable);
                         });
                     } else {

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -722,9 +722,7 @@ public class Settings implements net.ess3.api.ISettings {
 
                     // This is 2 because Settings are reloaded twice in the startup lifecycle
                     if (reloadCount.get() < 2) {
-                        ess.scheduleSyncDelayedTask(() -> {
-                            _addAlternativeCommand(effectiveAlias, toDisable);
-                        });
+                        ess.scheduleSyncDelayedTask(() -> _addAlternativeCommand(effectiveAlias, toDisable));
                     } else {
                         _addAlternativeCommand(effectiveAlias, toDisable);
                     }

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -23,6 +23,7 @@ import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 
 import java.io.File;
@@ -703,6 +704,18 @@ public class Settings implements net.ess3.api.ISettings {
                 ess.getKnownCommandsProvider().getKnownCommands().putAll(disabledBukkitCommands);
                 disabledBukkitCommands.clear();
                 mapModified = true;
+            }
+
+            if (reloadCount.get() < 2) {
+                // on startup: add plugins again in case they registered commands with the new API
+                // we need to schedule this task before any of the below tasks using _addAlternativeCommand.
+                ess.scheduleSyncDelayedTask(() -> {
+                    for (final Plugin plugin : ess.getServer().getPluginManager().getPlugins()) {
+                        if (plugin.isEnabled()) {
+                            ess.getAlternativeCommandsHandler().addPlugin(plugin);
+                        }
+                    }
+                });
             }
 
             for (final String command : disabledCommands) {

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -23,6 +23,7 @@ import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
 import org.spongepowered.configurate.CommentedConfigurationNode;
 
 import java.io.File;
@@ -722,7 +723,13 @@ public class Settings implements net.ess3.api.ISettings {
 
                     // This is 2 because Settings are reloaded twice in the startup lifecycle
                     if (reloadCount.get() < 2) {
-                        ess.scheduleSyncDelayedTask(() -> _addAlternativeCommand(effectiveAlias, toDisable));
+                        ess.scheduleSyncDelayedTask(() -> {
+                            for (Plugin plugin : ess.getServer().getPluginManager().getPlugins()) {
+                                // add plugins again in case they registered commands with the new API
+                                ess.getAlternativeCommandsHandler().addPlugin(plugin);
+                            }
+                            _addAlternativeCommand(effectiveAlias, toDisable);
+                        });
                     } else {
                         _addAlternativeCommand(effectiveAlias, toDisable);
                     }


### PR DESCRIPTION
When addPlugin is called from the plugin enable listener, commands registered with the new API may not exist yet as they are registered during the command registration event, which is called after all plugins are enabled (unless they are registered at bootstrap time). The existing code appears to already handle repeated addPlugin calls for the same plugin correctly. So we can fix this problem by adding an additional call to addPlugin once all plugins have loaded. We do not remove the existing addPlugin call as that would prevent collecting some alternate commands registered with the old API (if they conflicted). This does mean the alternate commands functionality is somewhat limited for commands registered with the new API compared to old API, however, this is much better than the current behavior where if a vanilla command exists with the same name, Essentials will attempt to re-register the vanilla command.