### PR TITLE
Remove extractUrls from default legacy serializer

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/adventure/SpigotAdventureFacet.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/adventure/SpigotAdventureFacet.java
@@ -21,17 +21,18 @@ import java.util.Locale;
 
 public class SpigotAdventureFacet implements AdventureFacet {
     private static final LegacyComponentSerializer LEGACY_SERIALIZER;
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER_URLS;
     private static final MiniMessage MINI_MESSAGE_NO_TAGS;
 
     static {
         final LegacyComponentSerializer.Builder builder = LegacyComponentSerializer.builder()
                 .flattener(ComponentFlattener.basic())
-                .extractUrls(AbstractChatEvent.URL_PATTERN)
                 .useUnusualXRepeatedCharacterHexFormat();
         if (VersionUtil.getServerBukkitVersion().isHigherThanOrEqualTo(VersionUtil.v1_16_1_R01)) {
             builder.hexColors();
         }
         LEGACY_SERIALIZER = builder.build();
+        LEGACY_SERIALIZER_URLS = builder.extractUrls(AbstractChatEvent.URL_PATTERN).build();
 
         MINI_MESSAGE_NO_TAGS = MiniMessage.builder().strict(true).build();
     }
@@ -125,6 +126,11 @@ public class SpigotAdventureFacet implements AdventureFacet {
     @Override
     public String stripTags(String input) {
         return miniMessageInstance.stripTags(input);
+    }
+
+    @Override
+    public String legacyToMiniWithUrls(String message) {
+        return miniMessageInstance.serialize(LEGACY_SERIALIZER_URLS.deserialize(message));
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcast.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcast.java
@@ -1,6 +1,7 @@
 package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
+import com.earth2me.essentials.adventure.AdventureUtil;
 import com.earth2me.essentials.utils.FormatUtil;
 import org.bukkit.Server;
 
@@ -15,6 +16,7 @@ public class Commandbroadcast extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
 
-        ess.broadcastTl("broadcast", FormatUtil.replaceFormat(getFinalArg(args, 0)).replace("\\n", "\n"), sender.getDisplayName());
+        final String message = FormatUtil.replaceFormat(getFinalArg(args, 0)).replace("\\n", "\n");
+        ess.broadcastTl("broadcast", AdventureUtil.parsed(ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(message))), sender.getDisplayName());
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcast.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcast.java
@@ -17,6 +17,8 @@ public class Commandbroadcast extends EssentialsCommand {
         }
 
         final String message = FormatUtil.replaceFormat(getFinalArg(args, 0)).replace("\\n", "\n");
-        ess.broadcastTl("broadcast", AdventureUtil.parsed(ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(message))), sender.getDisplayName());
+        ess.broadcastTl("broadcast",
+                AdventureUtil.parsed(ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(message))),
+                sender.getDisplayName());
     }
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcastworld.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcastworld.java
@@ -55,7 +55,10 @@ public class Commandbroadcastworld extends EssentialsCommand {
             throw new NotEnoughArgumentsException();
         }
         final String formatted = FormatUtil.replaceFormat(message).replace("\\n", "\n");
