### PR TITLE
hide version check disabled message

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/updatecheck/UpdateChecker.java
@@ -208,6 +208,9 @@ public final class UpdateChecker {
 
     public Component[] getVersionMessages(final boolean sendLatestMessage, final boolean verboseErrors, final CommandSource source) {
         if (!ess.getSettings().isUpdateCheckEnabled()) {
+            if (source.isPlayer()) {
+                return new Component[] {};
+            }
             return new Component[] {source.tlComponent("versionCheckDisabled")};
         }
 


### PR DESCRIPTION
my fork EssentialsY (Why do you do this)
disables the message saying "version checker is disabled" if its sending to a player because it is stupid.
