### PR TITLE
Add config for use of Paper chat events

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -56,6 +56,8 @@ public interface ISettings extends IConf {
 
     boolean isChatQuestionEnabled();
 
+    boolean isUsePaperChatEvent();
+
     BigDecimal getCommandCost(IEssentialsCommand cmd);
 
     BigDecimal getCommandCost(String label);

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -266,6 +266,11 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getBoolean("chat.question-enabled", true);
     }
 
+    @Override
+    public boolean isUsePaperChatEvent() {
+        return config.getBoolean("chat.paper-chat-events", true);
+    }
+
     public boolean _isTeleportSafetyEnabled() {
         return config.getBoolean("teleport-safety", true);
     }

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -988,6 +988,12 @@ chat:
   # Whether chat questions should be enabled or not.
   question-enabled: true
 
+  # Whether EssentialsX should use Paper's modern chat event system in 1.16.5+.
+  # This is required for modern chat features such as hover events and click events.
+  # If you're experiencing issues with other plugins that use the chat event system, you can disable this.
+  # You must restart your server after changing this setting.
+  paper-chat-events: true
+
 ############################################################
 # +------------------------------------------------------+ #
 # |                 EssentialsX Protect                  | #

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/EssentialsChat.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/EssentialsChat.java
@@ -34,7 +34,7 @@ public class EssentialsChat extends JavaPlugin {
             return;
         }
 
-        if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_16_5_R01) && VersionUtil.isPaper()) {
+        if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_16_5_R01) && VersionUtil.isPaper() && ess.getSettings().isUsePaperChatEvent()) {
             final PaperChatHandler paperHandler = new PaperChatHandler((Essentials) ess, this);
             paperHandler.registerListeners();
         } else {


### PR DESCRIPTION
adds a config option to disable the use of paper chat events while other plugins learn how to join the 21st century.

re #6048
re #6051 