### PR TITLE
Add negative-effects option for remove-effects-on-heal

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/HealEffectRemovalMode.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/HealEffectRemovalMode.java
@@ -1,0 +1,7 @@
+package com.earth2me.essentials;
+
+public enum HealEffectRemovalMode {
+    NONE,
+    ALL,
+    NEGATIVE_ONLY
+}

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -425,6 +425,8 @@ public interface ISettings extends IConf {
 
     boolean isRemovingEffectsOnHeal();
 
+    HealEffectRemovalMode getHealEffectRemovalMode();
+
     boolean isSpawnIfNoHome();
 
     boolean isConfirmHomeOverwrite();

--- a/Essentials/src/main/java/com/earth2me/essentials/Potions.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Potions.java
@@ -5,6 +5,7 @@ import com.earth2me.essentials.utils.RegistryUtil;
 import org.bukkit.potion.PotionEffectType;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -13,6 +14,7 @@ import java.util.Set;
 public final class Potions {
     private static final Map<String, PotionEffectType> POTIONS = new HashMap<>();
     private static final Map<String, PotionEffectType> ALIASPOTIONS = new HashMap<>();
+    private static final Set<PotionEffectType> HARMFUL_EFFECTS = new HashSet<>();
 
     static {
 
@@ -169,9 +171,44 @@ public final class Potions {
             ALIASPOTIONS.put("nautilus", PotionEffectType.BREATH_OF_THE_NAUTILUS);
         } catch (final Throwable ignored) {
         }
+
+        registerHarmful(SLOWNESS);
+        registerHarmful(MINING_FATIGUE);
+        registerHarmful(INSTANT_DAMAGE);
+        registerHarmful(NAUSEA);
+        registerHarmful(PotionEffectType.BLINDNESS);
+        registerHarmful(PotionEffectType.HUNGER);
+        registerHarmful(PotionEffectType.WEAKNESS);
+        registerHarmful(PotionEffectType.POISON);
+        registerHarmful(PotionEffectType.WITHER);
+        registerHarmful(PotionEffectType.UNLUCK);
+
+        try {
+            registerHarmful(PotionEffectType.GLOWING);
+            registerHarmful(PotionEffectType.LEVITATION);
+            registerHarmful(PotionEffectType.BAD_OMEN);
+            registerHarmful(PotionEffectType.DARKNESS);
+            registerHarmful(PotionEffectType.INFESTED);
+            registerHarmful(PotionEffectType.OOZING);
+            registerHarmful(PotionEffectType.WEAVING);
+            registerHarmful(PotionEffectType.WIND_CHARGED);
+            registerHarmful(PotionEffectType.TRIAL_OMEN);
+            registerHarmful(PotionEffectType.RAID_OMEN);
+        } catch (final Throwable ignored) {
+        }
+    }
+
+    private static void registerHarmful(final PotionEffectType type) {
+        if (type != null) {
+            HARMFUL_EFFECTS.add(type);
+        }
     }
 
     private Potions() {
+    }
+
+    public static boolean isHarmful(final PotionEffectType type) {
+        return type != null && HARMFUL_EFFECTS.contains(type);
     }
 
     public static PotionEffectType getByName(final String name) {

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -149,7 +149,7 @@ public class Settings implements net.ess3.api.ISettings {
     private Set<Predicate<String>> nickBlacklist;
     private boolean resetNickOnNameChange;
     private double maxProjectileSpeed;
-    private boolean removeEffectsOnHeal;
+    private HealEffectRemovalMode healEffectRemovalMode;
     private Map<String, String> worldAliases;
     private String primaryColor = DEFAULT_PRIMARY_COLOR;
     private String secondaryColor = DEFAULT_SECONDARY_COLOR;
@@ -944,7 +944,7 @@ public class Settings implements net.ess3.api.ISettings {
         logConsoleCommands = _logConsoleCommands();
         nickBlacklist = _getNickBlacklist();
         maxProjectileSpeed = _getMaxProjectileSpeed();
-        removeEffectsOnHeal = _isRemovingEffectsOnHeal();
+        healEffectRemovalMode = _getHealEffectRemovalMode();
         vanishingItemPolicy = _getVanishingItemsPolicy();
         bindingItemPolicy = _getBindingItemsPolicy();
         currencySymbol = _getCurrencySymbol();
@@ -2138,13 +2138,40 @@ public class Settings implements net.ess3.api.ISettings {
         return maxProjectileSpeed;
     }
 
-    private boolean _isRemovingEffectsOnHeal() {
-        return config.getBoolean("remove-effects-on-heal", true);
+    private HealEffectRemovalMode _getHealEffectRemovalMode() {
+        if (!config.hasProperty("remove-effects-on-heal")) {
+            return HealEffectRemovalMode.ALL;
+        }
+        if (config.isBoolean("remove-effects-on-heal")) {
+            return config.getBoolean("remove-effects-on-heal", true) ? HealEffectRemovalMode.ALL : HealEffectRemovalMode.NONE;
+        }
+        final String value = config.getString("remove-effects-on-heal", "true").toLowerCase(Locale.ENGLISH);
+        switch (value) {
+            case "true":
+            case "all":
+                return HealEffectRemovalMode.ALL;
+            case "false":
+            case "none":
+                return HealEffectRemovalMode.NONE;
+            case "negative":
+            case "negative-effects":
+            case "negative_only":
+            case "negative-only":
+                return HealEffectRemovalMode.NEGATIVE_ONLY;
+            default:
+                ess.getLogger().warning("Unknown remove-effects-on-heal value: '" + value + "'. Using 'all'.");
+                return HealEffectRemovalMode.ALL;
+        }
     }
 
     @Override
     public boolean isRemovingEffectsOnHeal() {
-        return removeEffectsOnHeal;
+        return healEffectRemovalMode != HealEffectRemovalMode.NONE;
+    }
+
+    @Override
+    public HealEffectRemovalMode getHealEffectRemovalMode() {
+        return healEffectRemovalMode;
     }
 
     @Override

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandheal.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandheal.java
@@ -1,6 +1,8 @@
 package com.earth2me.essentials.commands;
 
 import com.earth2me.essentials.CommandSource;
+import com.earth2me.essentials.HealEffectRemovalMode;
+import com.earth2me.essentials.Potions;
 import com.earth2me.essentials.User;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
@@ -65,9 +67,12 @@ public class Commandheal extends EssentialsLoopCommand {
             player.setFireTicks(0);
             player.setRemainingAir(player.getMaximumAir());
             user.sendTl("heal");
-            if (ess.getSettings().isRemovingEffectsOnHeal()) {
+            final HealEffectRemovalMode effectRemovalMode = ess.getSettings().getHealEffectRemovalMode();
+            if (effectRemovalMode != HealEffectRemovalMode.NONE) {
                 for (final PotionEffect effect : player.getActivePotionEffects()) {
-                    player.removePotionEffect(effect.getType());
+                    if (effectRemovalMode == HealEffectRemovalMode.ALL || Potions.isHarmful(effect.getType())) {
+                        player.removePotionEffect(effect.getType());
+                    }
                 }
             }
             if (!sender.isPlayer() || !user.getBase().equals(sender.getPlayer())) {

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -126,6 +126,9 @@ teleport-to-center: true
 heal-cooldown: 60
 
 # Should potion effects be removed when healing a player?
+# Accepts: true/all, false/none, negative-effects/negative
+# When set to negative-effects, only harmful effects (poison, slowness, etc.) are removed.
+# Positive effects like Hero of the Village, speed, and regeneration are preserved.
 remove-effects-on-heal: true
 
 # The default radius when /near is used.


### PR DESCRIPTION
## Summary
- `/heal` can now remove only harmful potion effects via `remove-effects-on-heal: negative-effects`
- Preserves beneficial buffs (e.g. Hero of the Village, speed, regeneration)

## Test plan
- [ ] `/heal` with poison + speed: only poison removed
- [ ] `/heal` with Hero of the Village: effect kept
- [ ] `remove-effects-on-heal: true` still removes all effects