### PR TITLE
Misc. Folia fixes

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -77,6 +77,7 @@ import net.ess3.provider.providers.BukkitMaterialTagProvider;
 import net.ess3.provider.providers.BukkitSchedulingProvider;
 import net.ess3.provider.providers.BukkitSpawnerBlockProvider;
 import net.ess3.provider.providers.BukkitTileEntityProvider;
+import net.ess3.provider.providers.BukkitWorldTileEntityCountProvider;
 import net.ess3.provider.providers.FixedHeightWorldInfoProvider;
 import net.ess3.provider.providers.FlatSpawnEggProvider;
 import net.ess3.provider.providers.FoliaSchedulingProvider;
@@ -105,6 +106,7 @@ import net.ess3.provider.providers.PaperSerializationProvider;
 import net.ess3.provider.providers.PaperServerStateProvider;
 import net.ess3.provider.providers.PaperTickCountProvider;
 import net.ess3.provider.providers.PaperTileEntityProvider;
+import net.ess3.provider.providers.PaperWorldTileEntityCountProvider;
 import net.ess3.provider.providers.PrehistoricPotionMetaProvider;
 import net.essentialsx.api.v2.services.BalanceTop;
 import net.essentialsx.api.v2.services.mail.MailService;
@@ -395,6 +397,9 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
 
             // Tile Entity Provider
             providerFactory.registerProvider(BukkitTileEntityProvider.class, PaperTileEntityProvider.class);
+
+            // World Tile Entity Count Provider
+            providerFactory.registerProvider(BukkitWorldTileEntityCountProvider.class, PaperWorldTileEntityCountProvider.class);
 
             // Tick Count Provider
             providerFactory.registerProvider(PaperTickCountProvider.class);

--- a/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Essentials.java
@@ -108,7 +108,6 @@ import net.ess3.provider.providers.PaperTileEntityProvider;
 import net.ess3.provider.providers.PrehistoricPotionMetaProvider;
 import net.essentialsx.api.v2.services.BalanceTop;
 import net.essentialsx.api.v2.services.mail.MailService;
-import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
@@ -612,8 +611,7 @@ public class Essentials extends JavaPlugin implements net.ess3.api.IEssentials {
             }
         }
 
