### PR TITLE
Fix SocialSpy local chat color bleeding from player display name

### DIFF
--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -225,7 +225,7 @@ public abstract class AbstractChatHandler {
         if (!spyEvent.isCancelled()) {
             final String legacyString = ess.getAdventureFacet().miniToLegacy(
                     String.format(spyEvent.getFormat(),
-                            ess.getAdventureFacet().legacyToMini(user.getDisplayName()),
+                            ess.getAdventureFacet().legacyToMini(user.getDisplayName()) + "<reset>",
                             ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(spyEvent.getMessage()))));
 
             for (final Player onlinePlayer : spyEvent.getRecipients()) {


### PR DESCRIPTION
The display name converted via legacyToMini() produces open MiniMessage formatting tags that bleed into the subsequent message text. Append <reset> after the display name to close any inherited formatting.

Fixes #6504