### PR TITLE
Revert removal of InvalidWorldException

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/api/InvalidWorldException.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/api/InvalidWorldException.java
@@ -1,0 +1,20 @@
+package com.earth2me.essentials.api;
+
+import net.ess3.api.TranslatableException;
+
+/**
+ * @deprecated This exception is unused. Use {@link net.ess3.api.InvalidWorldException} instead.
+ */
+@Deprecated
+public class InvalidWorldException extends TranslatableException {
+    private final String world;
+
+    public InvalidWorldException(final String world) {
+        super("invalidWorld");
+        this.world = world;
+    }
+
+    public String getWorld() {
+        return this.world;
+    }
+}

--- a/Essentials/src/main/java/net/ess3/api/InvalidWorldException.java
+++ b/Essentials/src/main/java/net/ess3/api/InvalidWorldException.java
@@ -1,0 +1,20 @@
+package net.ess3.api;
+/**
+ * Fired when trying to teleport a user to an invalid world. This usually only occurs if a world has been removed from
+ * the server and a player tries to teleport to a warp or home in that world.
+ *
+ * @deprecated no longer thrown.
+ */
+@Deprecated
+public class InvalidWorldException extends TranslatableException {
+    private final String world;
+
+    public InvalidWorldException(final String world) {
+        super("invalidWorld");
+        this.world = world;
+    }
+
+    public String getWorld() {
+        return this.world;
+    }
+}


### PR DESCRIPTION
Fixes API breakage for people who catch the exception.

It is no longer thrown.