### PR TITLE
Fix exception during first time joins

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -81,6 +81,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
@@ -343,36 +344,54 @@ public class EssentialsPlayerListener implements Listener {
 
     @SuppressWarnings("UnstableApiUsage")
     private final class JoinListener1_21 implements Listener {
+        private final Map<UUID, String> newUserLocales = new ConcurrentHashMap<>();
+
         @EventHandler
         public void onPlayerConfigure(final AsyncPlayerConnectionConfigureEvent event) {
             ess.getBackup().onPlayerJoin();
             final User dUser = ess.getUser(event.getConnection().getProfile().getId());
 
-            dUser.startTransaction();
-            if (dUser.isNPC()) {
-                dUser.setNPC(false);
+            // Force loading of the locale bundle while we are async to ensure it's ready when the player joins.
+            final String locale = event.getConnection().getClientOption(ClientOption.LOCALE);
+            ess.getI18n().blockingLoadBundle(I18n.getLocale(locale));
+
+            // This is a first time join, we have to wait until the bukkit Player object is created to create the User object.
+            // So we store the locale here and apply it when the PlayerJoinEvent is fired.
+            if (dUser == null) {
+                newUserLocales.put(event.getConnection().getProfile().getId(), locale);
+                return;
             }
 
-            final long currentTime = System.currentTimeMillis();
-            dUser.checkMuteTimeout(currentTime);
-            dUser.updateActivity(false, AfkStatusChangeEvent.Cause.JOIN);
-            dUser.stopTransaction();
-
             // Set the locale for player to preload the language bundle.
-            final String locale = event.getConnection().getClientOption(ClientOption.LOCALE);
             dUser.getPlayerLocale(locale);
         }
 
         @EventHandler(priority = EventPriority.HIGHEST)
         public void onPlayerJoin(final PlayerJoinEvent event) {
-            if (!ess.getUsers().isCached(event.getPlayer().getUniqueId())) {
+            final User user = ess.getUser(event.getPlayer());
+            if (user == null) {
                 legacyJoinFlow(event);
                 return;
             }
 
-            final User user = ess.getUser(event.getPlayer());
             user.update(event.getPlayer());
+
+            // If this is a new user, we set their locale that we stored earlier.
+            final String locale = newUserLocales.remove(user.getUUID());
+            if (locale != null) {
+                user.getPlayerLocale(locale);
+            }
+
             final long currentTime = System.currentTimeMillis();
+            user.startTransaction();
+            if (user.isNPC()) {
+                user.setNPC(false);
+            }
+
+            user.checkMuteTimeout(currentTime);
+            user.updateActivity(false, AfkStatusChangeEvent.Cause.JOIN);
+            user.stopTransaction();
+
             joinFlow(user, currentTime, event.getJoinMessage(), event::setJoinMessage);
         }
     }
@@ -636,8 +655,7 @@ public class EssentialsPlayerListener implements Listener {
     private final class LoginListener1_21 implements Listener {
         @EventHandler(priority = EventPriority.HIGH)
         public void onPlayerListFull(final PlayerServerFullCheckEvent event) {
-            final User user = ess.getUser(event.getPlayerProfile().getId());
-            if (user.isAuthorized("essentials.joinfullserver")) {
+            if (ess.getPermissionsHandler().isOfflinePermissionSet(event.getPlayerProfile().getId(), "essentials.joinfullserver")) {
                 event.allow(true);
                 return;
             }

--- a/Essentials/src/main/java/com/earth2me/essentials/I18n.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/I18n.java
@@ -125,18 +125,7 @@ public class I18n implements net.ess3.api.II18n {
                 if (!loadingBundles.contains(locale)) {
                     loadingBundles.add(locale);
                     BUNDLE_LOADER_EXECUTOR.submit(() -> {
-                        ResourceBundle bundle;
-                        try {
-                            bundle = ResourceBundle.getBundle(MESSAGES, locale, new FileResClassLoader(I18n.class.getClassLoader(), ess), new UTF8PropertiesControl());
-                        } catch (MissingResourceException ex) {
-                            try {
-                                bundle = ResourceBundle.getBundle(MESSAGES, locale, new UTF8PropertiesControl());
-                            } catch (MissingResourceException ex2) {
-                                bundle = NULL_BUNDLE;
-                            }
-                        }
-
-                        loadedBundles.put(locale, bundle);
+                        blockingLoadBundle(locale);
                         synchronized (loadingBundles) {
                             loadingBundles.remove(locale);
                         }
@@ -144,6 +133,23 @@ public class I18n implements net.ess3.api.II18n {
                 }
             }
             return defaultBundle;
+        }
+    }
+
+    public void blockingLoadBundle(final Locale locale) {
+        if (!loadedBundles.containsKey(locale)) {
+            ResourceBundle bundle;
+            try {
+                bundle = ResourceBundle.getBundle(MESSAGES, locale, new FileResClassLoader(I18n.class.getClassLoader(), ess), new UTF8PropertiesControl());
+            } catch (MissingResourceException ex) {
+                try {
+                    bundle = ResourceBundle.getBundle(MESSAGES, locale, new UTF8PropertiesControl());
+                } catch (MissingResourceException ex2) {
+                    bundle = NULL_BUNDLE;
+                }
+            }
+
+            loadedBundles.put(locale, bundle);
         }
     }
 


### PR DESCRIPTION
Fixes an issue during first join with the player configuration events on Paper. The usermap will refuse to implicitly store new users into the usermap unless it can get a Bukkit player object for it, which is only created during the PlayerJoinEvent. So for new users, we must defer to then. The code that was being run (activity/mute checks) was probably incorrect to be placed inside of configure event anyway.

Also force loads the locale bundle into memory to ensure it's ready for servers with slow i/o.

Fixes #6315
