### PR TITLE
fix: reset nickname when player changes Minecraft account name

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -421,6 +421,18 @@ public class EssentialsPlayerListener implements Listener {
         final String lastAccountName = user.getLastAccountName(); // For comparison
         user.setLastAccountName(user.getBase().getName());
 
+        // Check for new username. If they don't want the message, let's just say it's false.
+final boolean newUsername = ess.getSettings().isCustomNewUsernameMessage() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName());
+
+        // If the Minecraft account name changed, reset the nickname so the old one doesn't persist
+        if (ess.getSettings().isResetNickOnNameChange() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName()) && user.getNickname() != null) {
+            user.setNickname(null);
+        }
+
+        user.setLastLogin(currentTime);
+        user.setDisplayNick();
+        updateCompass(user);
+        user.setLeavingHidden(false);
         // If the Minecraft account name changed, reset the nickname so the old one doesn't persist
         if (ess.getSettings().isResetNickOnNameChange() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName()) && user.getNickname() != null) {
             user.setNickname(null);

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -421,11 +421,10 @@ public class EssentialsPlayerListener implements Listener {
         final String lastAccountName = user.getLastAccountName(); // For comparison
         user.setLastAccountName(user.getBase().getName());
 
-        // Check for new username. If they don't want the message, let's just say it's false.
-        final boolean newUsername = ess.getSettings().isCustomNewUsernameMessage() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName());
+        final boolean newUsername = lastAccountName != null && !lastAccountName.equals(user.getBase().getName());
 
         // If the Minecraft account name changed, reset the nickname so the old one doesn't persist
-        if (ess.getSettings().isResetNickOnNameChange() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName()) && user.getNickname() != null) {
+        if (ess.getSettings().isResetNickOnNameChange() && newUsername && user.getNickname() != null) {
             user.setNickname(null);
         }
 
@@ -459,7 +458,7 @@ public class EssentialsPlayerListener implements Listener {
         } else if (message == null || hideJoinQuitMessages()) {
             effectiveMessage = null;
         } else if (ess.getSettings().isCustomJoinMessage()) {
-            final String msg = (newUsername ? ess.getSettings().getCustomNewUsernameMessage() : ess.getSettings().getCustomJoinMessage())
+            final String msg = (newUsername && ess.getSettings().isCustomNewUsernameMessage() ? ess.getSettings().getCustomNewUsernameMessage() : ess.getSettings().getCustomJoinMessage())
                     .replace("{PLAYER}", user.getDisplayName()).replace("{USERNAME}", user.getName())
                     .replace("{UNIQUE}", NumberFormat.getInstance().format(ess.getUsers().getUserCount()))
                     .replace("{ONLINE}", NumberFormat.getInstance().format(ess.getOnlinePlayers().size()))

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -420,6 +420,12 @@ public class EssentialsPlayerListener implements Listener {
 
         final String lastAccountName = user.getLastAccountName(); // For comparison
         user.setLastAccountName(user.getBase().getName());
+
+        // If the Minecraft account name changed, reset the nickname so the old one doesn't persist
+        if (lastAccountName != null && !lastAccountName.equals(user.getBase().getName()) && user.getNickname() != null) {
+            user.setNickname(null);
+        }
+
         user.setLastLogin(currentTime);
         user.setDisplayNick();
         updateCompass(user);

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -443,9 +443,6 @@ public class EssentialsPlayerListener implements Listener {
         updateCompass(user);
         user.setLeavingHidden(false);
 
-        // Check for new username. If they don't want the message, let's just say it's false.
-        final boolean newUsername = ess.getSettings().isCustomNewUsernameMessage() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName());
-
         if (!ess.getVanishedPlayersNew().isEmpty() && !user.isAuthorized("essentials.vanish.see")) {
             for (final String p : ess.getVanishedPlayersNew()) {
                 final Player toVanish = ess.getServer().getPlayerExact(p);

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -433,15 +433,6 @@ public class EssentialsPlayerListener implements Listener {
         user.setDisplayNick();
         updateCompass(user);
         user.setLeavingHidden(false);
-        // If the Minecraft account name changed, reset the nickname so the old one doesn't persist
-        if (ess.getSettings().isResetNickOnNameChange() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName()) && user.getNickname() != null) {
-            user.setNickname(null);
-        }
-
-        user.setLastLogin(currentTime);
-        user.setDisplayNick();
-        updateCompass(user);
-        user.setLeavingHidden(false);
 
         if (!ess.getVanishedPlayersNew().isEmpty() && !user.isAuthorized("essentials.vanish.see")) {
             for (final String p : ess.getVanishedPlayersNew()) {

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -422,7 +422,7 @@ public class EssentialsPlayerListener implements Listener {
         user.setLastAccountName(user.getBase().getName());
 
         // Check for new username. If they don't want the message, let's just say it's false.
-final boolean newUsername = ess.getSettings().isCustomNewUsernameMessage() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName());
+        final boolean newUsername = ess.getSettings().isCustomNewUsernameMessage() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName());
 
         // If the Minecraft account name changed, reset the nickname so the old one doesn't persist
         if (ess.getSettings().isResetNickOnNameChange() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName()) && user.getNickname() != null) {

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -422,7 +422,7 @@ public class EssentialsPlayerListener implements Listener {
         user.setLastAccountName(user.getBase().getName());
 
         // If the Minecraft account name changed, reset the nickname so the old one doesn't persist
-        if (lastAccountName != null && !lastAccountName.equals(user.getBase().getName()) && user.getNickname() != null) {
+        if (ess.getSettings().isResetNickOnNameChange() && lastAccountName != null && !lastAccountName.equals(user.getBase().getName()) && user.getNickname() != null) {
             user.setNickname(null);
         }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/IEssentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/IEssentials.java
@@ -94,8 +94,6 @@ public interface IEssentials extends Plugin {
 
     RandomTeleport getRandomTeleport();
 
-    boolean isResetNickOnNameChange();
-
     UpdateChecker getUpdateChecker();
 
     BukkitTask runTaskAsynchronously(Runnable run);

--- a/Essentials/src/main/java/com/earth2me/essentials/IEssentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/IEssentials.java
@@ -94,6 +94,8 @@ public interface IEssentials extends Plugin {
 
     RandomTeleport getRandomTeleport();
 
+    boolean isResetNickOnNameChange();
+
     UpdateChecker getUpdateChecker();
 
     BukkitTask runTaskAsynchronously(Runnable run);

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -94,6 +94,8 @@ public interface ISettings extends IConf {
 
     String getNicknamePrefix();
 
+    boolean isResetNickOnNameChange();
+
     String getOperatorColor() throws Exception;
 
     boolean getPerWarpPermission();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -147,7 +147,7 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean logCommandBlockCommands;
     private boolean logConsoleCommands;
     private Set<Predicate<String>> nickBlacklist;
-    private boolean resetNickOnNameChange = false;
+    private boolean resetNickOnNameChange;
     private double maxProjectileSpeed;
     private boolean removeEffectsOnHeal;
     private Map<String, String> worldAliases;

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -147,6 +147,7 @@ public class Settings implements net.ess3.api.ISettings {
     private boolean logCommandBlockCommands;
     private boolean logConsoleCommands;
     private Set<Predicate<String>> nickBlacklist;
+    private boolean resetNickOnNameChange = false;
     private double maxProjectileSpeed;
     private boolean removeEffectsOnHeal;
     private Map<String, String> worldAliases;
@@ -508,9 +509,18 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getString("nickname-prefix", "~");
     }
 
+    private boolean _resetNickOnNameChange() {
+        return config.getBoolean("reset-nick-on-name-change", false);
+    }
+
     @Override
     public String getNicknamePrefix() {
         return nicknamePrefix;
+    }
+
+    @Override
+    public boolean isResetNickOnNameChange() {
+        return resetNickOnNameChange;
     }
 
     @Override
@@ -886,6 +896,7 @@ public class Settings implements net.ess3.api.ISettings {
         }
 
         nicknamePrefix = _getNicknamePrefix();
+        resetNickOnNameChange = _resetNickOnNameChange();
         operatorColor = _getOperatorColor();
         changePlayerListName = _changePlayerListName();
         configDebug = _isDebug();

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -51,6 +51,10 @@ nick-blacklist:
 # For example, if "&6Notch" has 7 characters (2 are part of a color code), a length of 5 is used when this option is set to true.
 ignore-colors-in-max-nick-length: false
 
+# When this option is enabled, any nickname set by a player will be reset when their Minecraft account name changes.
+# This prevents old nicknames (including RGB-formatted ones) from persisting after a name change.
+reset-nick-on-name-change: false
+
 # When this option is enabled, display names for hidden players will not be shown. This prevents players from being
 # able to see that they are online while vanished.
 hide-displayname-in-vanish: true


### PR DESCRIPTION
Closes #6469