### PR TITLE
Fix event thread assignment in TeleportWarmupCancelledEvent

### DIFF
--- a/Essentials/src/main/java/net/essentialsx/api/v2/events/TeleportWarmupCancelledEvent.java
+++ b/Essentials/src/main/java/net/essentialsx/api/v2/events/TeleportWarmupCancelledEvent.java
@@ -1,5 +1,6 @@
 package net.essentialsx.api.v2.events;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -17,7 +18,8 @@ public class TeleportWarmupCancelledEvent extends Event {
     private final CancelReason cancelReason;
     private final boolean notifyUser;
 
-    public TeleportWarmupCancelledEvent(final Player player, final TeleportType teleportType, CancelReason cancelReason, final boolean notifyUser) {
+    public TeleportWarmupCancelledEvent(final Player player, final TeleportType teleportType, final CancelReason cancelReason, final boolean notifyUser) {
+        super(!Bukkit.isPrimaryThread());
         this.player = player;
         this.teleportType = teleportType;
         this.cancelReason = cancelReason;

--- a/Essentials/src/main/java/net/essentialsx/api/v2/events/TeleportWarmupCancelledEvent.java
+++ b/Essentials/src/main/java/net/essentialsx/api/v2/events/TeleportWarmupCancelledEvent.java
@@ -1,10 +1,10 @@
 package net.essentialsx.api.v2.events;
 
+import com.earth2me.essentials.AsyncTeleport.TeleportType;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
-import com.earth2me.essentials.AsyncTeleport.TeleportType;
 
 /**
  * Called when a player's teleport warmup is cancelled.


### PR DESCRIPTION
Adds a call to super with the correct async flag based on Bukkit's primary thread status, ensuring proper event handling for TeleportWarmupCancelledEvent.

fix this error:

```
[18:40:31 WARN]: [Essentials] Plugin Essentials v2.22.0-dev+278-984a0c1 generated an exception while executing task 156164
java.lang.IllegalStateException: TeleportWarmupCancelledEvent may only be triggered synchronously.
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:42) ~[paper-1.21.10.jar:1.21.10-117-df4b668]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.10.jar:1.21.10-117-df4b668]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.10-R0.1-SNAPSHOT.jar:?]
        at EssentialsX-2.22.0-278.jar/com.earth2me.essentials.AsyncTimedTeleport.cancelTimer(AsyncTimedTeleport.java:160) ~[EssentialsX-2.22.0-278.jar:?]
        at EssentialsX-2.22.0-278.jar/com.earth2me.essentials.AsyncTimedTeleport.run(AsyncTimedTeleport.java:96) ~[EssentialsX-2.22.0-278.jar:?]
        at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:78) ~[paper-1.21.10.jar:1.21.10-117-df4b668]
        at org.bukkit.craftbukkit.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[paper-1.21.10.jar:1.21.10-117-df4b668]
        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[paper-1.21.10.jar:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```