### PR TITLE
Fix command cooldown bug with case-sensitive commands (#5915)

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -836,7 +836,8 @@ public class EssentialsPlayerListener implements Listener {
             final int argStartIndex = effectiveCommand.indexOf(" ");
             final String args = argStartIndex == -1 ? "" // No arguments present
                 : " " + effectiveCommand.substring(argStartIndex); // arguments start at argStartIndex; substring from there.
-            final String fullCommand = pluginCommand == null ? effectiveCommand : pluginCommand.getName() + args;
+            // Normalize to lowercase to ensure case-insensitive cooldown matching (fixes #5915)
+            final String fullCommand = (pluginCommand == null ? effectiveCommand : pluginCommand.getName() + args).toLowerCase(Locale.ENGLISH);
 
             // Used to determine whether a user already has an existing cooldown
             // If so, no need to check for (and write) new ones.


### PR DESCRIPTION
## Description
Fixes a bug where command cooldowns were being applied even when commands typed in different cases (e.g., `/EAT`, `/Eat`) failed to execute.

## Changes
- Normalized the `fullCommand` string to lowercase in `EssentialsPlayerListener.handlePlayerCommandPreprocess()` to ensure case-insensitive cooldown matching
- This aligns cooldown behavior with the existing case-insensitive command lookup logic

## Testing
- Commands like `/eat`, `/EAT`, `/Eat` now all properly share the same cooldown timer
- Cooldowns are only applied when the command is successfully recognized by the system
- Players can no longer trigger cooldowns by typing invalid capitalized commands

Fixes #5915