### PR TITLE
Fix updating join message when not needed

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -450,7 +450,10 @@ public class EssentialsPlayerListener implements Listener {
             effectiveMessage = message;
         }
 
-        joinMessageConsumer.accept(effectiveMessage);
+        // Only change the vanilla join message if it's different to avoid nuking client translation
+        if (effectiveMessage != null && !effectiveMessage.equals(message) || message != null && effectiveMessage == null) {
+            joinMessageConsumer.accept(effectiveMessage);
+        }
 
         ess.runTaskAsynchronously(() -> ess.getServer().getPluginManager().callEvent(new AsyncUserDataLoadEvent(user, effectiveMessage)));
 


### PR DESCRIPTION
Prevents calling setJoinMessage when the message is unchanged causing Bukkit to no longer send the translation key to the client (nuking vanilla translation)

Fixes #6307