### PR TITLE
Use an identity map for Paper chat listener

### DIFF
--- a/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperChatListenerProvider.java
+++ b/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperChatListenerProvider.java
@@ -10,11 +10,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
 
 public abstract class PaperChatListenerProvider implements Listener {
     private final LegacyComponentSerializer serializer;
-    private final HashMap<AsyncChatEvent, PaperChatEvent> eventMap = new HashMap<>();
+    private final Map<AsyncChatEvent, PaperChatEvent> eventMap = new IdentityHashMap<>();
 
     public PaperChatListenerProvider() {
         this.serializer = LegacyComponentSerializer.builder()


### PR DESCRIPTION
This was what I should have used from the start, since the event itself is what were targeting. It's possible that the hashcode could change throughout the event cycle.

Possibly fixes issues like #6066?