### PR TITLE
Fix essentials.home.bed permission being ignored

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandhome.java
@@ -41,7 +41,10 @@ public class Commandhome extends EssentialsCommand {
             }
         }
         try {
-            if ("bed".equalsIgnoreCase(homeName) && user.isAuthorized("essentials.home.bed")) {
+            if ("bed".equalsIgnoreCase(homeName)) {
+                if (!user.isAuthorized("essentials.home.bed")) {
+                    throw new TranslatableException("noAccessCommand");
+                }
                 if (!player.getBase().isOnline() || player.getBase() instanceof OfflinePlayerStub) {
                     throw new TranslatableException("bedOffline");
                 }
@@ -73,10 +76,15 @@ public class Commandhome extends EssentialsCommand {
                 final List<String> homes = finalPlayer.getHomes();
                 if (homes.isEmpty() && finalPlayer.equals(user)) {
                     if (ess.getSettings().isSpawnIfNoHome()) {
-                        final UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, null, bed != null ? bed : finalPlayer.getWorld().getSpawnLocation(), bed != null ? UserTeleportHomeEvent.HomeType.BED : UserTeleportHomeEvent.HomeType.SPAWN);
+                        final boolean useBed = bed != null && user.isAuthorized("essentials.home.bed");
+                        final UserTeleportHomeEvent event = new UserTeleportHomeEvent(user, null, useBed ? bed : finalPlayer.getWorld().getSpawnLocation(), useBed ? UserTeleportHomeEvent.HomeType.BED : UserTeleportHomeEvent.HomeType.SPAWN);
                         server.getPluginManager().callEvent(event);
                         if (!event.isCancelled()) {
-                            user.getAsyncTeleport().respawn(charge, TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
+                            if (useBed) {
+                                user.getAsyncTeleport().respawn(charge, TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
+                            } else {
+                                user.getAsyncTeleport().teleport(finalPlayer.getWorld().getSpawnLocation(), charge, TeleportCause.COMMAND, getNewExceptionFuture(user.getSource(), commandLabel));
+                            }
                         }
                     } else {
                         showError(user.getBase(), new TranslatableException("noHomeSetPlayer"), commandLabel);


### PR DESCRIPTION
Two paths bypassed the permission check:

1. Explicit /home bed: the permission check at line 44 was combined
   with the bed-spawn logic in a single condition. When denied, it
   fell through to goHome("bed") which found the stored bed home
   by name and teleported anyway. Now rejects immediately.

2. Fallback respawn: when a player has no homes and isSpawnIfNoHome
   is true, respawn() was called unconditionally which tries the bed.
   Now checks the permission and falls back to world spawn when denied.

Fixes #5963