### PR TITLE
Fix /book command on 1.20+

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/MetaItemStack.java
@@ -3,7 +3,6 @@ package com.earth2me.essentials;
 import com.earth2me.essentials.textreader.BookInput;
 import com.earth2me.essentials.textreader.BookPager;
 import com.earth2me.essentials.textreader.IText;
-import com.earth2me.essentials.utils.EnumUtil;
 import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.MaterialUtil;
 import com.earth2me.essentials.utils.NumberUtil;
@@ -217,8 +216,6 @@ public class MetaItemStack {
             return;
         }
 
-        final Material WRITTEN_BOOK = EnumUtil.getMaterial("WRITTEN_BOOK");
-
         if (split.length > 1 && split[0].equalsIgnoreCase("name") && hasMetaPermission(sender, "name", false, true, ess)) {
             final String displayName = FormatUtil.replaceFormat(split[1].replaceAll("(?<!\\\\)_", " ").replace("\\_", "_"));
             final ItemMeta meta = stack.getItemMeta();
@@ -254,7 +251,7 @@ public class MetaItemStack {
             final IText input = new BookInput("book", true, ess);
             final BookPager pager = new BookPager(input);
             // This fix only applies to written books - which require an author and a title. https://bugs.mojang.com/browse/MC-59153
-            if (stack.getType() == WRITTEN_BOOK) {
+            if (stack.getType() == Material.WRITTEN_BOOK) {
                 if (!meta.hasAuthor()) {
                     // The sender can be null when this method is called from {@link  com.earth2me.essentials.signs.EssentialsSign#getItemMeta(ItemStack, String, IEssentials)}
                     meta.setAuthor(sender == null ? Console.getInstance().getDisplayName() : sender.getPlayer().getName());
@@ -267,12 +264,12 @@ public class MetaItemStack {
             final List<String> pages = pager.getPages(split[1]);
             meta.setPages(pages);
             stack.setItemMeta(meta);
-        } else if (split.length > 1 && split[0].equalsIgnoreCase("author") && stack.getType() == WRITTEN_BOOK && hasMetaPermission(sender, "author", false, true, ess)) {
+        } else if (split.length > 1 && split[0].equalsIgnoreCase("author") && stack.getType() == Material.WRITTEN_BOOK && hasMetaPermission(sender, "author", false, true, ess)) {
             final String author = FormatUtil.replaceFormat(split[1]);
             final BookMeta meta = (BookMeta) stack.getItemMeta();
             meta.setAuthor(author);
             stack.setItemMeta(meta);
-        } else if (split.length > 1 && split[0].equalsIgnoreCase("title") && stack.getType() == WRITTEN_BOOK && hasMetaPermission(sender, "title", false, true, ess)) {
+        } else if (split.length > 1 && split[0].equalsIgnoreCase("title") && stack.getType() == Material.WRITTEN_BOOK && hasMetaPermission(sender, "title", false, true, ess)) {
             final String title = FormatUtil.replaceFormat(split[1].replaceAll("(?<!\\\\)_", " ").replace("\\_", "_"));
             final BookMeta meta = (BookMeta) stack.getItemMeta();
             meta.setTitle(title);

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbook.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbook.java
@@ -4,12 +4,14 @@ import com.earth2me.essentials.User;
 import com.earth2me.essentials.craftbukkit.Inventories;
 import com.earth2me.essentials.utils.EnumUtil;
 import com.earth2me.essentials.utils.FormatUtil;
+import com.earth2me.essentials.utils.VersionUtil;
 import com.google.common.collect.Lists;
 import net.ess3.api.TranslatableException;
 import org.bukkit.Material;
 import org.bukkit.Server;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.WritableBookMeta;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +52,14 @@ public class Commandbook extends EssentialsCommand {
             } else {
                 if (isAuthor(bmeta, player) || user.isAuthorized("essentials.book.others")) {
                     final ItemStack newItem = new ItemStack(WRITABLE_BOOK, item.getAmount());
-                    newItem.setItemMeta(bmeta);
+                    if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_20_6_R01)) {
+                        final WritableBookMeta wbmeta = (WritableBookMeta) newItem.getItemMeta();
+                        //noinspection DataFlowIssue
+                        wbmeta.setPages(bmeta.getPages());
+                        newItem.setItemMeta(wbmeta);
+                    } else {
+                        newItem.setItemMeta(bmeta);
+                    }
                     Inventories.setItemInMainHand(user.getBase(), newItem);
                     user.sendTl("editBookContents");
                 } else {
@@ -63,7 +72,15 @@ public class Commandbook extends EssentialsCommand {
                 bmeta.setAuthor(player);
             }
             final ItemStack newItem = new ItemStack(Material.WRITTEN_BOOK, item.getAmount());
-            newItem.setItemMeta(bmeta);
+            if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_20_6_R01)) {
+                final BookMeta real = (BookMeta) newItem.getItemMeta();
+                real.setAuthor(bmeta.getAuthor());
+                real.setTitle(bmeta.getTitle());
+                real.setPages(bmeta.getPages());
+                newItem.setItemMeta(real);
+            } else {
+                newItem.setItemMeta(bmeta);
+            }
             Inventories.setItemInMainHand(user.getBase(), newItem);
             user.sendTl("bookLocked");
         } else {


### PR DESCRIPTION
Starting with 1.20, there are two different type of book metas, one for writeable and another for written. Since they are different types, the server silently rejects the setItemMeta call. Just copy over the relevant parts to the new meta.

Fixes #6030