### PR TITLE
Add non-reflection provider for syncCommands

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -86,6 +86,7 @@ import net.ess3.provider.providers.ModernPersistentDataProvider;
 import net.ess3.provider.providers.ModernPlayerLocaleProvider;
 import net.ess3.provider.providers.ModernPotionMetaProvider;
 import net.ess3.provider.providers.ModernSignDataProvider;
+import net.ess3.provider.providers.ModernSyncCommandsProvider;
 import net.ess3.provider.providers.PaperBiomeKeyProvider;
 import net.ess3.provider.providers.PaperContainerProvider;
 import net.ess3.provider.providers.PaperKnownCommandsProvider;
@@ -393,7 +394,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             providerFactory.registerProvider(BukkitMaterialTagProvider.class, PaperMaterialTagProvider.class);
 
             // Sync Commands Provider
-            providerFactory.registerProvider(ReflSyncCommandsProvider.class);
+            providerFactory.registerProvider(ReflSyncCommandsProvider.class, ModernSyncCommandsProvider.class);
 
             // Persistent Data Provider
             providerFactory.registerProvider(ReflPersistentDataProvider.class, ModernPersistentDataProvider.class);

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/providers/ModernSyncCommandsProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/providers/ModernSyncCommandsProvider.java
@@ -1,0 +1,28 @@
+package net.ess3.provider.providers;
+
+import net.ess3.provider.SyncCommandsProvider;
+import net.essentialsx.providers.ProviderData;
+import net.essentialsx.providers.ProviderTest;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+@ProviderData(description = "1.21.4+ Sync Commands Provider", weight = 1)
+public class ModernSyncCommandsProvider implements SyncCommandsProvider {
+    @Override
+    public void syncCommands() {
+        for (final Player player : Bukkit.getOnlinePlayers()) {
+            player.updateCommands();
+        }
+    }
+
+    @ProviderTest
+    public static boolean test() {
+        try {
+            // There isn't a real good way to test this, but we can check if the Creaking class exists.
+            Class.forName("org.bukkit.entity.Creaking");
+            return true;
+        } catch (final Throwable ignored) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
On 1.21.4+ Player#updateCommands has the same logic as CraftServer#updateCommands, so we can just use that.