### PR TITLE
Fix per-world flight permissions

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -778,7 +778,7 @@ public class EssentialsPlayerListener implements Listener, FakeAccessor {
         }
 
         final TickCountProvider tickCountProvider = ess.provider(TickCountProvider.class);
-        if (tickCountProvider != null && user.getFlightTick() == tickCountProvider.getTickCount()) {
+        if (tickCountProvider != null && user.getFlightTick() == tickCountProvider.getTickCount() && user.isAuthorized("essentials.fly")) {
             user.getBase().setAllowFlight(true);
             user.getBase().setFlying(true);
         }


### PR DESCRIPTION
With the implementation of #6012, there was no permission check done when we re-add flight to user's changing worlds. This broke servers with per-world flight permissions.

Fixes #6044