-        AdventureUtil.setEss(this);
-        bukkitAudience = BukkitAudiences.create(this);
+        initAdventureFacet();
     }
 
     private void initAdventureFacet() {

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandgc.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandgc.java
@@ -3,15 +3,13 @@ package com.earth2me.essentials.commands;
 import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.NumberUtil;
-import net.ess3.provider.TileEntityProvider;
+import net.ess3.provider.WorldTileEntityCountProvider;
 import org.bukkit.ChatColor;
-import org.bukkit.Chunk;
 import org.bukkit.Server;
 import org.bukkit.World;
 
 import java.lang.management.ManagementFactory;
 import java.util.List;
-import java.util.logging.Level;
 
 public class Commandgc extends EssentialsCommand {
     public Commandgc() {
@@ -37,7 +35,7 @@ public class Commandgc extends EssentialsCommand {
         sender.sendTl("gcfree", Runtime.getRuntime().freeMemory() / 1024 / 1024);
 
         final List<World> worlds = server.getWorlds();
-        final TileEntityProvider tileEntityProvider = ess.provider(TileEntityProvider.class);
+        final WorldTileEntityCountProvider worldTileEntityCountProvider = ess.provider(WorldTileEntityCountProvider.class);
         for (final World w : worlds) {
             String worldType = "World";
             switch (w.getEnvironment()) {
@@ -49,15 +47,7 @@ public class Commandgc extends EssentialsCommand {
                     break;
             }
 
-            int tileEntities = 0;
-
-            try {
-                for (final Chunk chunk : w.getLoadedChunks()) {
-                    tileEntities += tileEntityProvider.getTileEntities(chunk).length;
-                }
-            } catch (final java.lang.ClassCastException ex) {
-                ess.getLogger().log(Level.SEVERE, "Corrupted chunk data on world " + w, ex);
-            }
+            final int tileEntities = worldTileEntityCountProvider.getTileEntityCount(w);
 
             sender.sendTl("gcWorld", worldType, w.getName(), w.getLoadedChunks().length, w.getEntities().size(), tileEntities);
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkill.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandkill.java
@@ -32,13 +32,15 @@ public class Commandkill extends EssentialsLoopCommand {
         }
         final DamageEventProvider provider = ess.provider(DamageEventProvider.class);
 
-        final EntityDamageEvent ede = provider.callDamageEvent(matchPlayer, sender.isPlayer() && sender.getPlayer().getName().equals(matchPlayer.getName()) ? EntityDamageEvent.DamageCause.SUICIDE : EntityDamageEvent.DamageCause.CUSTOM, Float.MAX_VALUE);
-        if (ede.isCancelled() && sender.isPlayer() && !ess.getUser(sender.getPlayer()).isAuthorized("essentials.kill.force")) {
-            return;
-        }
-        ede.getEntity().setLastDamageCause(ede);
-        matchPlayer.setHealth(0);
-        sender.sendTl("kill", matchPlayer.getDisplayName());
+        ess.scheduleEntityDelayedTask(matchPlayer, () -> {
+            final EntityDamageEvent ede = provider.callDamageEvent(matchPlayer, sender.isPlayer() && sender.getPlayer().getName().equals(matchPlayer.getName()) ? EntityDamageEvent.DamageCause.SUICIDE : EntityDamageEvent.DamageCause.CUSTOM, Float.MAX_VALUE);
+            if (ede.isCancelled() && sender.isPlayer() && !ess.getUser(sender.getPlayer()).isAuthorized("essentials.kill.force")) {
+                return;
+            }
+            ede.getEntity().setLastDamageCause(ede);
+            matchPlayer.setHealth(0);
+            sender.sendTl("kill", matchPlayer.getDisplayName());
+        });
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandlightning.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandlightning.java
@@ -33,15 +33,17 @@ public class Commandlightning extends EssentialsLoopCommand {
         }
         final int finalPower = power;
         loopOnlinePlayersConsumer(server, sender, false, true, args[0], player -> {
-            sender.sendTl("lightningUse", player.getDisplayName());
-            final LightningStrike strike = player.getBase().getWorld().strikeLightningEffect(player.getBase().getLocation());
+            ess.scheduleEntityDelayedTask(player.getBase(), () -> {
+                sender.sendTl("lightningUse", player.getDisplayName());
+                final LightningStrike strike = player.getBase().getWorld().strikeLightningEffect(player.getBase().getLocation());
 
-            if (!player.isGodModeEnabled()) {
-                player.getBase().damage(finalPower, strike);
-            }
-            if (ess.getSettings().warnOnSmite()) {
-                player.sendTl("lightningSmited");
-            }
+                if (!player.isGodModeEnabled()) {
+                    player.getBase().damage(finalPower, strike);
+                }
+                if (ess.getSettings().warnOnSmite()) {
+                    player.sendTl("lightningSmited");
+                }
+            });
         });
         loopOnlinePlayers(server, sender, true, true, args[0], null);
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandthunder.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandthunder.java
@@ -22,13 +22,15 @@ public class Commandthunder extends EssentialsCommand {
         final World world = user.getWorld();
         final boolean setThunder = args[0].equalsIgnoreCase("true");
         if (args.length == 1) {
-            world.setThundering(setThunder);
+            ess.scheduleGlobalDelayedTask(() -> world.setThundering(setThunder));
             user.sendTl("thunder", setThunder ? user.playerTl("enabled") : user.playerTl("disabled"));
             return;
         }
 
-        world.setThundering(setThunder);
-        world.setThunderDuration(Integer.parseInt(args[1]) * 20);
+        ess.scheduleGlobalDelayedTask(() -> {
+            world.setThundering(setThunder);
+            world.setThunderDuration(Integer.parseInt(args[1]) * 20);
+        });
         user.sendTl("thunderDuration", setThunder ? user.playerTl("enabled") : user.playerTl("disabled"), Integer.parseInt(args[1]));
     }
 

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/WorldTileEntityCountProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/WorldTileEntityCountProvider.java
@@ -1,0 +1,7 @@
+package net.ess3.provider;
+
+import org.bukkit.World;
+
+public interface WorldTileEntityCountProvider extends Provider {
+    int getTileEntityCount(final World world);
+}

--- a/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BukkitWorldTileEntityCountProvider.java
+++ b/providers/BaseProviders/src/main/java/net/ess3/provider/providers/BukkitWorldTileEntityCountProvider.java
@@ -1,0 +1,20 @@
+package net.ess3.provider.providers;
+
+import net.ess3.provider.WorldTileEntityCountProvider;
+import net.essentialsx.providers.ProviderData;
+import org.bukkit.Chunk;
+import org.bukkit.World;
+
+@ProviderData(description = "Bukkit World Tile Entity Count Provider")
+public class BukkitWorldTileEntityCountProvider implements WorldTileEntityCountProvider {
+    @Override
+    public int getTileEntityCount(World world) {
+        int tileEntities = 0;
+
+        for (final Chunk chunk : world.getLoadedChunks()) {
+            tileEntities += chunk.getTileEntities().length;
+        }
+
+        return tileEntities;
+    }
+}

--- a/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperWorldTileEntityCountProvider.java
+++ b/providers/PaperProvider/src/main/java/net/ess3/provider/providers/PaperWorldTileEntityCountProvider.java
@@ -1,0 +1,13 @@
+package net.ess3.provider.providers;
+
+import net.ess3.provider.WorldTileEntityCountProvider;
+import net.essentialsx.providers.ProviderData;
+import org.bukkit.World;
+
+@ProviderData(description = "Paper 1.11+ World Tile Entity Count Provider", weight = 1)
+public class PaperWorldTileEntityCountProvider implements WorldTileEntityCountProvider {
+    @Override
+    public int getTileEntityCount(World world) {
+        return world.getTileEntityCount();
+    }
+}


### PR DESCRIPTION
Minor fixes for the folia branch, in one PR to not be spammy. Includes a new provider for the gc command to retrieve tile entity counts per world in a simple manner that works on folia.