### PR TITLE
Remove extraneous code in command preprocess event handling

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -705,21 +705,17 @@ public class EssentialsPlayerListener implements Listener, FakeAccessor {
             // If so, no need to check for (and write) new ones.
             boolean cooldownFound = false;
 
-            // Iterate over a copy of getCommandCooldowns in case of concurrent modifications
-            for (final Entry<Pattern, Long> entry : new HashMap<>(user.getCommandCooldowns()).entrySet()) {
+            for (final Entry<Pattern, Long> entry : user.getCommandCooldowns().entrySet()) {
                 // Remove any expired cooldowns
                 if (entry.getValue() <= System.currentTimeMillis()) {
                     user.clearCommandCooldown(entry.getKey());
                     // Don't break in case there are other command cooldowns left to clear.
                 } else if (entry.getKey().matcher(fullCommand).matches()) {
                     // User's current cooldown hasn't expired, inform and terminate cooldown code.
-                    if (entry.getValue() > System.currentTimeMillis()) {
-                        final String commandCooldownTime = DateUtil.formatDateDiff(entry.getValue());
-                        user.sendTl("commandCooldown", commandCooldownTime);
-                        cooldownFound = true;
-                        event.setCancelled(true);
-                        break;
-                    }
+                    final String commandCooldownTime = DateUtil.formatDateDiff(entry.getValue());
+                    user.sendTl("commandCooldown", commandCooldownTime);
+                    cooldownFound = true;
+                    event.setCancelled(true);
                 }
             }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -65,7 +65,6 @@ import java.lang.management.ManagementFactory;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
no need to recreate a HashMap instance to prevent concurrency since user.getCommandCooldowns() already makes a new HashMap  instance

the second if condition verifying entry.getValue() > System.currentTimeMillis() is redundant as it is already implied by the first if condition

Don't break in case there are other command cooldowns left to clear

You need to select a pull request template!

If you're adding a new feature, copy and paste the following parameter at the end of the URL:
    ?template=new-feature.md

If you're fixing a bug, copy and paste the following parameter at the end of the URL:
    ?template=bug-fix.md

For more information about contributing to EssentialsX, see CONTRIBUTING.md:
    https://github.com/EssentialsX/Essentials/blob/2.x/CONTRIBUTING.md
