### PR TITLE
Bump PlaceholderAPI dependency to version 2.11.6

### DIFF
--- a/EssentialsDiscord/build.gradle
+++ b/EssentialsDiscord/build.gradle
@@ -12,7 +12,7 @@ dependencies {
         exclude(module: 'okhttp')
     }
     compileOnly 'org.apache.logging.log4j:log4j-core:2.17.1'
-    compileOnly 'me.clip:placeholderapi:2.10.9'
+    compileOnly 'me.clip:placeholderapi:2.11.6'
 }
 
 shadowJar {


### PR DESCRIPTION
Versions older than 2.11.5 are currently missing from the PlaceholderAPI Maven repo, so we need to bump this for EssentialsX to compile.