### PR TITLE
Fix removing negative items in /clearinventory

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandclearinventory.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandclearinventory.java
@@ -6,6 +6,7 @@ import com.earth2me.essentials.craftbukkit.Inventories;
 import com.earth2me.essentials.utils.NumberUtil;
 import com.earth2me.essentials.utils.StringUtil;
 import com.earth2me.essentials.utils.VersionUtil;
+import net.ess3.api.TranslatableException;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
@@ -80,7 +81,7 @@ public class Commandclearinventory extends EssentialsCommand {
         }
     }
 
-    protected void clearHandler(final CommandSource sender, final Player player, final String[] args, final int offset, final boolean showExtended) {
+    protected void clearHandler(final CommandSource sender, final Player player, final String[] args, final int offset, final boolean showExtended) throws TranslatableException {
         ClearHandlerType type = ClearHandlerType.ALL_EXCEPT_ARMOR;
         final Set<Item> items = new HashSet<>();
         int amount = -1;
@@ -122,6 +123,11 @@ public class Commandclearinventory extends EssentialsCommand {
                 if (VersionUtil.PRE_FLATTENING) {
                     //noinspection deprecation
                     stack.setDurability(item.getData());
+                }
+
+                // can't remove a negative amount of items. (it adds them)
+                if(amount < -1){
+                    throw new TranslatableException("cannotRemoveNegativeItems");
                 }
 
                 // amount -1 means all items will be cleared

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandclearinventory.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandclearinventory.java
@@ -126,7 +126,7 @@ public class Commandclearinventory extends EssentialsCommand {
                 }
 
                 // can't remove a negative amount of items. (it adds them)
-                if(amount < -1){
+                if (amount < -1) {
                     throw new TranslatableException("cannotRemoveNegativeItems");
                 }
 
@@ -137,7 +137,6 @@ public class Commandclearinventory extends EssentialsCommand {
                         sender.sendTl("inventoryClearingStack", removedAmount, stack.getType().toString().toLowerCase(Locale.ENGLISH), player.getDisplayName());
                     }
                 } else {
-                    stack.setAmount(amount < 0 ? 1 : amount);
                     if (Inventories.removeItemAmount(player, stack, amount)) {
                         sender.sendTl("inventoryClearingStack", amount, stack.getType().toString().toLowerCase(Locale.ENGLISH), player.getDisplayName());
                     } else {

--- a/Essentials/src/main/java/com/earth2me/essentials/craftbukkit/Inventories.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/craftbukkit/Inventories.java
@@ -243,6 +243,10 @@ public final class Inventories {
     }
 
     public static boolean removeItemAmount(final Player player, final ItemStack toRemove, int amount) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("Amount cannot be negative.");
+        }
+
         final List<Integer> clearSlots = new ArrayList<>();
         final ItemStack[] items = player.getInventory().getContents();
 

--- a/Essentials/src/main/resources/messages.properties
+++ b/Essentials/src/main/resources/messages.properties
@@ -118,6 +118,7 @@ burnMsg=<primary>You set<secondary> {0} <primary>on fire for<secondary> {1} seco
 cannotSellNamedItem=<primary>You are not allowed to sell named items.
 cannotSellTheseNamedItems=<primary>You are not allowed to sell these named items\: <dark_red>{0}
 cannotStackMob=<dark_red>You do not have permission to stack multiple mobs.
+cannotRemoveNegativeItems=<dark_red>You can not remove negative items.
 canTalkAgain=<primary>You can now talk again.
 cantFindGeoIpDB=Can''t find GeoIP database\!
 cantGamemode=<dark_red>You do not have permission to change to gamemode {0}


### PR DESCRIPTION
### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes #5894 

### Details

**Proposed fix:**    
ensure amount of removed items is not less than -1 (-1 clears all items of that type)


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 10

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  21.0.3

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ x ] Most recent Paper version (1.21)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**    
before: 
![image](https://github.com/user-attachments/assets/13229f21-1f78-4999-a426-c7bcb1f6b621)

after:
![image](https://github.com/user-attachments/assets/a906210c-c15c-40a6-923a-4e42a8fca39a)

