### PR TITLE
Fix command descriptions not using player's locale

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -837,7 +837,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
                     sender.sendTl("commandHelpLine2", description);
                     sender.sendTl("commandHelpLine3");
                     for (Map.Entry<String, String> usage : cmd.getUsageStrings().entrySet()) {
-                        sender.sendTl("commandHelpLineUsage", AdventureUtil.parsed(usage.getKey().replace("<command>", commandLabel)), AdventureUtil.parsed(usage.getValue()));
+                        sender.sendTl("commandHelpLineUsage", AdventureUtil.parsed(usage.getKey().replace("<command>", commandLabel)), AdventureUtil.parsed(sender.tl(usage.getValue())));
                     }
                 } else {
                     sender.sendMessage(command.getDescription());

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhelp.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhelp.java
@@ -54,7 +54,7 @@ public class Commandhelp extends EssentialsCommand {
                         user.sendTl("commandHelpLine3");
                         if (essCommand != null && !essCommand.getUsageStrings().isEmpty()) {
                             for (Map.Entry<String, String> usage : essCommand.getUsageStrings().entrySet()) {
-                                user.sendTl("commandHelpLineUsage", AdventureUtil.parsed(usage.getKey().replace("<command>", cmd)), AdventureUtil.parsed(usage.getValue()));
+                                user.sendTl("commandHelpLineUsage", AdventureUtil.parsed(usage.getKey().replace("<command>", cmd)), AdventureUtil.parsed(user.playerTl(usage.getValue())));
                             }
                         } else {
                             user.sendMessage(bukkit.getUsage());

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/EssentialsCommand.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/EssentialsCommand.java
@@ -56,7 +56,7 @@ public abstract class EssentialsCommand implements IEssentialsCommand {
             //noinspection InfiniteLoopStatement
             while (true) {
                 final String baseKey = name + "CommandUsage" + i;
-                addUsageString(tlLiteral(baseKey), tlLiteral(baseKey + "Description"));
+                addUsageString(tlLiteral(baseKey), baseKey + "Description");
                 i++;
             }
         } catch (MissingResourceException ignored) {


### PR DESCRIPTION
Usage descriptions were resolved once at command construction time via tlLiteral() (server default locale) and cached. Now store the translation key instead and resolve per-player at display time using playerTl()/tl().

Fixes #6353