### PR TITLE
added a config-entry to selectively ignore causes of the back-in-listener

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -695,6 +695,22 @@ public class EssentialsPlayerListener implements Listener {
         }
     }
 
+    private boolean isTeleportListenerIgnored(StackTraceElement[] stackTrace) {
+        List<List<String>> ignoreList = ess.getSettings().getBackInListenerIgnoreList();
+
+        if (ignoreList.isEmpty())
+            return false;
+
+        for (StackTraceElement stackElement : stackTrace) {
+            String representation = (stackElement.getClassName() + "#" + stackElement.getMethodName()).toLowerCase();
+
+            if (ignoreList.stream().anyMatch(keywords -> keywords.stream().allMatch(representation::contains)))
+                return true;
+        }
+
+        return false;
+    }
+
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerTeleport(final PlayerTeleportEvent event) {
         final Player player = event.getPlayer();
@@ -703,7 +719,8 @@ public class EssentialsPlayerListener implements Listener {
         }
         final User user = ess.getUser(player);
         if (ess.getSettings().registerBackInListener() && user.isAuthorized("essentials.back.onteleport")) {
-            user.setLastLocation();
+            if (!isTeleportListenerIgnored(Thread.currentThread().getStackTrace()))
+                user.setLastLocation();
         }
         if (ess.getSettings().isTeleportInvulnerability()) {
             user.enableInvulnerabilityAfterTeleport();

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -695,13 +695,13 @@ public class EssentialsPlayerListener implements Listener {
         }
     }
 
-    private boolean isTeleportListenerIgnored(StackTraceElement[] stackTrace) {
+    private boolean isTeleportListenerIgnored() {
         List<List<String>> ignoreList = ess.getSettings().getBackInListenerIgnoreList();
 
         if (ignoreList.isEmpty())
             return false;
 
-        for (StackTraceElement stackElement : stackTrace) {
+        for (StackTraceElement stackElement : Thread.currentThread().getStackTrace()) {
             String representation = (stackElement.getClassName() + "#" + stackElement.getMethodName()).toLowerCase();
 
             if (ignoreList.stream().anyMatch(keywords -> keywords.stream().allMatch(representation::contains)))
@@ -719,7 +719,7 @@ public class EssentialsPlayerListener implements Listener {
         }
         final User user = ess.getUser(player);
         if (ess.getSettings().registerBackInListener() && user.isAuthorized("essentials.back.onteleport")) {
-            if (!isTeleportListenerIgnored(Thread.currentThread().getStackTrace()))
+            if (!isTeleportListenerIgnored())
                 user.setLastLocation();
         }
         if (ess.getSettings().isTeleportInvulnerability()) {

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -258,6 +258,8 @@ public interface ISettings extends IConf {
 
     boolean registerBackInListener();
 
+    List<List<String>> getBackInListenerIgnoreList();
+
     boolean getDisableItemPickupWhileAfk();
 
     EventPriority getRespawnPriority();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -115,6 +115,7 @@ public class Settings implements net.ess3.api.ISettings {
     private KeepInvPolicy bindingItemPolicy;
     private Set<String> noGodWorlds = new HashSet<>();
     private boolean registerBackInListener;
+    private List<List<String>> backInListenerIgnoreList = new ArrayList<>();
     private boolean disableItemPickupWhileAfk;
     private long teleportInvulnerabilityTime;
     private boolean teleportInvulnerability;
@@ -805,6 +806,7 @@ public class Settings implements net.ess3.api.ISettings {
         teleportInvulnerability = _isTeleportInvulnerability();
         disableItemPickupWhileAfk = _getDisableItemPickupWhileAfk();
         registerBackInListener = _registerBackInListener();
+        backInListenerIgnoreList = _getBackInListenerIgnoreList();
         cancelAfkOnInteract = _cancelAfkOnInteract();
         cancelAfkOnMove = _cancelAfkOnMove();
         getFreezeAfkPlayers = _getFreezeAfkPlayers();
@@ -1419,6 +1421,31 @@ public class Settings implements net.ess3.api.ISettings {
     @Override
     public boolean registerBackInListener() {
         return registerBackInListener;
+    }
+
+    @Override
+    public List<List<String>> getBackInListenerIgnoreList() {
+        return backInListenerIgnoreList;
+    }
+
+    private List<List<String>> _getBackInListenerIgnoreList() {
+        List<List<String>> ignoreList = new ArrayList<>();
+
+        for (String entry : config.getList("back-in-listener-ignore-list", String.class)) {
+            List<String> ignoreEntry = new ArrayList<>();
+
+            for (String keyword : entry.split(",")) {
+                keyword = keyword.trim();
+
+                if (!keyword.isEmpty())
+                    ignoreEntry.add(keyword.toLowerCase());
+            }
+
+            if (!ignoreEntry.isEmpty())
+                ignoreList.add(ignoreEntry);
+        }
+
+        return ignoreList;
     }
 
     @Override

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -647,6 +647,12 @@ tree-command-range-limit: 300
 # If you set this to true, any plugin that uses teleport will have the previous location registered.
 register-back-in-listener: false
 
+# If some events of a teleportation are to be ignored selectively, they can be described as an entry of this list.
+# For example, the elevators of CraftBook would be "com.sk89q.craftbook.mechanics.Elevator#teleportPlayer".
+# Each entry down below can be made up of comma-separated and case-insensitive keywords, for abbreviation and generality.
+# Thus, "craftbook,elevator" would suffice to match the fully-qualified name mentioned above.
+back-in-listener-ignore-list: []
+
 # The delay, in seconds, before people can cause attack damage after logging in.
 # This prevents players from exploiting the temporary invulnerability they receive upon joining.
 login-attack-delay: 5


### PR DESCRIPTION
### Information 

This PR aims to add a simple and very much non-invasive feature to Essentials. I didn't create an issue beforehand, seeing how it would be much easier to explain my requirements with a concrete implementation - one that only took a few minutes anyway.

### Details

The existing config-entry `register-back-in-listener` allows to update the last-location of a player by not just internal features, but also by teleportation caused by external plugins. The issue I ran into was that this becomes either an "all" or "nothing" option, as the user cannot selectively exclude plugins. Teleporting players is such a ubiquitous action that it is virtually impossible to make all of these plugins talk to the Essentials API and provide an option for whether to affect the last-location themselves. It is much more reasonable to enable the user to selectively block plugins from indirectly modifying this state.

I've added descriptive comments to the newly introduced config-entry and hope that they properly explain the syntax. If they lack in clarity, I am always willing to improve them, given some feedback.

_Last but not least, I wasn't quite able to follow on how Essentials migrates new keys into the existing config on the user's machine, so any hints would be much appreciated! The current setup of it simply being absent and requiring manual adding is not ideal._

**Environments tested:**    

OS: Fedora Linux 42 (Workstation Edition)

Java version:  21.0.9

- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8

**Demonstration:**  

There's not much to demonstrate here, other than the observation that if I add an entry of `'craftbook,elevator'` to the ignore-list, players on our server will never `/back` to the location of a lift, which has been a real nuisance since we've tried to enable `/back` for other plugins, like shop-search, etc.