### PR TITLE
Fix nickname format codes bleeding into following text

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/adventure/SpigotAdventureFacet.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/adventure/SpigotAdventureFacet.java
@@ -76,7 +76,7 @@ public class SpigotAdventureFacet implements AdventureFacet {
 
     @Override
     public String legacyToMini(String message) {
-        return legacyToMini(message, true);
+        return legacyToMini(message, false);
     }
 
     @Override

--- a/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
+++ b/EssentialsChat/src/main/java/com/earth2me/essentials/chat/processing/AbstractChatHandler.java
@@ -225,7 +225,7 @@ public abstract class AbstractChatHandler {
         if (!spyEvent.isCancelled()) {
             final String legacyString = ess.getAdventureFacet().miniToLegacy(
                     String.format(spyEvent.getFormat(),
-                            ess.getAdventureFacet().legacyToMini(user.getDisplayName()) + "<reset>",
+                            ess.getAdventureFacet().legacyToMini(user.getDisplayName()),
                             ess.getAdventureFacet().legacyToMiniWithUrls(ess.getAdventureFacet().escapeTags(spyEvent.getMessage()))));
 
             for (final Player onlinePlayer : spyEvent.getRecipients()) {

--- a/providers/PaperProvider/src/main/java/com/earth2me/essentials/adventure/PaperAdventureFacet.java
+++ b/providers/PaperProvider/src/main/java/com/earth2me/essentials/adventure/PaperAdventureFacet.java
@@ -76,7 +76,7 @@ public class PaperAdventureFacet implements AdventureFacet {
 
     @Override
     public String legacyToMini(String message) {
-        return legacyToMini(message, true);
+        return legacyToMini(message, false);
     }
 
     @Override


### PR DESCRIPTION
The single-arg legacyToMini() facet default flipped from false to true during the Paper adventure migration (#6220), switching message placeholder serialization from strict to non-strict. Non-strict output leaves format tags open, so a formatted nickname/display name bleeds its color and formatting into the rest of the message.

Restore the default to false and drop the now-redundant <reset> workaround in SocialSpy local chat (#6507).

Fixes #6559
Fixes #6537