### PR TITLE
Fire GlobalChatEvent even when local chat is disabled

### DIFF
--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -141,8 +141,9 @@ public abstract class AbstractChatHandler {
 
         final ChatProcessingCache.Chat chat = cache.getProcessedChat(event.getPlayer());
 
-        // If local chat is enabled, handle the recipients here; else we have nothing to do
+        // If local chat is enabled, handle the recipients here; else we can just fire the chat event and return
         if (chat.getRadius() < 1) {
+            callChatEvent(event, chat.getType(), null);
             return;
         }
         final long radiusSquared = chat.getRadius() * chat.getRadius();


### PR DESCRIPTION
This allows EssentialsX Discord to send EssentialsX Chat messages to Discord when `use-essentials-events: true` is set in the Discord config while local chat is disabled.

It also allows plugins to hook and modify EssentialsX Chat message contents, formatting and recipients when local chat is disabled.