### PR TITLE
Expose IUser's last activity time

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/IUser.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/IUser.java
@@ -177,6 +177,17 @@ public interface IUser {
 
     String getFormattedJailTime();
 
+    /**
+     * Returns last activity time.
+     * <p>
+     * It is used internally to determine if user's afk status should be set to
+     * true because of ACTIVITY {@link AfkStatusChangeEvent.Cause}, or the player
+     * should be kicked for being afk too long.
+     *
+     * @return Last activity time (Epoch Milliseconds)
+     */
+    long getLastActivityTime();
+
     @Deprecated
     List<String> getMails();
 

--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -775,6 +775,11 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
         return false;
     }
 
+    @Override
+    public long getLastActivityTime() {
+        return this.lastActivity;
+    }
+
     @Deprecated
     public void updateActivity(final boolean broadcast) {
         updateActivity(broadcast, AfkStatusChangeEvent.Cause.UNKNOWN);


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

This PR closes #6100. 

### Details

**Proposed feature:**  
<!-- Type a description of your proposed feature below this line. -->
I added a new method `getLastActivityTime` in `IUser` interface and implemented it in `User`. It returns `lastActivity` for the User.
I also added javadocs description to the method to explain what it does return and how the value should be used.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Ubuntu 22.04, Windows 11 24H2

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:  21.0.6+7-LTS

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [x] CraftBukkit/Spigot/Paper 1.12.2
- [x] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Example code that uses the new method:
https://gist.github.com/maxcom1/ea5f8cf7f316f9663d1b1ac7e491a700