### PR TITLE
Add correct initialization for consoleName (loading time differs) in order to (partially) fix #6343

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Console.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Console.java
@@ -15,7 +15,7 @@ import static com.earth2me.essentials.I18n.tlLiteral;
 
 public final class Console implements IMessageRecipient {
     public static final String NAME = "Console";
-    public static final String DISPLAY_NAME = tlLiteral("consoleName");
+    public static String DISPLAY_NAME = tlLiteral("consoleName");
     private static Console instance; // Set in essentials
 
     private final IEssentials ess;

--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -428,6 +428,12 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             PermissionsDefaults.registerAllBackDefaults();
             PermissionsDefaults.registerAllHatDefaults();
 
+            // Load and set the correct Console.DISPLAY_NAME
+            // Do not remove this line although it's already set in
+            // Essentials/src/main/java/com/earth2me/essentials/Console.java,
+            // this is required to be set again after the correct initialization process.
+            Console.DISPLAY_NAME = tlLiteral("consoleName");
+
             if (!TESTING) {
                 updateChecker = new UpdateChecker(this);
                 runTaskAsynchronously(() -> {


### PR DESCRIPTION
This PR adds correct initialization for consoleName (loading time differs) in order to (partially) fix #6343 

This change fixes the issue that consoleName was never actually shown in any command answer because it was always set to "Console". The reason for this was that by the time of loading tlLiteral("consoleName") the consoleName could not be correctly accessed and for this reason it was always set to something wrong. This fix works by setting the tlLiteral("consoleName") after the correct initialization process of the loading functionality of the individual consoleName in onEnable() which requires the String DISPLAY_NAME to be non-final which should IMO not cause big problems while it theoretically should be final because it's set via locale, but if anyone decided to change the server's display name, it should not be a big problem if they're allowed to do so.

This fix only addresses one of the reasons causing the issue #6343 because there are many classes which just use the NAME (or getName()) instead of the DISPLAY_NAME (or getDisplayName()). Those will all have to be changed to DISPLAY_NAME in order to fully fix #6343, but this will be done in other PRs because this is just simple changing of variables. However, this fix is at first required in order to enable the ability for the other changes to work at all, so this is at first the most important fix for #6343 and it already includes many commands corrected (which already use the correct DISPLAY_NAME (or getDisplayName()) like /ban.

What we do not (and will not) change is "CONSOLE issued server command" because this is intended to use the real name of CONSOLE and not the changed name.