### PR TITLE
Show muted players' private messages to social spies

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -193,22 +193,7 @@ public class EssentialsPlayerListener implements Listener {
         final User user = ess.getUser(event.getPlayer());
         if (user.isMuted()) {
             event.setCancelled(true);
-
-            final String dateDiff = user.getMuteTimeout() > 0 ? DateUtil.formatDateDiff(user.getMuteTimeout()) : null;
-            if (dateDiff == null) {
-                if (user.hasMuteReason()) {
-                    user.sendTl("voiceSilencedReason", user.getMuteReason());
-                } else {
-                    user.sendTl("voiceSilenced");
-                }
-            } else {
-                if (user.hasMuteReason()) {
-                    user.sendTl("voiceSilencedReasonTime", dateDiff, user.getMuteReason());
-                } else {
-                    user.sendTl("voiceSilencedTime", dateDiff);
-                }
-            }
-
+            user.notifyMuted();
             ess.getLogger().info(ess.getAdventureFacet().miniToLegacy(tlLiteral("mutedUserSpeaks", user.getName(), event.getMessage())));
         }
         try {
@@ -825,20 +810,7 @@ public class EssentialsPlayerListener implements Listener {
         final User user = ess.getUser(player);
         if (user.isMuted() && (ess.getSettings().getMuteCommands().contains(cmd) || ess.getSettings().getMuteCommands().contains("*"))) {
             event.setCancelled(true);
-            final String dateDiff = user.getMuteTimeout() > 0 ? DateUtil.formatDateDiff(user.getMuteTimeout()) : null;
-            if (dateDiff == null) {
-                if (user.hasMuteReason()) {
-                    user.sendTl("voiceSilencedReason", user.getMuteReason());
-                } else {
-                    user.sendTl("voiceSilenced");
-                }
-            } else {
-                if (user.hasMuteReason()) {
-                    user.sendTl("voiceSilencedReasonTime", dateDiff, user.getMuteReason());
-                } else {
-                    user.sendTl("voiceSilencedTime", dateDiff);
-                }
-            }
+            user.notifyMuted();
             ess.getLogger().info(ess.getAdventureFacet().miniToLegacy(tlLiteral("mutedUserSpeaks", player.getName(), event.getMessage())));
             return;
         }

--- a/Essentials/src/main/java/com/earth2me/essentials/User.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/User.java
@@ -822,6 +822,24 @@ public class User extends UserData implements Comparable<User>, IMessageRecipien
         return false;
     }
 
+    // Notifies this (muted) user that they have been silenced, including the reason and remaining time if applicable.
+    public void notifyMuted() {
+        final String dateDiff = getMuteTimeout() > 0 ? DateUtil.formatDateDiff(getMuteTimeout()) : null;
+        if (dateDiff == null) {
+            if (hasMuteReason()) {
+                sendTl("voiceSilencedReason", getMuteReason());
+            } else {
+                sendTl("voiceSilenced");
+            }
+        } else {
+            if (hasMuteReason()) {
+                sendTl("voiceSilencedReasonTime", dateDiff, getMuteReason());
+            } else {
+                sendTl("voiceSilencedTime", dateDiff);
+            }
+        }
+    }
+
     @Override
     public long getLastActivityTime() {
         return this.lastActivity;

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandmsg.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandmsg.java
@@ -4,9 +4,7 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Console;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.messaging.IMessageRecipient;
-import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.FormatUtil;
-import net.ess3.api.TranslatableException;
 import org.bukkit.Server;
 
 import java.util.Collections;
@@ -27,13 +25,8 @@ public class Commandmsg extends EssentialsLoopCommand {
         final boolean canWildcard = sender.isAuthorized("essentials.msg.multiple");
         if (sender.isPlayer()) {
             final User user = ess.getUser(sender.getPlayer());
-            if (user.isMuted()) {
-                final String dateDiff = user.getMuteTimeout() > 0 ? DateUtil.formatDateDiff(user.getMuteTimeout()) : null;
-                if (dateDiff == null) {
-                    throw new TranslatableException(user.hasMuteReason() ? "voiceSilencedReason" : "voiceSilenced", user.getMuteReason());
-                }
-                throw new TranslatableException(user.hasMuteReason() ? "voiceSilencedReasonTime" : "voiceSilencedTime", dateDiff, user.getMuteReason());
-            }
+            // Muted players are handled in SimpleMessageRecipient#sendMessage so that the message can still
+            // be shown to social spies before being dropped instead of being delivered to the recipient.
             message = FormatUtil.formatMessage(user, "essentials.msg", message);
         } else {
             message = FormatUtil.replaceFormat(message);

--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandr.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandr.java
@@ -4,7 +4,6 @@ import com.earth2me.essentials.CommandSource;
 import com.earth2me.essentials.Console;
 import com.earth2me.essentials.User;
 import com.earth2me.essentials.messaging.IMessageRecipient;
-import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.FormatUtil;
 import net.ess3.api.TranslatableException;
 import org.bukkit.Server;
@@ -24,14 +23,8 @@ public class Commandr extends EssentialsCommand {
         final IMessageRecipient messageSender;
         if (sender.isPlayer()) {
             final User user = ess.getUser(sender.getPlayer());
-            if (user.isMuted()) {
-                final String dateDiff = user.getMuteTimeout() > 0 ? DateUtil.formatDateDiff(user.getMuteTimeout()) : null;
-                if (dateDiff == null) {
-                    throw new TranslatableException(user.hasMuteReason() ? "voiceSilencedReason" : "voiceSilenced", user.getMuteReason());
-                }
-                throw new TranslatableException(user.hasMuteReason() ? "voiceSilencedReasonTime" : "voiceSilencedTime", dateDiff, user.getMuteReason());
-            }
-
+            // Muted players are handled in SimpleMessageRecipient#sendMessage so that the message can still
+            // be shown to social spies before being dropped instead of being delivered to the recipient.
             message = FormatUtil.formatMessage(user, "essentials.msg", message);
             messageSender = user;
         } else {

--- a/Essentials/src/main/java/com/earth2me/essentials/messaging/IMessageRecipient.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/messaging/IMessageRecipient.java
@@ -122,7 +122,12 @@ public interface IMessageRecipient extends MailSender {
         /**
          * States that the message was <b>NOT</b> received as a result of the message pre-send event being cancelled.
          */
-        EVENT_CANCELLED;
+        EVENT_CANCELLED,
+        /**
+         * States that the message was <b>NOT</b> delivered as a result of the sender being muted. The message may
+         * still have been shown to social spies.
+         */
+        SENDER_MUTED;
 
         /**
          * Returns whether this response is a success. In other words equal to {@link #SUCCESS} or {@link #SUCCESS_BUT_AFK}

--- a/Essentials/src/main/java/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
@@ -91,6 +91,18 @@ public class SimpleMessageRecipient implements IMessageRecipient {
         }
 
         message = preSendEvent.getMessage();
+
+        final User senderUser = getUser(this);
+        // A muted player must not have their message delivered to the recipient. However, social spies
+        // may still observe the attempted message (see the socialspy-listen-muted-players setting).
+        // Note: PrivateMessageSentEvent is intentionally not fired here so the message is not relayed
+        // elsewhere (e.g. to Discord) as though it had actually been delivered.
+        if (senderUser != null && senderUser.isMuted()) {
+            sendSocialSpy(recipient, message, true);
+            senderUser.notifyMuted();
+            return MessageResponse.SENDER_MUTED;
+        }
+
         final MessageResponse messageResponse = recipient.onReceiveMessage(this.parent, message);
         switch (messageResponse) {
             case UNREACHABLE:
@@ -114,29 +126,7 @@ public class SimpleMessageRecipient implements IMessageRecipient {
                 sendTl("msgFormat", AdventureUtil.parsed(tlSender("meSender")), recipient.getDisplayName(), message);
 
                 // Better Social Spy
-                if (ess.getSettings().isSocialSpyMessages()) {
-                    final User senderUser = getUser(this);
-                    final User recipientUser = getUser(recipient);
-                    if (senderUser != null // not null if player.
-                            // Dont spy on chats involving socialspy exempt players
-                            && !senderUser.isAuthorized("essentials.chat.spy.exempt")
-                            && recipientUser != null && !recipientUser.isAuthorized("essentials.chat.spy.exempt")) {
-                        final String senderName = ess.getSettings().isSocialSpyDisplayNames() ? getDisplayName() : getName();
-                        final String recipientName = ess.getSettings().isSocialSpyDisplayNames() ? recipient.getDisplayName() : recipient.getName();
-                        for (final User onlineUser : ess.getOnlineUsers()) {
-                            if (onlineUser.isSocialSpyEnabled()
-                                    // Don't send socialspy messages to message sender/receiver to prevent spam
-                                    && !onlineUser.equals(senderUser)
-                                    && !onlineUser.equals(recipient)) {
-                                if (senderUser.isMuted() && ess.getSettings().getSocialSpyListenMutedPlayers()) {
-                                    onlineUser.sendComponent(ess.getAdventureFacet().deserializeMiniMessage(tlSender("socialSpyMutedPrefix") + tlLiteral("socialSpyMsgFormat", senderName, recipientName, message)));
-                                } else {
-                                    onlineUser.sendComponent(ess.getAdventureFacet().deserializeMiniMessage(tlLiteral("socialSpyPrefix") + tlLiteral("socialSpyMsgFormat", senderName, recipientName, message)));
-                                }
-                            }
-                        }
-                    }
-                }
+                sendSocialSpy(recipient, message, false);
                 break;
         }
         // If the message was a success, set this sender's reply-recipient to the current recipient.
@@ -148,6 +138,45 @@ public class SimpleMessageRecipient implements IMessageRecipient {
         ess.getServer().getPluginManager().callEvent(sentEvent);
 
         return messageResponse;
+    }
+
+    /**
+     * Shows a private message to all online social spies, unless either party is exempt from being spied on.
+     *
+     * @param recipient the recipient of the private message
+     * @param message   the message that was sent
+     * @param muted     whether the sender is muted; muted messages are only shown when
+     *                  {@code socialspy-listen-muted-players} is enabled and use a distinct prefix
+     */
+    private void sendSocialSpy(final IMessageRecipient recipient, final String message, final boolean muted) {
+        if (!ess.getSettings().isSocialSpyMessages()) {
+            return;
+        }
+        if (muted && !ess.getSettings().getSocialSpyListenMutedPlayers()) {
+            return;
+        }
+
+        final User senderUser = getUser(this);
+        final User recipientUser = getUser(recipient);
+        // Don't spy on chats involving socialspy exempt players.
+        if (senderUser == null // not null if player.
+                || senderUser.isAuthorized("essentials.chat.spy.exempt")
+                || recipientUser == null
+                || recipientUser.isAuthorized("essentials.chat.spy.exempt")) {
+            return;
+        }
+
+        final String senderName = ess.getSettings().isSocialSpyDisplayNames() ? getDisplayName() : getName();
+        final String recipientName = ess.getSettings().isSocialSpyDisplayNames() ? recipient.getDisplayName() : recipient.getName();
+        final String prefix = muted ? tlSender("socialSpyMutedPrefix") : tlLiteral("socialSpyPrefix");
+        for (final User onlineUser : ess.getOnlineUsers()) {
+            if (onlineUser.isSocialSpyEnabled()
+                    // Don't send socialspy messages to message sender/receiver to prevent spam
+                    && !onlineUser.equals(senderUser)
+                    && !onlineUser.equals(recipient)) {
+                onlineUser.sendComponent(ess.getAdventureFacet().deserializeMiniMessage(prefix + tlLiteral("socialSpyMsgFormat", senderName, recipientName, message)));
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Muted players' /msg and /r attempts threw a "silenced" error before reaching SimpleMessageRecipient, so the socialspy-listen-muted-players option never applied to private messages.

Move mute handling into SimpleMessageRecipient#sendMessage: a muted sender's message is dropped instead of delivered, the sender is notified they're silenced, and social spies still see it with the muted prefix when socialspy-listen-muted-players is enabled. PrivateMessageSentEvent is not fired in this case so undelivered messages aren't relayed elsewhere (e.g. Discord).

Also adds User#notifyMuted() to dedupe the silenced-message logic shared with EssentialsPlayerListener.

Fixes #6341