### PR TITLE
Fix deposits rejected when account has negative balance

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/api/Economy.java
@@ -323,7 +323,13 @@ public class Economy {
             throw new IllegalArgumentException("Economy user cannot be null");
         }
         final BigDecimal result = getMoneyExact(user).add(amount, MATH_CONTEXT);
-        setMoney(user, result);
+        // Deposits (positive amounts) always improve the balance, so minMoney and
+        // loan checks don't apply — they exist to prevent the balance from dropping.
+        if (amount.signum() <= 0) {
+            setMoney(user, result);
+        } else {
+            user.setMoney(result, UserBalanceUpdateEvent.Cause.API);
+        }
         Trade.log("API", "Add", "API", user.getName(), new Trade(amount, ess), null, null, null, result, ess);
     }
 


### PR DESCRIPTION
Economy.add() delegated to setMoney() which checks minMoney and loan
permission against the resulting balance. Both checks reject negative
results even when the balance is improving from a deposit. Since
deposits can only move the balance upward, route them directly to
user.setMoney() bypassing the floor/loan checks. Withdrawals still
go through setMoney() with full validation.

Fixes #5606