### PR TITLE
Fix VanishStatusChangeEvent NPE and document parameter inversion

### DIFF
--- a/Essentials/src/main/java/net/ess3/api/events/VanishStatusChangeEvent.java
+++ b/Essentials/src/main/java/net/ess3/api/events/VanishStatusChangeEvent.java
@@ -8,6 +8,12 @@ import org.bukkit.event.HandlerList;
  * <p>
  * For other cases where the player's vanish status changes, you should listen on PlayerJoinEvent and
  * check with {@link IUser#isVanished()}.
+ *
+ * <b>WARNING: The values of {@link #getAffected()} and {@link #getController()} are inverted due to
+ * a long-standing parameter swap. {@link #getAffected()} returns the command sender (null for console),
+ * and {@link #getController()} returns the player whose vanish status changed.</b>
+ *
+ * @see <a href="https://github.com/EssentialsX/Essentials/issues/2604">#2604</a>
  */
 public class VanishStatusChangeEvent extends StatusChangeEvent {
     private static final HandlerList handlers = new HandlerList();

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -126,14 +126,16 @@ public class BukkitListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onVanishStatusChange(VanishStatusChangeEvent event) {
-        if (!jda.getSettings().isVanishFakeJoinLeave() || event.getAffected().isLeavingHidden()) {
+        // Note: getController() returns the vanished player due to a long-standing parameter swap in Commandvanish.
+        final IUser vanished = event.getController();
+        if (vanished == null || !jda.getSettings().isVanishFakeJoinLeave() || vanished.isLeavingHidden()) {
             return;
         }
         if (event.getValue()) {
-            sendJoinQuitMessage(event.getAffected().getBase(), ChatColor.YELLOW + event.getAffected().getName() + " left the game", MessageType.DefaultTypes.LEAVE);
+            sendJoinQuitMessage(vanished.getBase(), ChatColor.YELLOW + vanished.getName() + " left the game", MessageType.DefaultTypes.LEAVE);
             return;
         }
-        sendJoinQuitMessage(event.getAffected().getBase(), ChatColor.YELLOW + event.getAffected().getName() + " joined the game", MessageType.DefaultTypes.JOIN);
+        sendJoinQuitMessage(vanished.getBase(), ChatColor.YELLOW + vanished.getName() + " joined the game", MessageType.DefaultTypes.JOIN);
     }
 
     public void sendJoinQuitMessage(final Player player, final String message, MessageType type) {


### PR DESCRIPTION
The affected/controller parameters are swapped in Commandvanish (#2604) but cannot be fixed without breaking the public API.

Fix BukkitListener to use getController() (the actual vanished player) instead of getAffected() (the sender, null for console), and add inversion warning javadoc matching the NickChangeEvent pattern.

Fixes #6388