### PR TITLE
Fixed unreachable nickNoMore Message in /nick command. Not a huge change. 

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandnick.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandnick.java
@@ -48,7 +48,8 @@ public class Commandnick extends EssentialsLoopCommand {
             target.sendTl("nickNoMore");
         } else if (target.getName().equalsIgnoreCase(nick)) {
             setNickname(server, sender, target, nick);
-            if (!target.getDisplayName().equalsIgnoreCase(target.getDisplayName())) {
+            final String strippedDisplay = FormatUtil.stripFormat(target.getDisplayName());
+            if (strippedDisplay != null && !strippedDisplay.equalsIgnoreCase(target.getName())) {
                 target.sendTl("nickNoMore");
             }
             target.sendTl("nickSet", ess.getSettings().changeDisplayName() ? target.getDisplayName() : nick);


### PR DESCRIPTION
The display name was comparing getDisplayName() to itself, making it always true which made the nickNoMore message unreachable. Now it uses FormatUtil.stripFormat() to strip color codes before comparing against getName(), also has a null-safety guard.

I have built it locally and tested it - it works well. Verified: "Nick set normally", "Nick equal to Username", "Colored nick equal to Username". Had no Errors.