### PR TITLE
Fix teleport-cooldown not applying to /tp <x> <y> <z>

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtp.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandtp.java
@@ -56,7 +56,7 @@ public class Commandtp extends EssentialsCommand {
                     throw new NotEnoughArgumentsException(user.playerTl("teleportInvalidLocation"));
                 }
                 final Location locpos = new Location(user.getWorld(), x2, y2, z2, user.getLocation().getYaw(), user.getLocation().getPitch());
-                user.getAsyncTeleport().now(locpos, false, TeleportCause.COMMAND, future);
+                user.getAsyncTeleport().now(locpos, true, TeleportCause.COMMAND, future);
                 future.thenAccept(success -> {
                     if (success) {
                         user.sendTl("teleporting", locpos.getWorld().getName(), locpos.getBlockX(), locpos.getBlockY(), locpos.getBlockZ());


### PR DESCRIPTION
Self-teleport to coordinates called now() with cooldown disabled, so it ignored teleport-cooldown while every other self-teleport path enforces it. Enable the cooldown flag for this case.

Fixes #6499