### PR TITLE
Discord: Fix custom bot name requiring show-avatar

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/DiscordSettings.java
@@ -202,6 +202,16 @@ public class DiscordSettings implements IConf {
         return config.getBoolean("show-displayname", false);
     }
 
+    protected boolean isCustomBotName() {
+        if (isShowName() || isShowDisplayName()) {
+            return true;
+        }
+
+        final String format = getFormatString("mc-to-discord-name-format");
+
+        return format != null && !format.isEmpty() && !format.equals("{botname}");
+    }
+
     public String getAvatarURL() {
         return config.getString("avatar-url", "https://crafthead.net/helm/{uuid}");
     }

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/JDADiscordService.java
@@ -367,7 +367,7 @@ public class JDADiscordService implements DiscordService, IEssentialsModule {
     }
 
     public void updateTypesRelay() {
-        if (!getSettings().isShowAvatar() && !getSettings().isShowName() && !getSettings().isShowDisplayName()) {
+        if (!getSettings().isShowAvatar() && !getSettings().isCustomBotName()) {
             for (WrappedWebhookClient webhook : channelIdToWebhook.values()) {
                 webhook.close();
             }


### PR DESCRIPTION
Fixes #5878. Caused by a regression from 384f63bf92cd3417899e1d3aca22201c3a523d7b, we were checking for for the legacy options when we should really be checking if `mc-to-discord-name-format` is anything other than the bot name.