### PR TITLE
Fix version comparison logic for pre-release/snapshot/rc variants

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/utils/VersionUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/VersionUtil.java
@@ -374,11 +374,9 @@ public final class VersionUtil {
 
         /**
          * Checks if this version has the same base version (major, minor, and patch)
-         * as the given version, ignoring development specifiers (snapshot release, pre-release,
-         * release candidate, paper build numbers) and Bukkit metadata (revision).
-         * Revision is ignored because Paper versions do not include the Bukkit revision
-         * suffix (e.g. {@code -R0.1-SNAPSHOT}).
-         * This is used to match development builds against their target release version.
+         * as the given version, ignoring development specifiers and Bukkit metadata.
+         * Revision is ignored because Paper versions do not include the Bukkit
+         * revision suffix (e.g. {@code -R0.1-SNAPSHOT}).
          */
         public boolean equalsBaseVersion(final BukkitVersion other) {
             if (this.snapshot || other.snapshot) {
@@ -449,6 +447,13 @@ public final class VersionUtil {
             return sb.append("-R").append(revision).toString();
         }
 
+        private static int compareDevSpecifier(final int a, final int b) {
+            if (a == b) return 0;
+            if (a == -1) return 1;
+            if (b == -1) return -1;
+            return Integer.compare(a, b);
+        }
+
         @Override
         public int compareTo(final BukkitVersion o) {
             // Snapshots are always considered the most recent
@@ -484,30 +489,20 @@ public final class VersionUtil {
                     } else if (patch > o.patch) {
                         return 1;
                     } else { // equal patch
-                        if (snapshotRelease < o.snapshotRelease) {
+                        // For dev specifiers, -1 means absent (final release) and
+                        // sorts HIGHER than any present value: snapshot < pre < rc < release
+                        int cmp = compareDevSpecifier(snapshotRelease, o.snapshotRelease);
+                        if (cmp != 0) return cmp;
+                        cmp = compareDevSpecifier(preRelease, o.preRelease);
+                        if (cmp != 0) return cmp;
+                        cmp = compareDevSpecifier(releaseCandidate, o.releaseCandidate);
+                        if (cmp != 0) return cmp;
+                        if (paperBuild < o.paperBuild) {
                             return -1;
-                        } else if (snapshotRelease > o.snapshotRelease) {
+                        } else if (paperBuild > o.paperBuild) {
                             return 1;
-                        } else { // equal snapshot release
-                            if (preRelease < o.preRelease) {
-                                return -1;
-                            } else if (preRelease > o.preRelease) {
-                                return 1;
-                            } else { // equal prerelease
-                                if (releaseCandidate < o.releaseCandidate) {
-                                    return -1;
-                                } else if (releaseCandidate > o.releaseCandidate) {
-                                    return 1;
-                                } else { // equal release candidate
-                                    if (paperBuild < o.paperBuild) {
-                                        return -1;
-                                    } else if (paperBuild > o.paperBuild) {
-                                        return 1;
-                                    } else { // equal paper build
-                                        return Double.compare(revision, o.revision);
-                                    }
-                                }
-                            }
+                        } else {
+                            return Double.compare(revision, o.revision);
                         }
                     }
                 }

--- a/Essentials/src/test/java/com/earth2me/essentials/UtilTest.java
+++ b/Essentials/src/test/java/com/earth2me/essentials/UtilTest.java
@@ -303,13 +303,17 @@ public class UtilTest {
             .isLowerThan(VersionUtil.BukkitVersion.fromString("26.1-pre-1-R0.1-SNAPSHOT")));
         assertTrue(VersionUtil.BukkitVersion.fromString("1.21.11-R0.1-SNAPSHOT")
             .isLowerThan(VersionUtil.BukkitVersion.fromString("26.1-rc-1-R0.1-SNAPSHOT")));
-        // Dev variants are considered higher than their base version (for feature checks)
-        assertTrue(VersionUtil.BukkitVersion.fromString("26.1-snapshot-1-R0.1-SNAPSHOT")
-            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-R0.1-SNAPSHOT")));
-        assertTrue(VersionUtil.BukkitVersion.fromString("26.1-pre-1-R0.1-SNAPSHOT")
-            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-R0.1-SNAPSHOT")));
+        // Base release is higher than dev variants: snapshot < pre < rc < release
+        assertTrue(VersionUtil.BukkitVersion.fromString("26.1-R0.1-SNAPSHOT")
+            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-snapshot-1-R0.1-SNAPSHOT")));
+        assertTrue(VersionUtil.BukkitVersion.fromString("26.1-R0.1-SNAPSHOT")
+            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-pre-1-R0.1-SNAPSHOT")));
+        assertTrue(VersionUtil.BukkitVersion.fromString("26.1-R0.1-SNAPSHOT")
+            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-rc-1-R0.1-SNAPSHOT")));
         assertTrue(VersionUtil.BukkitVersion.fromString("26.1-rc-1-R0.1-SNAPSHOT")
-            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-R0.1-SNAPSHOT")));
+            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-pre-1-R0.1-SNAPSHOT")));
+        assertTrue(VersionUtil.BukkitVersion.fromString("26.1-pre-1-R0.1-SNAPSHOT")
+            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-snapshot-1-R0.1-SNAPSHOT")));
         // Dev variants of 26.1 are lower than 26.2
         assertTrue(VersionUtil.BukkitVersion.fromString("26.1-snapshot-99-R0.1-SNAPSHOT")
             .isLowerThan(VersionUtil.BukkitVersion.fromString("26.2-R0.1-SNAPSHOT")));
@@ -441,5 +445,17 @@ public class UtilTest {
             VersionUtil.BukkitVersion.fromString("26.1.build.99-recommended"));
         assertEquals(VersionUtil.BukkitVersion.fromString("26.1-rc-3.build.8-alpha"),
             VersionUtil.BukkitVersion.fromString("26.1-rc-3-R0.0"));
+        // Patch release with Paper build does not match different patch via equalsBaseVersion
+        assertFalse(VersionUtil.BukkitVersion.fromString("26.1.1.build.14-alpha")
+            .equalsBaseVersion(VersionUtil.BukkitVersion.fromString("26.1-R0.1-SNAPSHOT")));
+        assertTrue(VersionUtil.BukkitVersion.fromString("26.1.1.build.14-alpha")
+            .equalsBaseVersion(VersionUtil.BukkitVersion.fromString("26.1.1-R0.1-SNAPSHOT")));
+        // Base release paper build is higher than rc/pre/snapshot paper builds
+        assertTrue(VersionUtil.BukkitVersion.fromString("26.1.build.5-alpha")
+            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-rc-3.build.8-alpha")));
+        assertTrue(VersionUtil.BukkitVersion.fromString("26.1.build.1-alpha")
+            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-pre-1.build.99-alpha")));
+        assertTrue(VersionUtil.BukkitVersion.fromString("26.1.build.1-alpha")
+            .isHigherThan(VersionUtil.BukkitVersion.fromString("26.1-snapshot-99.build.99-alpha")));
     }
 }


### PR DESCRIPTION
Pre-release, snapshot, and RC variants should be considered lower than the base release version. Updated test assertions and comparison logic to reflect that release versions are higher than their dev variants (snapshot < pre < rc < release).
