### PR TITLE
fix(commands): propagate Essentials and module to tree nodes

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/EssentialsTreeCommand.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/EssentialsTreeCommand.java
@@ -1,7 +1,9 @@
 package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
+import com.earth2me.essentials.IEssentialsModule;
 import com.earth2me.essentials.User;
+import net.ess3.api.IEssentials;
 import org.bukkit.Server;
 
 import java.util.ArrayList;
@@ -10,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
 
 public class EssentialsTreeCommand extends EssentialsCommand {
     private final Map<String, EssentialsTreeNode> nodes = new HashMap<>();
@@ -30,6 +33,22 @@ public class EssentialsTreeCommand extends EssentialsCommand {
         node.setEssentials(ess);
         node.setEssentialsModule(module);
         node.setParent(this);
+    }
+
+    @Override
+    public void setEssentials(final IEssentials ess) {
+        super.setEssentials(ess);
+        for (final EssentialsTreeNode node : new HashSet<>(nodes.values())) {
+            node.setEssentials(ess);
+        }
+    }
+
+    @Override
+    public void setEssentialsModule(final IEssentialsModule module) {
+        super.setEssentialsModule(module);
+        for (final EssentialsTreeNode node : new HashSet<>(nodes.values())) {
+            node.setEssentialsModule(module);
+        }
     }
 
     public void runDefault(final User user, final String commandLabel) throws Exception {


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where `EssentialsTreeNode` instances did not receive updated
`Essentials` and `IEssentialsModule` references after registration.

This could lead to null references during command execution,
especially in test environments.

### Changes made

- Override `setEssentials` in `EssentialsTreeCommand`
- Override `setEssentialsModule` in `EssentialsTreeCommand`
- Propagate updated references to all registered nodes

### Why is this needed?

Nodes only received references during registration.
If the parent command updated its references later,
the nodes would retain outdated (null) values.

### Does this PR break compatibility?

No.