### PR TITLE
Fix newbie messages not firing for new players on modern Paper

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -425,7 +425,8 @@ public class EssentialsPlayerListener implements Listener {
 
         // A null last account name means EssentialsX has never recorded this player before, i.e. it's their first join.
         // We rely on EssentialsX's own user data here rather than Player#hasPlayedBefore(), which is unreliable on modern
-        // server platforms that persist player data during the login/configuration phase (see GH-6466, GH-6464).
+        // server platforms that persist player data during the login/configuration phase.
+        // See https://github.com/EssentialsX/Essentials/issues/6466, https://github.com/EssentialsX/Essentials/issues/6464
         final boolean firstJoin = lastAccountName == null;
 
         // If the Minecraft account name changed, reset the nickname so the old one doesn't persist

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -423,6 +423,11 @@ public class EssentialsPlayerListener implements Listener {
 
         final boolean newUsername = lastAccountName != null && !lastAccountName.equals(user.getBase().getName());
 
+        // A null last account name means EssentialsX has never recorded this player before, i.e. it's their first join.
+        // We rely on EssentialsX's own user data here rather than Player#hasPlayedBefore(), which is unreliable on modern
+        // server platforms that persist player data during the login/configuration phase (see GH-6466, GH-6464).
+        final boolean firstJoin = lastAccountName == null;
+
         // If the Minecraft account name changed, reset the nickname so the old one doesn't persist
         if (ess.getSettings().isResetNickOnNameChange() && newUsername && user.getNickname() != null) {
             user.setNickname(null);
@@ -478,7 +483,7 @@ public class EssentialsPlayerListener implements Listener {
             joinMessageConsumer.accept(effectiveMessage);
         }
 
-        ess.runTaskAsynchronously(() -> ess.getServer().getPluginManager().callEvent(new AsyncUserDataLoadEvent(user, effectiveMessage)));
+        ess.runTaskAsynchronously(() -> ess.getServer().getPluginManager().callEvent(new AsyncUserDataLoadEvent(user, effectiveMessage, firstJoin)));
 
         if (ess.getSettings().getMotdDelay() >= 0) {
             final int motdDelay = ess.getSettings().getMotdDelay() / 50;

--- a/Essentials/src/main/java/net/essentialsx/api/v2/events/AsyncUserDataLoadEvent.java
+++ b/Essentials/src/main/java/net/essentialsx/api/v2/events/AsyncUserDataLoadEvent.java
@@ -13,11 +13,13 @@ public class AsyncUserDataLoadEvent extends Event {
 
     private final IUser user;
     private final String joinMessage;
+    private final boolean firstJoin;
 
-    public AsyncUserDataLoadEvent(IUser user, String joinMessage) {
+    public AsyncUserDataLoadEvent(IUser user, String joinMessage, boolean firstJoin) {
         super(true);
         this.user = user;
         this.joinMessage = joinMessage;
+        this.firstJoin = firstJoin;
     }
 
     /**
@@ -32,6 +34,18 @@ public class AsyncUserDataLoadEvent extends Event {
      */
     public String getJoinMessage() {
         return joinMessage;
+    }
+
+    /**
+     * Whether this is the first time EssentialsX has seen this player join.
+     * <p>
+     * This is determined from EssentialsX's own user data rather than {@link org.bukkit.OfflinePlayer#hasPlayedBefore()},
+     * which is unreliable on modern server platforms that persist player data during the login/configuration phase.
+     *
+     * @return {@code true} if this is the player's first recorded join, otherwise {@code false}.
+     */
+    public boolean isFirstJoin() {
+        return firstJoin;
     }
 
     @Override

--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/listeners/BukkitListener.java
@@ -101,7 +101,7 @@ public class BukkitListener implements Listener {
         // Delay join to let nickname load
         if (!isSilentJoinQuit(event.getUser(), "join") && !isVanishHide(event.getUser())) {
             // Check if this is the first time the player has joined
-            if (!event.getUser().getBase().hasPlayedBefore()) {
+            if (event.isFirstJoin()) {
                 sendJoinQuitMessage(event.getUser().getBase(), event.getJoinMessage(), MessageType.DefaultTypes.FIRST_JOIN);
             } else {
                 sendJoinQuitMessage(event.getUser().getBase(), event.getJoinMessage(), MessageType.DefaultTypes.JOIN);

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawn.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawn.java
@@ -3,11 +3,11 @@ package com.earth2me.essentials.spawn;
 import com.earth2me.essentials.EssentialsLogger;
 import com.earth2me.essentials.metrics.MetricsWrapper;
 import net.ess3.api.IEssentials;
+import net.essentialsx.api.v2.events.AsyncUserDataLoadEvent;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.EventPriority;
-import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -48,8 +48,10 @@ public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn {
 
         final EventPriority joinPriority = ess.getSettings().getSpawnJoinPriority();
         if (joinPriority != null) {
-            pluginManager.registerEvent(PlayerJoinEvent.class, playerListener, joinPriority, (ll, event) ->
-                ((EssentialsSpawnPlayerListener) ll).onPlayerJoin((PlayerJoinEvent) event), this);
+            // Listen on AsyncUserDataLoadEvent (fired after the core join flow) so we can reliably tell whether this is
+            // a player's first join, instead of using the unreliable Player#hasPlayedBefore() (see GH-6466).
+            pluginManager.registerEvent(AsyncUserDataLoadEvent.class, playerListener, joinPriority, (ll, event) ->
+                ((EssentialsSpawnPlayerListener) ll).onUserDataLoad((AsyncUserDataLoadEvent) event), this);
         }
 
         if (metrics == null) {

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawn.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawn.java
@@ -49,7 +49,8 @@ public class EssentialsSpawn extends JavaPlugin implements IEssentialsSpawn {
         final EventPriority joinPriority = ess.getSettings().getSpawnJoinPriority();
         if (joinPriority != null) {
             // Listen on AsyncUserDataLoadEvent (fired after the core join flow) so we can reliably tell whether this is
-            // a player's first join, instead of using the unreliable Player#hasPlayedBefore() (see GH-6466).
+            // a player's first join, instead of using Player#hasPlayedBefore() which doesn't since data is persisted during the configuration phase.
+            // See https://github.com/EssentialsX/Essentials/issues/6466
             pluginManager.registerEvent(AsyncUserDataLoadEvent.class, playerListener, joinPriority, (ll, event) ->
                 ((EssentialsSpawnPlayerListener) ll).onUserDataLoad((AsyncUserDataLoadEvent) event), this);
         }

--- a/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
+++ b/EssentialsSpawn/src/main/java/com/earth2me/essentials/spawn/EssentialsSpawnPlayerListener.java
@@ -7,10 +7,10 @@ import com.earth2me.essentials.textreader.IText;
 import com.earth2me.essentials.textreader.KeywordReplacer;
 import com.earth2me.essentials.utils.VersionUtil;
 import net.ess3.api.IEssentials;
+import net.essentialsx.api.v2.events.AsyncUserDataLoadEvent;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -76,12 +76,14 @@ class EssentialsSpawnPlayerListener implements Listener {
         }
     }
 
-    void onPlayerJoin(final PlayerJoinEvent event) {
-        ess.runTaskAsynchronously(() -> delayedJoin(event.getPlayer()));
+    void onUserDataLoad(final AsyncUserDataLoadEvent event) {
+        // AsyncUserDataLoadEvent is already fired asynchronously, after EssentialsX has determined whether this is a
+        // first join, so we can jump straight into the join handling without racing the core join flow.
+        delayedJoin(event.getUser().getBase(), event.isFirstJoin());
     }
 
-    private void delayedJoin(final Player player) {
-        if (player.hasPlayedBefore()) {
+    private void delayedJoin(final Player player, final boolean firstJoin) {
+        if (!firstJoin) {
             logger.log(Level.FINE, "Old player join");
             final List<String> spawnOnJoinGroups = ess.getSettings().getSpawnOnJoinGroups();
             if (!spawnOnJoinGroups.isEmpty()) {


### PR DESCRIPTION
Player#hasPlayedBefore() is unreliable since the switch to configuration-phase events, as player data is persisted during login, so genuine first-joiners were treated as returning players. This broke EssentialsSpawn newbie spawn/kit/announce-format (#6466).

Add a firstJoin flag to AsyncUserDataLoadEvent, derived from EssentialsX's own user data, and use it in EssentialsSpawn and EssentialsDiscord instead of hasPlayedBefore().

Fixes #6466