-        ess.broadcastTl(null, u -> !u.getBase().getWorld().equals(world), true, "broadcast", AdventureUtil.parsed(ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(formatted))), AdventureUtil.parsed(ess.getAdventureFacet().legacyToMini(name)));
+        ess.broadcastTl(null, u -> !u.getBase().getWorld().equals(world), true, "broadcast",
+                AdventureUtil.parsed(
+                        ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(formatted))),
+                AdventureUtil.parsed(ess.getAdventureFacet().legacyToMini(name)));
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcastworld.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandbroadcastworld.java
@@ -54,7 +54,8 @@ public class Commandbroadcastworld extends EssentialsCommand {
         if (message.isEmpty()) {
             throw new NotEnoughArgumentsException();
         }
-        ess.broadcastTl(null, u -> !u.getBase().getWorld().equals(world), true, "broadcast", FormatUtil.replaceFormat(message).replace("\\n", "\n"), AdventureUtil.parsed(ess.getAdventureFacet().legacyToMini(name)));
+        final String formatted = FormatUtil.replaceFormat(message).replace("\\n", "\n");
+        ess.broadcastTl(null, u -> !u.getBase().getWorld().equals(world), true, "broadcast", AdventureUtil.parsed(ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(formatted))), AdventureUtil.parsed(ess.getAdventureFacet().legacyToMini(name)));
     }
 
     @Override

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -223,7 +223,7 @@ public abstract class AbstractChatHandler {
         server.getPluginManager().callEvent(spyEvent);
 
         if (!spyEvent.isCancelled()) {
-            final String legacyString = ess.getAdventureFacet().miniToLegacy(String.format(spyEvent.getFormat(), ess.getAdventureFacet().legacyToMini(user.getDisplayName()), ess.getAdventureFacet().legacyToMini(ess.getAdventureFacet().escapeTags(spyEvent.getMessage()))));
+            final String legacyString = ess.getAdventureFacet().miniToLegacy(String.format(spyEvent.getFormat(), ess.getAdventureFacet().legacyToMini(user.getDisplayName()), ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(spyEvent.getMessage()))));
 
             for (final Player onlinePlayer : spyEvent.getRecipients()) {
                 onlinePlayer.sendMessage(legacyString);

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -223,7 +223,10 @@ public abstract class AbstractChatHandler {
         server.getPluginManager().callEvent(spyEvent);
 
         if (!spyEvent.isCancelled()) {
-            final String legacyString = ess.getAdventureFacet().miniToLegacy(String.format(spyEvent.getFormat(), ess.getAdventureFacet().legacyToMini(user.getDisplayName()), ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(spyEvent.getMessage()))));
+            final String legacyString = ess.getAdventureFacet().miniToLegacy(
+                    String.format(spyEvent.getFormat(),
+                            ess.getAdventureFacet().legacyToMini(user.getDisplayName()),
+                            ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(spyEvent.getMessage()))));
 
             for (final Player onlinePlayer : spyEvent.getRecipients()) {
                 onlinePlayer.sendMessage(legacyString);

--- a/providers/BaseProviders/src/main/java/com/earth2me/essentials/adventure/AdventureFacet.java
+++ b/providers/BaseProviders/src/main/java/com/earth2me/essentials/adventure/AdventureFacet.java
@@ -25,6 +25,11 @@ public interface AdventureFacet {
     String legacyToMini(String message, boolean useCustomTags);
 
     /**
+     * Converts a section sign legacy string to a MiniMessage string, auto-linking detected URLs as click events.
+     */
+    String legacyToMiniWithUrls(String message);
+
+    /**
      * Convenience method for submodules to escape MiniMessage tags.
      */
     String escapeTags(String input);

--- a/providers/PaperProvider/src/main/java/com/earth2me/essentials/adventure/PaperAdventureFacet.java
+++ b/providers/PaperProvider/src/main/java/com/earth2me/essentials/adventure/PaperAdventureFacet.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 
 public class PaperAdventureFacet implements AdventureFacet {
     private final LegacyComponentSerializer legacySerializer;
+    private final LegacyComponentSerializer legacySerializerUrls;
     private final MiniMessage miniMessageNoTags;
     private final MiniMessage miniMessageInstance;
 
@@ -29,10 +30,10 @@ public class PaperAdventureFacet implements AdventureFacet {
 
         final LegacyComponentSerializer.Builder builder = LegacyComponentSerializer.builder()
                 .flattener(ComponentFlattener.basic())
-                .extractUrls(AbstractChatEvent.URL_PATTERN)
                 .hexColors()
                 .useUnusualXRepeatedCharacterHexFormat();
         legacySerializer = builder.build();
+        legacySerializerUrls = builder.extractUrls(AbstractChatEvent.URL_PATTERN).build();
 
         miniMessageNoTags = MiniMessage.builder().strict(true).build();
 
@@ -86,6 +87,11 @@ public class PaperAdventureFacet implements AdventureFacet {
         } else {
             return miniMessageNoTags.serialize(deserializedText);
         }
+    }
+
+    @Override
+    public String legacyToMiniWithUrls(String message) {
+        return miniMessageInstance.serialize(legacySerializerUrls.deserialize(message));
     }
 
     @Override


### PR DESCRIPTION
extractUrls on the default LegacyComponentSerializer caused
legacyToMini to auto-wrap URLs in <click:open_url> tags. When
translation templates like discordCommandLink already wrapped {0}
in their own click tag, this produced nested click events that
Paper 1.21.11+ rejected.

The default serializer no longer extracts URLs. A new
legacyToMiniWithUrls method is available for cases that explicitly
need clickable URL extraction (chat, broadcast).

Fixes #6463