### PR TITLE
Fix /tpr on legacy versions

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -72,6 +72,7 @@ import net.ess3.provider.providers.BukkitSpawnerBlockProvider;
 import net.ess3.provider.providers.FixedHeightWorldInfoProvider;
 import net.ess3.provider.providers.FlatSpawnEggProvider;
 import net.ess3.provider.providers.LegacyBannerDataProvider;
+import net.ess3.provider.providers.LegacyBiomeNameProvider;
 import net.ess3.provider.providers.LegacyDamageEventProvider;
 import net.ess3.provider.providers.LegacyInventoryViewProvider;
 import net.ess3.provider.providers.LegacyItemUnbreakableProvider;
@@ -372,6 +373,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
             // Inventory View Provider
             providerFactory.registerProvider(LegacyInventoryViewProvider.class, BaseInventoryViewProvider.class);
+
+            // Biome Name Provider
+            providerFactory.registerProvider(LegacyBiomeNameProvider.class);
 
             // Biome Key Provider
             providerFactory.registerProvider(PaperBiomeKeyProvider.class);

--- a/Essentials/src/main/java/com/earth2me/essentials/RandomTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/RandomTeleport.java
@@ -7,6 +7,7 @@ import com.earth2me.essentials.utils.LocationUtil;
 import com.earth2me.essentials.utils.VersionUtil;
 import io.papermc.lib.PaperLib;
 import net.ess3.provider.BiomeKeyProvider;
+import net.ess3.provider.BiomeNameProvider;
 import net.ess3.provider.WorldInfoProvider;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -238,8 +239,9 @@ public class RandomTeleport implements IConf {
 
     // Exclude biome if enum or namespaced key matches
     private boolean isExcludedBiome(final Location location) {
+        final BiomeNameProvider biomeNameProvider = ess.provider(BiomeNameProvider.class);
         final Set<String> excluded = getExcludedBiomes();
-        final String enumKey = location.getBlock().getBiome().name().toLowerCase();
+        final String enumKey = biomeNameProvider.getBiomeName(location.getBlock());
         // Try with good old bukkit enum
         if (excluded.contains(enumKey)) {
             return true;

--- a/providers/1_8Provider/src/main/java/net/ess3/provider/providers/LegacyBiomeNameProvider.java
+++ b/providers/1_8Provider/src/main/java/net/ess3/provider/providers/LegacyBiomeNameProvider.java
@@ -1,0 +1,15 @@
+package net.ess3.provider.providers;
+
+import net.ess3.provider.BiomeNameProvider;
+import net.essentialsx.providers.ProviderData;
+import org.bukkit.block.Block;
+
+import java.util.Locale;
+
+@ProviderData(description = "Legacy Item Unbreakable Provider")
+public class LegacyBiomeNameProvider implements BiomeNameProvider {
+    @Override
+    public String getBiomeName(final Block block) {
+        return block.getBiome().name().toLowerCase(Locale.ENGLISH);
+    }
+}

--- a/providers/1_8Provider/src/main/java/net/ess3/provider/providers/LegacyBiomeNameProvider.java
+++ b/providers/1_8Provider/src/main/java/net/ess3/provider/providers/LegacyBiomeNameProvider.java
@@ -10,6 +10,8 @@ import java.util.Locale;
 public class LegacyBiomeNameProvider implements BiomeNameProvider {
     @Override
     public String getBiomeName(final Block block) {
+        // For some reason, compiling against modern versions causes this call to break, possibly related to OldEnum?
+        // Compiling this against versions that still have proper enums allow this to work
         return block.getBiome().name().toLowerCase(Locale.ENGLISH);
     }
 }

--- a/providers/1_8Provider/src/main/java/net/ess3/provider/providers/LegacyBiomeNameProvider.java
+++ b/providers/1_8Provider/src/main/java/net/ess3/provider/providers/LegacyBiomeNameProvider.java
@@ -6,7 +6,7 @@ import org.bukkit.block.Block;
 
 import java.util.Locale;
 
-@ProviderData(description = "Legacy Item Unbreakable Provider")
+@ProviderData(description = "Legacy Biome Name Provider")
 public class LegacyBiomeNameProvider implements BiomeNameProvider {
     @Override
     public String getBiomeName(final Block block) {

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/BiomeNameProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/BiomeNameProvider.java
@@ -1,0 +1,7 @@
+package net.ess3.provider;
+
+import org.bukkit.block.Block;
+
+public interface BiomeNameProvider extends Provider {
+    String getBiomeName(Block block);
+}


### PR DESCRIPTION
Commodore breaks this on legacy likely, use a provider to ensure we use the old ABI...................i love legacy

Fixes #6211