### PR TITLE
chore: add issue types to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-a-bug.yml
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.yml
@@ -1,6 +1,7 @@
 name: Report bug
 description: Report a bug in EssentialsX.
 labels: 'bug: unconfirmed'
+type: Bug
 body:
 - type: markdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/request-a-feature.yml
+++ b/.github/ISSUE_TEMPLATE/request-a-feature.yml
@@ -1,6 +1,7 @@
 name: Request a feature
 description: Suggest a feature you want to see in EssentialsX!
 labels: 'type: enhancement'
+type: Feature
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
Adds a new [issue type](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization) to new issues. Basically built in labels.