### PR TITLE
Fix support for Chinese and other characters in setwarp and sethome filenames; ensure backward compatibility with old safe string names replaced by underscores

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Worth.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Worth.java
@@ -32,6 +32,7 @@ public class Worth implements IConf {
     public BigDecimal getPrice(final IEssentials ess, final ItemStack itemStack) {
         BigDecimal result = BigDecimal.ONE.negate();
 
+
         final String itemname = itemStack.getType().toString().toLowerCase(Locale.ENGLISH).replace("_", "");
 
         if (VersionUtil.PRE_FLATTENING) {

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
@@ -8,7 +8,7 @@ import com.earth2me.essentials.utils.StringUtil;
 import io.papermc.lib.PaperLib;
 import net.ess3.api.TranslatableException;
 import net.ess3.api.events.UserTeleportHomeEvent;
-import org.bukkit.Bukkit;
+
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -144,7 +144,6 @@ public class Commandhome extends EssentialsCommand {
             future.thenAccept(success -> {
                 if (success) {
                     user.sendTl("teleportHome", home);
-                    Bukkit.getLogger().info(home);
                 }
             });
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
@@ -8,7 +8,6 @@ import com.earth2me.essentials.utils.StringUtil;
 import io.papermc.lib.PaperLib;
 import net.ess3.api.TranslatableException;
 import net.ess3.api.events.UserTeleportHomeEvent;
-
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -18,7 +17,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
 
 public class Commandhome extends EssentialsCommand {
     public Commandhome() {
@@ -128,8 +126,7 @@ public class Commandhome extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
 
-       final  Location loc = Optional.ofNullable(player.getHome(home))
-               .orElse(player.getHome(StringUtil.old_safeString(home)));
+        final  Location loc = player.getHome(home);
 
         if (loc == null) {
             throw new NotEnoughArgumentsException();

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
@@ -8,6 +8,7 @@ import com.earth2me.essentials.utils.StringUtil;
 import io.papermc.lib.PaperLib;
 import net.ess3.api.TranslatableException;
 import net.ess3.api.events.UserTeleportHomeEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -15,7 +16,9 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+
 
 public class Commandhome extends EssentialsCommand {
     public Commandhome() {
@@ -124,7 +127,10 @@ public class Commandhome extends EssentialsCommand {
         if (home.length() < 1) {
             throw new NotEnoughArgumentsException();
         }
-        final Location loc = player.getHome(home);
+
+       final  Location loc = Optional.ofNullable(player.getHome(home))
+               .orElse(player.getHome(StringUtil.old_safeString(home)));
+
         if (loc == null) {
             throw new NotEnoughArgumentsException();
         }
@@ -138,6 +144,7 @@ public class Commandhome extends EssentialsCommand {
             future.thenAccept(success -> {
                 if (success) {
                     user.sendTl("teleportHome", home);
+                    Bukkit.getLogger().info(home);
                 }
             });
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
@@ -10,10 +10,11 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 public final class StringUtil {
-    private static final Pattern INVALIDFILECHARS = Pattern.compile("[^a-z0-9-]");
+    private static final Pattern INVALIDFILECHARS = Pattern.compile("[^\\p{L}\\p{N}\\.\\-\\p{IsHan}\\p{IsHiragana}\\p{IsKatakana}\\p{IsHangul}]");
     private static final Pattern STRICTINVALIDCHARS = Pattern.compile("[^a-z0-9]");
     @SuppressWarnings("CheckStyle")
-    private static final Pattern INVALIDCHARS = Pattern.compile("[^\t\n\r\u0020-\u007E\u0085\u00A0-\uD7FF\uE000-\uFFFC]");
+    private static final Pattern INVALIDCHARS = Pattern.compile("[^\t\n\r\u0020-\u007E\u0085\u00A0-\uD7FF\uE000-\uFFFD]");
+
 
     private StringUtil() {
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
@@ -10,8 +10,9 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 public final class StringUtil {
-    private static final Pattern INVALIDFILECHARS = Pattern.compile("[/\\\\:*?\"<>|\\x00-\\x1F]");
-    private static final Pattern STRICTINVALIDCHARS = Pattern.compile("[^a-z0-9]");
+    private static final Pattern INVALIDCHARACTER = Pattern.compile("[/\\\\:*?\"<>|\\x00-\\x1F]");
+    private static final Pattern OLD_INVALIDCHARACTER = Pattern.compile("[^a-z0-9-]");
+    //private static final Pattern STRICTINVALIDCHARS = Pattern.compile("[^a-z0-9]");
     @SuppressWarnings("CheckStyle")
     private static final Pattern INVALIDCHARS = Pattern.compile("[^\t\n\r\u0020-\u007E\u0085\u00A0-\uD7FF\uE000-\uFFFD]");
 
@@ -21,7 +22,7 @@ public final class StringUtil {
 
     //Used to clean file names before saving to disk
     public static String sanitizeFileName(final String name) {
-        return INVALIDFILECHARS.matcher(name.toLowerCase(Locale.ENGLISH)).replaceAll("_");
+        return INVALIDCHARACTER.matcher(name.toLowerCase(Locale.ENGLISH)).replaceAll("_");
     }
 
     //Used to clean strings/names before saving as filenames/permissions
@@ -29,13 +30,13 @@ public final class StringUtil {
         if (string == null) {
             return null;
         }
-        return INVALIDFILECHARS.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
+        return INVALIDCHARACTER.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
     }
     public static String old_safeString(final String string) {
         if (string == null) {
             return null;
         }
-        return STRICTINVALIDCHARS.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
+        return OLD_INVALIDCHARACTER.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
     }
     //Less restrictive string sanitizing, when not used as perm or filename
     public static String sanitizeString(final String string) {

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 public final class StringUtil {
-    private static final Pattern INVALIDFILECHARS = Pattern.compile("[^\\p{L}\\p{N}\\.\\-\\p{IsHan}\\p{IsHiragana}\\p{IsKatakana}\\p{IsHangul}]");
+    private static final Pattern INVALIDFILECHARS = Pattern.compile("[/\\\\:*?\"<>|\\x00-\\x1F]");
     private static final Pattern STRICTINVALIDCHARS = Pattern.compile("[^a-z0-9]");
     @SuppressWarnings("CheckStyle")
     private static final Pattern INVALIDCHARS = Pattern.compile("[^\t\n\r\u0020-\u007E\u0085\u00A0-\uD7FF\uE000-\uFFFD]");
@@ -29,9 +29,14 @@ public final class StringUtil {
         if (string == null) {
             return null;
         }
+        return INVALIDFILECHARS.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
+    }
+    public static String old_safeString(final String string) {
+        if (string == null) {
+            return null;
+        }
         return STRICTINVALIDCHARS.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
     }
-
     //Less restrictive string sanitizing, when not used as perm or filename
     public static String sanitizeString(final String string) {
         return INVALIDCHARS.matcher(string).replaceAll("");

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
@@ -11,8 +11,7 @@ import java.util.regex.Pattern;
 
 public final class StringUtil {
     private static final Pattern INVALIDCHARACTER = Pattern.compile("[/\\\\:*?\"<>|\\x00-\\x1F]");
-    private static final Pattern OLD_INVALIDCHARACTER = Pattern.compile("[^a-z0-9-]");
-    //private static final Pattern STRICTINVALIDCHARS = Pattern.compile("[^a-z0-9]");
+    private static final Pattern STRICTINVALIDCHARS = Pattern.compile("[^a-z0-9]");
     @SuppressWarnings("CheckStyle")
     private static final Pattern INVALIDCHARS = Pattern.compile("[^\t\n\r\u0020-\u007E\u0085\u00A0-\uD7FF\uE000-\uFFFD]");
 
@@ -30,14 +29,15 @@ public final class StringUtil {
         if (string == null) {
             return null;
         }
-        return INVALIDCHARACTER.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
+        return STRICTINVALIDCHARS.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
     }
-    public static String old_safeString(final String string) {
+    public static String new_safeString(final String string) {
         if (string == null) {
             return null;
         }
-        return OLD_INVALIDCHARACTER.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
+        return INVALIDCHARACTER.matcher(string.toLowerCase(Locale.ENGLISH)).replaceAll("_");
     }
+
     //Less restrictive string sanitizing, when not used as perm or filename
     public static String sanitizeString(final String string) {
         return INVALIDCHARS.matcher(string).replaceAll("");


### PR DESCRIPTION
## Information
This PR fixes #5889.

## Details
Proposed fix:
This PR addresses the issue where  and  commands in the Essentials plugin do not support Chinese and other non-alphanumeric characters in filenames. The following changes have been made to ensure broader character support and maintain backward compatibility:setwarpsethome

## Support for Chinese and other characters:

Updated the regular expression patterns to allow Chinese characters and other non-alphanumeric characters in  and  filenames.setwarpsethome
Backward compatibility with old safe string names:

When a player uses the  command, the system will first attempt to match the provided  with the new format./home <homename>homename
If no match is found, it will then attempt to match the old format where special characters were replaced by underscores, ensuring compatibility with existing configurations.
These changes allow players to use a wider range of characters in their home and warp names while preserving the functionality for names created with the previous format.

## Example Usage:

New behavior: Players can now set home names like ./sethome 我的房子
Backward compatibility: If a player previously had a home named  (converted from ), using  will still work./home 我的菜地 ("____") 
## Environments tested:

OS: Windows 10
Java version: OpenJDK 21(21.0.3)

 Most recent Paper version (1.20.4, #497)
