### PR TITLE
Fix {USERNAME} underscore escaping in kit items

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/textreader/KeywordReplacer.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/textreader/KeywordReplacer.java
@@ -380,8 +380,10 @@ public class KeywordReplacer implements IText {
                 }
 
                 if (this.replaceSpacesWithUnderscores) {
-                    // Don't replace spaces with underscores in command nor escape underscores.
-                    if (!line.startsWith("/")) {
+                    // Don't replace spaces with underscores in commands, and skip escaping
+                    // for USERNAME since Minecraft names never contain spaces but can
+                    // contain underscores that must stay literal (e.g. player:{USERNAME}).
+                    if (!line.startsWith("/") && validKeyword != KeywordType.USERNAME) {
                         replacer = replacer.replace("_", "\\_").replaceAll("\\s", "_");
                     }
                 }


### PR DESCRIPTION
The underscore-to-backslash escaping in KeywordReplacer is needed for
item names/lores where underscores represent spaces, but Minecraft
usernames never contain spaces and their underscores must stay literal.
Skip the escaping for USERNAME keywords so player:{USERNAME} resolves
correctly for names like Player_Name.

Fixes #6296