### PR TITLE
Update VersionUtil support status check for dangerous optimizations

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/utils/VersionUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/VersionUtil.java
@@ -67,6 +67,9 @@ public final class VersionUtil {
         builder.put("ml.tcoded.nochatreports.NoChatReportsSpigot", SupportStatus.STUPID_PLUGIN);
         builder.put("me.doclic.noencryption.NoEncryption", SupportStatus.STUPID_PLUGIN);
 
+        // Dangerous hacky "optimization" plugin that breaks EssentialsProtect
+        builder.put("org.virgil.akiasync.AkiAsyncPlugin", SupportStatus.STUPID_PLUGIN);
+
         // Forge - Doesn't support Bukkit
         builder.put("net.minecraftforge.common.MinecraftForge", SupportStatus.UNSTABLE);
         builder.put(make("4?.t734?9(;<.<5(=?t957754t\\02734?9(;<.\\0345(=?"), SupportStatus.UNSTABLE);


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

This PR adds detection to [AkiAsync](https://github.com/virgil698/Aki-Async), this AI-generated optimization plugin is used by lots of server owners through advertising on Minecraft forums and Discord servers. From reports, it [breaks EssentialsProtect explode protection](https://github.com/virgil698/Aki-Async/blob/7d8c8cff3a6cbd45d33826e27839348545fc4c2e/src/mixin/java/org/virgil/akiasync/mixin/mixins/explosion/TNTExplosionMixin.java#L31). Also, it pulled patches from a known dangerous Paper fork Leaf.

### Details

**Proposed feature:**  
<!-- Type a description of your proposed feature below this line. -->


**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 11 Version 25H2(26200.7171), Ubuntu 22.04

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: Java(TM) SE Runtime Environment Oracle GraalVM 21.0.9+7.1 (build 21.0.9+7-LTS-jvmci-23.1-b79)

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.21.10, git-Paper-117)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

https://github.com/virgil698/Aki-Async
