### PR TITLE
Fix potion command not supporting infinite durations

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/MetaItemStack.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/MetaItemStack.java
@@ -549,7 +549,8 @@ public class MetaItemStack {
             } else if (split[0].equalsIgnoreCase("duration") || (allowShortName && split[0].equalsIgnoreCase("d"))) {
                 if (NumberUtil.isInt(split[1])) {
                     validPotionDuration = true;
-                    duration = Integer.parseInt(split[1]) * 20; //Duration is in ticks by default, converted to seconds
+                    final int parsed = Integer.parseInt(split[1]);
+                    duration = parsed == -1 ? -1 : parsed * 20; //Duration is in ticks by default, converted to seconds
                 } else {
                     throw new TranslatableException("invalidPotionMeta", split[1]);
                 }


### PR DESCRIPTION
Minecraft understands infinite durations to be `-1` and only `-1`. Our second -> tick conversion was changing this to `-20` causing a potion command with a `-1` duration to end up as `-20` and only causing the potion to occur for 1 tick.

Fixes #5558