### PR TITLE
Revert changes to /home and /sethome that break bed interactions

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -823,15 +823,12 @@ public class EssentialsPlayerListener implements Listener, FakeAccessor {
                         break;
                     }
                     final User player = ess.getUser(event.getPlayer());
-                    final boolean isAuthorized = player.isAuthorized("essentials.sethome.bed");
-                    if (isAuthorized && player.getWorld().getEnvironment().equals(World.Environment.NORMAL)) {
+                    if (player.isAuthorized("essentials.sethome.bed") && player.getWorld().getEnvironment().equals(World.Environment.NORMAL)) {
                         player.getBase().setBedSpawnLocation(event.getClickedBlock().getLocation());
                         // In 1.15 and above, vanilla sends its own bed spawn message.
                         if (VersionUtil.getServerBukkitVersion().isLowerThan(VersionUtil.v1_15_R01)) {
                             player.sendTl("bedSet", player.getLocation().getWorld().getName(), player.getLocation().getBlockX(), player.getLocation().getBlockY(), player.getLocation().getBlockZ());
                         }
-                    } else if (!isAuthorized) {
-                        event.setCancelled(true);
                     }
                 }
                 break;

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
@@ -74,13 +74,9 @@ public class Commandhome extends EssentialsCommand {
                 if (homes.isEmpty() && finalPlayer.equals(user)) {
                     if (ess.getSettings().isSpawnIfNoHome()) {
                         final UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, null, bed != null ? bed : finalPlayer.getWorld().getSpawnLocation(), bed != null ? UserTeleportHomeEvent.HomeType.BED : UserTeleportHomeEvent.HomeType.SPAWN);
-                        if (event.getHomeType() != UserTeleportHomeEvent.HomeType.BED || finalPlayer.isAuthorized("essentials.home.bed")) {
-                            server.getPluginManager().callEvent(event);
-                            if (!event.isCancelled()) {
-                                user.getAsyncTeleport().respawn(charge, TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
-                            }
-                        } else {
-                            showError(user.getBase(), new TranslatableException("noPerm", "essentials.home.bed"), commandLabel);
+                        server.getPluginManager().callEvent(event);
+                        if (!event.isCancelled()) {
+                            user.getAsyncTeleport().respawn(charge, TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
                         }
                     } else {
                         showError(user.getBase(), new TranslatableException("noHomeSetPlayer"), commandLabel);


### PR DESCRIPTION
This reverts PR #5991 (commit 3fe1495fdb6eaabe01742025289b139c75e61091), which appears to have broken interacting with a bed and performs duplicate permission checks. A proper fix should be done for #5963 in the next release.