### PR TITLE
Fix integer overflow with /burn + /more & fix % in chat formats

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandburn.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandburn.java
@@ -19,8 +19,12 @@ public class Commandburn extends EssentialsCommand {
         }
 
         final User user = getPlayer(server, sender, args, 0);
-        user.getBase().setFireTicks(Integer.parseInt(args[1]) * 20);
-        sender.sendTl("burnMsg", user.getDisplayName(), Integer.parseInt(args[1]));
+        final int seconds = Integer.parseInt(args[1]);
+
+        final int fireTicks = (int) Math.max(0L, Math.min((long) seconds * 20, Integer.MAX_VALUE));
+
+        user.getBase().setFireTicks(fireTicks);
+        sender.sendTl("burnMsg", user.getDisplayName(), Math.max(0, seconds));
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandmore.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandmore.java
@@ -36,11 +36,13 @@ public class Commandmore extends EssentialsCommand {
             if (!NumberUtil.isPositiveInt(args[0])) {
                 throw new TranslatableException("nonZeroPosNumber");
             }
-            newStackSize += Integer.parseInt(args[0]);
-
-            if (newStackSize > (canOversized ? ess.getSettings().getOversizedStackSize() : stack.getMaxStackSize())) {
-                user.sendTl(canOversized ? "fullStackDefaultOversize" : "fullStackDefault", canOversized ? ess.getSettings().getOversizedStackSize() : stack.getMaxStackSize());
-                newStackSize = canOversized ? ess.getSettings().getOversizedStackSize() : stack.getMaxStackSize();
+            final int cap = canOversized ? ess.getSettings().getOversizedStackSize() : stack.getMaxStackSize();
+            final long newSizeLong = (long) stack.getAmount() + Integer.parseInt(args[0]);
+            if (newSizeLong > cap) {
+                user.sendTl(canOversized ? "fullStackDefaultOversize" : "fullStackDefault", cap);
+                newStackSize = cap;
+            } else {
+                newStackSize = (int) newSizeLong;
             }
         } else if (canOversized) {
             newStackSize = ess.getSettings().getOversizedStackSize();

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -92,16 +92,16 @@ public abstract class AbstractChatHandler {
 
         final ChatType chatType = chat.getType();
         String format = ess.getSettings().getChatFormat(group, chat.getRadius() > 0 && chatType == ChatType.UNKNOWN ? ChatType.LOCAL : chatType);
-        format = format.replace("{0}", group);
-        format = format.replace("{1}", ess.getSettings().getWorldAlias(world));
-        format = format.replace("{2}", world.substring(0, 1).toUpperCase(Locale.ENGLISH));
-        format = format.replace("{3}", team == null ? "" : team.getPrefix());
-        format = format.replace("{4}", team == null ? "" : team.getSuffix());
-        format = format.replace("{5}", team == null ? "" : team.getDisplayName());
-        format = format.replace("{6}", prefix);
-        format = format.replace("{7}", suffix);
-        format = format.replace("{8}", username);
-        format = format.replace("{9}", nickname == null ? username : nickname);
+        format = format.replace("{0}", group.replace("%", "%%"));
+        format = format.replace("{1}", ess.getSettings().getWorldAlias(world).replace("%", "%%"));
+        format = format.replace("{2}", world.substring(0, 1).toUpperCase(Locale.ENGLISH).replace("%", "%%"));
+        format = format.replace("{3}", team == null ? "" : team.getPrefix().replace("%", "%%"));
+        format = format.replace("{4}", team == null ? "" : team.getSuffix().replace("%", "%%"));
+        format = format.replace("{5}", team == null ? "" : team.getDisplayName().replace("%", "%%"));
+        format = format.replace("{6}", prefix.replace("%", "%%"));
+        format = format.replace("{7}", suffix.replace("%", "%%"));
+        format = format.replace("{8}", username.replace("%", "%%"));
+        format = format.replace("{9}", (nickname == null ? username : nickname).replace("%", "%%"));
 
         // Local, shout and question chat types are only enabled when there's a valid radius
         if (chat.getRadius() > 0 && !event.getMessage().isEmpty()) {


### PR DESCRIPTION
Before:

- Using `/burn <player> 107374183` extinguished the player.
- `/burn` accepted negative values.
- Using `/more 2147483647` deleted the held item(s) entirely.

After:

- Using `/burn <player> 107374183` sets the player on fire for 107374183 seconds correctly.
- `/burn` doesn't accept negative values.
- Using `/more 2147483647` correctly increases the held item stack to 64.