### PR TITLE
Add option to limit baltop entries

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
@@ -54,9 +54,9 @@ public class BalanceTopImpl implements BalanceTop {
         final LinkedHashMap<UUID, Entry> sortedMap = new LinkedHashMap<>();
         entries.sort((entry1, entry2) -> entry2.getBalance().compareTo(entry1.getBalance()));
         final int entryLimit = ess.getSettings().getBaltopEntryLimit();
-        int i = 0;
-        for (Entry entry : entries) {
-            if (entryLimit != -1 && ++i > entryLimit) break;
+        final int limit = entryLimit == -1 ? entries.size() : Math.min(entryLimit, entries.size());
+        for (int i = 0; i < limit; i++) {
+            Entry entry = entries.get(i);
             sortedMap.put(entry.getUuid(), entry);
         }
         topCache = sortedMap;

--- a/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
@@ -53,7 +53,10 @@ public class BalanceTopImpl implements BalanceTop {
         }
         final LinkedHashMap<UUID, Entry> sortedMap = new LinkedHashMap<>();
         entries.sort((entry1, entry2) -> entry2.getBalance().compareTo(entry1.getBalance()));
+        int entryLimit = ess.getSettings().getBaltopEntryLimit();
+        int i = 0;
         for (Entry entry : entries) {
+            if (entryLimit != -1 && ++i > entryLimit) break;
             sortedMap.put(entry.getUuid(), entry);
         }
         topCache = sortedMap;

--- a/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
@@ -56,7 +56,7 @@ public class BalanceTopImpl implements BalanceTop {
         final int entryLimit = ess.getSettings().getBaltopEntryLimit();
         final int limit = entryLimit == -1 ? entries.size() : Math.min(entryLimit, entries.size());
         for (int i = 0; i < limit; i++) {
-            Entry entry = entries.get(i);
+            final Entry entry = entries.get(i);
             sortedMap.put(entry.getUuid(), entry);
         }
         topCache = sortedMap;

--- a/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/BalanceTopImpl.java
@@ -53,7 +53,7 @@ public class BalanceTopImpl implements BalanceTop {
         }
         final LinkedHashMap<UUID, Entry> sortedMap = new LinkedHashMap<>();
         entries.sort((entry1, entry2) -> entry2.getBalance().compareTo(entry1.getBalance()));
-        int entryLimit = ess.getSettings().getBaltopEntryLimit();
+        final int entryLimit = ess.getSettings().getBaltopEntryLimit();
         int i = 0;
         for (Entry entry : entries) {
             if (entryLimit != -1 && ++i > entryLimit) break;

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -446,6 +446,8 @@ public interface ISettings extends IConf {
 
     long getBaltopMinPlaytime();
 
+    int getBaltopEntryLimit();
+
     enum KeepInvPolicy {
         KEEP,
         DELETE,

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -2232,6 +2232,11 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     @Override
+    public int getBaltopEntryLimit() {
+        return config.getInt("baltop-entry-limit", -1);
+    }
+
+    @Override
     public long getBaltopMinPlaytime() {
         return config.getLong("baltop-requirements.minimum-playtime", 0);
     }

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -893,6 +893,11 @@ baltop-requirements:
   minimum-balance: 0
   minimum-playtime: 0
 
+# Allows to limit cached balance top (/baltop) entries. This is especially recommended if
+# you have a large number of players, then only a certain number of entries will be stored
+# in the server's memory. Set to -1 to disable the limit
+baltop-entry-limit: -1
+
 # The format of currency, excluding symbols. For symbol configuration, see 'currency-symbol-format-locale' below.
 #
 # "#,##0.00" is how the majority of countries display currency.


### PR DESCRIPTION
```yml
# Allows to limit cached balance top (/baltop) entries. This is especially recommended if
# you have a large number of players, then only a certain number of entries will be stored
# in the server's memory. Set to -1 to disable the limit
baltop-entry-limit: -1
```