### PR TITLE
Improve gc command performance

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -70,6 +70,7 @@ import net.ess3.provider.providers.BaseInventoryViewProvider;
 import net.ess3.provider.providers.BlockMetaSpawnerItemProvider;
 import net.ess3.provider.providers.BukkitMaterialTagProvider;
 import net.ess3.provider.providers.BukkitSpawnerBlockProvider;
+import net.ess3.provider.providers.BukkitTileEntityProvider;
 import net.ess3.provider.providers.FixedHeightWorldInfoProvider;
 import net.ess3.provider.providers.FlatSpawnEggProvider;
 import net.ess3.provider.providers.LegacyBannerDataProvider;
@@ -96,6 +97,7 @@ import net.ess3.provider.providers.PaperRecipeBookListener;
 import net.ess3.provider.providers.PaperSerializationProvider;
 import net.ess3.provider.providers.PaperServerStateProvider;
 import net.ess3.provider.providers.PaperTickCountProvider;
+import net.ess3.provider.providers.PaperTileEntityProvider;
 import net.ess3.provider.providers.PrehistoricPotionMetaProvider;
 import net.essentialsx.api.v2.services.BalanceTop;
 import net.essentialsx.api.v2.services.mail.MailService;
@@ -384,6 +386,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
             // Biome Key Provider
             providerFactory.registerProvider(PaperBiomeKeyProvider.class);
+
+            // Tile Entity Provider
+            providerFactory.registerProvider(BukkitTileEntityProvider.class, PaperTileEntityProvider.class);
 
             // Tick Count Provider
             providerFactory.registerProvider(PaperTickCountProvider.class);

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandgc.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandgc.java
@@ -3,6 +3,7 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.NumberUtil;
+import net.ess3.provider.TileEntityProvider;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.Server;
@@ -36,6 +37,7 @@ public class Commandgc extends EssentialsCommand {
         sender.sendTl("gcfree", Runtime.getRuntime().freeMemory() / 1024 / 1024);
 
         final List<World> worlds = server.getWorlds();
+        final TileEntityProvider tileEntityProvider = ess.provider(TileEntityProvider.class);
         for (final World w : worlds) {
             String worldType = "World";
             switch (w.getEnvironment()) {
@@ -51,7 +53,7 @@ public class Commandgc extends EssentialsCommand {
 
             try {
                 for (final Chunk chunk : w.getLoadedChunks()) {
-                    tileEntities += chunk.getTileEntities().length;
+                    tileEntities += tileEntityProvider.getTileEntities(chunk).length;
                 }
             } catch (final java.lang.ClassCastException ex) {
                 ess.getLogger().log(Level.SEVERE, "Corrupted chunk data on world " + w, ex);

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/TileEntityProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/TileEntityProvider.java
@@ -1,0 +1,8 @@
+package net.ess3.provider;
+
+import org.bukkit.Chunk;
+import org.bukkit.block.BlockState;
+
+public interface TileEntityProvider extends Provider {
+    BlockState[] getTileEntities(Chunk chunk);
+}

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BukkitTileEntityProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BukkitTileEntityProvider.java
@@ -1,0 +1,14 @@
+package net.ess3.provider.providers;
+
+import net.ess3.provider.TileEntityProvider;
+import net.essentialsx.providers.ProviderData;
+import org.bukkit.Chunk;
+import org.bukkit.block.BlockState;
+
+@ProviderData(description = "Bukkit Tile Entity Provider")
+public class BukkitTileEntityProvider implements TileEntityProvider {
+    @Override
+    public BlockState[] getTileEntities(Chunk chunk) {
+        return chunk.getTileEntities();
+    }
+}

--- a/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperTileEntityProvider.java
+++ b/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperTileEntityProvider.java
@@ -1,0 +1,25 @@
+package net.ess3.provider.providers;
+
+import net.ess3.provider.TileEntityProvider;
+import net.essentialsx.providers.ProviderData;
+import net.essentialsx.providers.ProviderTest;
+import org.bukkit.Chunk;
+import org.bukkit.block.BlockState;
+
+@ProviderData(description = "Paper 1.13+ Tile Entity Provider", weight = 1)
+public class PaperTileEntityProvider implements TileEntityProvider {
+    @Override
+    public BlockState[] getTileEntities(Chunk chunk) {
+        return chunk.getTileEntities(false);
+    }
+
+    @ProviderTest
+    public static boolean test() {
+        try {
+            Chunk.class.getDeclaredMethod("getTileEntities", boolean.class);
+            return true;
+        } catch (final NoSuchMethodException ignored) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Updates /gc to use the new provider methods, allowing Paper to use getTileEntities(false) and avoid unnecessary snapshots while maintaining spigot compatibility.

"Benchmarks:"
Before, Paper: https://spark.lucko.me/kf2MVRQ5td - 76mspt
After, Paper: https://spark.lucko.me/NhZQXtLqvh - 1mspt

Spigot: https://spark.lucko.me/toXyvx0yq0