### PR TITLE
Fix startup issue with potion providers

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/ProviderFactory.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ProviderFactory.java
@@ -68,7 +68,7 @@ public class ProviderFactory {
                         highestProvider = provider;
                         highestProviderData = providerData;
                     }
-                } catch (final Exception e) {
+                } catch (final Throwable e) {
                     essentials.getLogger().log(Level.SEVERE, "Failed to initialize provider " + provider.getName(), e);
                 }
             }

--- a/providers/1_12Provider/src/main/java/net/ess3/provider/providers/LegacyPotionMetaProvider.java
+++ b/providers/1_12Provider/src/main/java/net/ess3/provider/providers/LegacyPotionMetaProvider.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 @ProviderData(description = "1.9-1.20.4 Potion Meta Provider", weight = 1)
 public class LegacyPotionMetaProvider implements PotionMetaProvider {
-    private static final Map<Integer, PotionType> damageValueToType = ImmutableMap.<Integer, PotionType>builder()
+    private final Map<Integer, PotionType> damageValueToType = ImmutableMap.<Integer, PotionType>builder()
         .put(1, PotionType.REGEN)
         .put(2, PotionType.SPEED)
         .put(3, PotionType.FIRE_RESISTANCE)


### PR DESCRIPTION
The LegacyPotionMetaProvider was initializing a map with enums that don't exist on modern versions. Since this was a static variable, this map got initialized when the test method was called, leading to a NoSuchFieldError.

Also improved resilience of these provider-type issues again by catching a Throwable rather than an Exception in the ProviderFactory.

Fixes #6054