### PR TITLE
Migrate Vault and emoji-java dependencies away from Jitpack

### DIFF
--- a/Essentials/build.gradle
+++ b/Essentials/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly('com.github.milkbowl:VaultAPI:1.7') {
+    compileOnly('net.essentialsx.deps:VaultAPI:1.7') {
         exclude group: "org.bukkit", module: "bukkit"
     }
     compileOnly 'net.luckperms:api:5.3'

--- a/EssentialsDiscord/build.gradle
+++ b/EssentialsDiscord/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation('net.dv8tion:JDA:6.0.0') {
         exclude(module: 'opus-java')
     }
-    implementation 'com.github.MinnDevelopment:emoji-java:v6.1.0'
+    implementation 'net.essentialsx.deps:emoji-java:v6.1.0'
     implementation('club.minnced:discord-webhooks:0.8.4') {
         exclude(module: 'okhttp')
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,10 +13,9 @@ dependencyResolutionManagement {
                 includeGroup("net.md_5")
             }
         }
-        maven("https://jitpack.io") {
+        maven("https://repo.essentialsx.net/releases") {
             content {
-                includeGroup("com.github.milkbowl")
-                includeGroup("com.github.MinnDevelopment")
+                includeGroup("net.essentialsx.deps")
             }
         }
         maven("https://repo.codemc.org/repository/maven-public") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,5 @@
 dependencyResolutionManagement {
     repositories {
-        maven("https://maven-prs.papermc.io/Paper/pr13194") {
-            name = "Maven for PR #13194" // https://github.com/PaperMC/Paper/pull/13194
-            mavenContent {
-                includeModule("io.papermc.paper", "paper-api")
-            }
-        }
         maven("https://repo.papermc.io/repository/maven-public/")
         maven("https://hub.spigotmc.org/nexus/content/groups/public/") {
             content {


### PR DESCRIPTION
Jitpack is down. Move dependencies to our own repo to remove the build-time dependency on Jitpack.

