### PR TITLE
Fix GeoIP dependencies

### DIFF
--- a/EssentialsGeoIP/build.gradle
+++ b/EssentialsGeoIP/build.gradle
@@ -13,7 +13,9 @@ shadowJar {
         include (dependency('com.maxmind.geoip2:geoip2'))
         include (dependency('com.maxmind.db:maxmind-db'))
         include (dependency('javatar:javatar'))
-        include (dependency('com.fasterxml.jackson.core:'))
+        include (dependency('com.fasterxml.jackson.core:jackson-core'))
+        include (dependency('com.fasterxml.jackson.core:jackson-annotations'))
+        include (dependency('com.fasterxml.jackson.core:jackson-databind'))
     }
 
     relocate 'com.maxmind', 'com.earth2me.essentials.geoip.libs.maxmind'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,14 +22,6 @@ dependencyResolutionManagement {
         maven("https://libraries.minecraft.net/") {
             content { includeGroup("com.mojang") }
         }
-        mavenCentral {
-            content {
-                includeGroup("net.kyori")
-                includeGroup("net.dv8tion")
-                includeGroup("org.apache.logging.log4j")
-                includeGroup("org.mockbukkit.mockbukkit")
-            }
-        }
     }
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 }


### PR DESCRIPTION
During the gradle/shadow upgrades during the 1.21.9 update, shadow removed implicit wildcards. Explicitly declare all shadow depends for jackson in geoip.

Also get rid of mavenCentral since paper mirrors it, was causing resolution issues for mockbukkit

Fixes #6313