### PR TITLE
Fix chat url parsing for tlds >3 chars

### DIFF
--- a/providers/BaseProviders/src/main/java/net/ess3/provider/AbstractChatEvent.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/AbstractChatEvent.java
@@ -7,7 +7,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public interface AbstractChatEvent {
-    Pattern URL_PATTERN = Pattern.compile("((?:(?:https?)://)?[\\w-_\\.]{2,})\\.([a-zA-Z]{2,3}(?:/\\S+)?)");
+    Pattern URL_PATTERN = Pattern.compile("((?:(?:https?)://)?[\\w-_\\.]{2,})\\.([a-zA-Z]{2,}(?:/\\S+)?)");
 
     boolean isAsynchronous();
 


### PR DESCRIPTION
Mojang only looks for urls with 2,3 chars but if we don't block urls with >3 their regex will still parse the url trimming the extra chars off the tld *sigh*

Fixes #6156