### PR TITLE
Fix matching players with similar names

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -956,10 +956,16 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
         try {
             exPlayer = server.getPlayer(UUID.fromString(searchTerm));
         } catch (final IllegalArgumentException ex) {
+            // Prefer exact online name match first always
             if (getOffline) {
+                // When offline lookups are allowed, do not pick partial online matches here; allow exact offline match later
                 exPlayer = server.getPlayerExact(searchTerm);
             } else {
-                exPlayer = server.getPlayer(searchTerm);
+                exPlayer = server.getPlayerExact(searchTerm);
+                if (exPlayer == null) {
+                    // Only consider partial/prefix online match when not explicitly doing an offline-capable lookup
+                    exPlayer = server.getPlayer(searchTerm);
+                }
             }
         }
 
@@ -996,6 +1002,16 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                 }
             }
         } else {
+            // Prefer exact username match among the matched players
+            for (final Player player : matches) {
+                if (player.getName().equalsIgnoreCase(searchTerm)) {
+                    final User userMatch = getUser(player);
+                    if (getHidden || canInteractWith(sourceUser, userMatch)) {
+                        return userMatch;
+                    }
+                }
+            }
+            // Then prefer display name/prefix match as before
             for (final Player player : matches) {
                 final User userMatch = getUser(player);
                 if (userMatch.getDisplayName().startsWith(searchTerm) && (getHidden || canInteractWith(sourceUser, userMatch))) {

--- a/Essentials/src/test/java/com/earth2me/essentials/MatchUserTest.java
+++ b/Essentials/src/test/java/com/earth2me/essentials/MatchUserTest.java
@@ -1,0 +1,82 @@
+package com.earth2me.essentials;
+
+import com.earth2me.essentials.commands.PlayerNotFoundException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MatchUserTest {
+    private Essentials ess;
+    private ServerMock server;
+
+    @BeforeEach
+    public void setUp() {
+        this.server = MockBukkit.mock();
+        Essentials.TESTING = true;
+        ess = MockBukkit.load(Essentials.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    public void exactMatchPreferredOverPartialOnline() throws Exception {
+        final PlayerMock exactPlayer = server.addPlayer("Ginshin");
+        final PlayerMock partialPlayer = server.addPlayer("Ginshin_BOT");
+        final PlayerMock callerBase = server.addPlayer("Caller");
+
+        final User caller = ess.getUser(callerBase);
+        ess.getUser(exactPlayer);
+        ess.getUser(partialPlayer);
+
+        final User matched = ess.matchUser(server, caller, "Ginshin", false, false);
+        assertEquals("Ginshin", matched.getName());
+    }
+
+    @Test
+    public void hiddenPlayerExactOnlyWhenOfflineLookupPlayerCaller() throws Exception {
+        final PlayerMock hiddenBase = server.addPlayer("Hidden");
+        final PlayerMock callerBase = server.addPlayer("Caller");
+
+        final User hidden = ess.getUser(hiddenBase);
+        final User caller = ess.getUser(callerBase);
+
+        hidden.setVanished(true);
+
+        // Without offline-capable lookup, hidden target should not be found
+        assertThrows(PlayerNotFoundException.class,
+                () -> ess.matchUser(server, caller, "Hidden", false, false));
+
+        // With offline-capable lookup, only exact matches should return the hidden user
+        assertThrows(PlayerNotFoundException.class,
+                () -> ess.matchUser(server, caller, "Hid", false, true));
+
+        final User matched = ess.matchUser(server, caller, "Hidden", false, true);
+        assertEquals("Hidden", matched.getName());
+    }
+
+    @Test
+    public void hiddenPlayerExactOnlyWhenOfflineLookupConsoleCaller() throws Exception {
+        final PlayerMock hiddenBase = server.addPlayer("HiddenTwo");
+        final User hidden = ess.getUser(hiddenBase);
+
+        hidden.setHidden(true);
+
+        // Console caller represented by null source user
+        assertThrows(PlayerNotFoundException.class,
+                () -> ess.matchUser(server, null, "HiddenT", false, true));
+
+        final User matched = ess.matchUser(server, null, "HiddenTwo", false, true);
+        assertEquals("HiddenTwo", matched.getName());
+    }
+}
+
+


### PR DESCRIPTION
Fixes an issue where matchPlayer didn't always match exact matches first.

Also adds a test for this method to ensure stuff like this doesn't happen in the future.

Fixes #6246