### PR TITLE
ISSUE#6502 fix: PlayerList appends literal <white> tag in customtext output

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/PlayerList.java
@@ -44,7 +44,7 @@ public final class PlayerList {
             if (ess.getSettings().realNamesOnList() && strippedNick != null && !strippedNick.equals(user.getName())) {
                 groupString.append(" ").append(tlLiteral("listRealName",user.getName()));
             }
-            groupString.append("<white>");
+            groupString.append("§f");
         }
         return groupString.toString();
     }


### PR DESCRIPTION
Title: {PLAYERLIST} placeholder appends literal <white> MiniMessage tag in custom.txt
Description:
When using {PLAYERLIST:group} placeholder inside custom.txt, the output contains a literal <white> tag appended after each player name instead of being parsed as MiniMessage.
Steps to reproduce:

Create a custom.txt with {PLAYERLIST:groupname}
Alias /list to customtext list in commands.yml
Run /list ingame

custom.txt
<img width="502" height="208" alt="Capture d&#39;écran 2026-04-12 012024" src="https://github.com/user-attachments/assets/6c72c3f5-2f67-4b73-a326-cb33bc9bac30" />

commands.yml

<img width="760" height="363" alt="Capture d&#39;écran 2026-04-12 012124" src="https://github.com/user-attachments/assets/0c9b0211-0859-4459-a9ab-6e4df8c8f689" />

Ingame chat output of /list
<img width="655" height="116" alt="Capture d&#39;écran 2026-04-12 011822" src="https://github.com/user-attachments/assets/9fdbf683-894c-4e24-83b8-7dde39e42e4d" />

Expected behavior: Player names display correctly with no visible tags
Actual behavior: white tag is rendered as plain text see screenshot above on Ingame input.
Root cause: In PlayerList.java line 36 : groupString.append("<white>"); is hardcoded but never parsed when output goes through customtext
Version: EssentialsX 2.21.0 / Paper 1.21

After compiling and testing this is the result with the PR request (reference to screenshot below)
<img width="356" height="119" alt="Capture d&#39;écran 2026-04-12 020057" src="https://github.com/user-attachments/assets/aad8eeff-7303-49ed-a1e7-3c461fcd53a0" />