### PR TITLE
Add essentials.tptoggle.bypass permission

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/UserData.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/UserData.java
@@ -399,6 +399,18 @@ public abstract class UserData extends PlayerExtension implements IConf {
         return holder.teleportEnabled();
     }
 
+    public boolean isTeleportAllowedFor(final IUser teleporter) {
+        if (isTeleportEnabled()) {
+            return true;
+        }
+        if (teleporter == null) {
+            return true;
+        }
+        return teleporter.isAuthorized("essentials.tptoggle.bypass")
+            || teleporter.isAuthorized("essentials.tpo")
+            || teleporter.isAuthorized("essentials.tpohere");
+    }
+
     public void setTeleportEnabled(final boolean set) {
         holder.teleportEnabled(set);
         config.save();

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtp.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtp.java
@@ -27,7 +27,7 @@ public class Commandtp extends EssentialsCommand {
             case 1:
                 final User player = getPlayer(server, user, args, 0, false, true);
 
-                if (!player.isTeleportEnabled()) {
+                if (!player.isTeleportAllowedFor(user)) {
                     throw new TranslatableException("teleportDisabled", player.getDisplayName());
                 }
 
@@ -78,7 +78,7 @@ public class Commandtp extends EssentialsCommand {
                     throw new NotEnoughArgumentsException(user.playerTl("teleportInvalidLocation"));
                 }
                 final Location locposother = new Location(target2.getWorld(), x, y, z, target2.getLocation().getYaw(), target2.getLocation().getPitch());
-                if (!target2.isTeleportEnabled()) {
+                if (!target2.isTeleportAllowedFor(user)) {
                     throw new TranslatableException("teleportDisabled", target2.getDisplayName());
                 }
                 user.sendTl("teleporting", locposother.getWorld().getName(), locposother.getBlockX(), locposother.getBlockY(), locposother.getBlockZ());
@@ -96,10 +96,10 @@ public class Commandtp extends EssentialsCommand {
                 }
                 final User target = getPlayer(server, user, args, 0);
                 final User toPlayer = getPlayer(server, user, args, 1);
-                if (!target.isTeleportEnabled()) {
+                if (!target.isTeleportAllowedFor(user)) {
                     throw new TranslatableException("teleportDisabled", target.getDisplayName());
                 }
-                if (!toPlayer.isTeleportEnabled()) {
+                if (!toPlayer.isTeleportAllowedFor(user)) {
                     throw new TranslatableException("teleportDisabled", toPlayer.getDisplayName());
                 }
                 if (target.getWorld() != toPlayer.getWorld() && ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + toPlayer.getWorld().getName())) {

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtpa.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtpa.java
@@ -30,7 +30,7 @@ public class Commandtpa extends EssentialsCommand {
         if (!player.isAuthorized("essentials.tpaccept")) {
             throw new TranslatableException("teleportNoAcceptPermission", player.getDisplayName());
         }
-        if (!player.isTeleportEnabled()) {
+        if (!player.isTeleportAllowedFor(user)) {
             throw new TranslatableException("teleportDisabled", player.getDisplayName());
         }
         if (user.getWorld() != player.getWorld() && ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + player.getWorld().getName())) {

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtpahere.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtpahere.java
@@ -26,7 +26,7 @@ public class Commandtpahere extends EssentialsCommand {
         if (!player.isAuthorized("essentials.tpaccept")) {
             throw new TranslatableException("teleportNoAcceptPermission", player.getDisplayName());
         }
-        if (!player.isTeleportEnabled()) {
+        if (!player.isTeleportAllowedFor(user)) {
             throw new TranslatableException("teleportDisabled", player.getDisplayName());
         }
         if (user.getWorld() != player.getWorld() && ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + user.getWorld().getName())) {

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtphere.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtphere.java
@@ -17,7 +17,7 @@ public class Commandtphere extends EssentialsCommand {
     @Override
     public void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
         final User player = getPlayer(server, user, args, 0);
-        if (!player.isTeleportEnabled()) {
+        if (!player.isTeleportAllowedFor(user)) {
             throw new TranslatableException("teleportDisabled", player.getDisplayName());
         }
         if (user.getWorld() != player.getWorld() && ess.getSettings().isWorldTeleportPermissions() && !user.isAuthorized("essentials.worlds." + user.getWorld().getName())) {

--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -1350,6 +1350,8 @@ permissions:
     description: Allows access to the /tptoggle command
   essentials.tptoggle.others:
     description: Allows access to the /tptoggle command for other players
+  essentials.tptoggle.bypass:
+    description: Allows the bearer to bypass the tptoggle setting for other players
   essentials.tpr:
     description: Allows access to the /tpr command
   essentials.settpr:


### PR DESCRIPTION
## Summary
- Adds \essentials.tptoggle.bypass\ (mirrors \msgtoggle.bypass\)
- \/tp\, \/tphere\, \/tpa\, \/tpahere\ respect bypass; existing \	po\/\	pohere\ perms also work

Fixes #5330

## Test plan
- [ ] Player with tptoggle off blocks normal /tp
- [ ] Staff with bypass/tpo can still /tp to them

Made with [Cursor](https://cursor.com)