### PR TITLE
Vanished metadata

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -990,7 +990,8 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
             }
             setHidden(false);
             ess.getVanishedPlayersNew().remove(getName());
-            this.getBase().setMetadata("vanished", new FixedMetadataValue(ess, false));
+            //this.getBase().setMetadata("vanished", new FixedMetadataValue(ess, false));
+            this.getBase().removeMetadata("vanished", ess);
             if (isAuthorized("essentials.vanish.effect")) {
                 this.getBase().removePotionEffect(PotionEffectType.INVISIBILITY);
             }


### PR DESCRIPTION
Instead of setting the Metadata "vanished" on false when user toggle its vanish status, it would be better to remove the metadata and move its status to the playerdata file, to ensure compatibility with plugins relying on the vanished metadata (for example when streaming and filtering players with such metadata)


