### PR TITLE
Fix wrong SpawnerBlockProvider on 1.21+

### DIFF
--- a/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BukkitSpawnerBlockProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BukkitSpawnerBlockProvider.java
@@ -20,7 +20,7 @@ public class BukkitSpawnerBlockProvider implements SpawnerBlockProvider {
     @ProviderTest
     public static boolean test() {
         try {
-            CreatureSpawner.class.getDeclaredMethod("setMaxSpawnDelay", int.class);
+            CreatureSpawner.class.getMethod("setMaxSpawnDelay", int.class);
             return true;
         } catch (final NoSuchMethodException ignored) {
             return false;


### PR DESCRIPTION
1.21 Adds a new org.bukkit.spawner.Spawner class as a superclass of CreatureSpawner which now contains the setMaxSpawnDelay method. Change our test to look for the method on any superclasses too.