### PR TITLE
Implemented Essentials config-option vanish-hide-messages

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsEntityListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsEntityListener.java
@@ -171,9 +171,13 @@ public class EssentialsEntityListener implements Listener {
             user.setLastLocation();
             user.sendTl("backAfterDeath");
         }
-        if (!ess.getSettings().areDeathMessagesEnabled()) {
+        if (!ess.getSettings().areDeathMessagesEnabled() || isVanishHide(user)) {
             event.setDeathMessage("");
         }
+    }
+
+    private boolean isVanishHide(final User user) {
+        return ess.getSettings().isVanishHideMessages() && user.isHidden();
     }
 
     @EventHandler(priority = EventPriority.LOW)

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -294,7 +294,7 @@ public class EssentialsPlayerListener implements Listener {
             ess.getScheduler().cancelTask(pendingId);
         }
 
-        if (hideJoinQuitMessages() || ess.getSettings().allowSilentJoinQuit() && user.isAuthorized("essentials.silentquit")) {
+        if (hideJoinQuitMessages() || ess.getSettings().allowSilentJoinQuit() && user.isAuthorized("essentials.silentquit") || isVanishHide(user)) {
             event.setQuitMessage(null);
         } else if (ess.getSettings().isCustomQuitMessage() && event.getQuitMessage() != null) {
             final Player player = event.getPlayer();
@@ -339,6 +339,10 @@ public class EssentialsPlayerListener implements Listener {
         user.stopTransaction();
 
         user.dispose();
+    }
+
+    private boolean isVanishHide(final User user) {
+        return ess.getSettings().isVanishHideMessages() && (user.isHidden() || user.isLeavingHidden());
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -229,6 +229,8 @@ public interface ISettings extends IConf {
 
     boolean sleepIgnoresVanishedPlayers();
 
+    boolean isVanishHideMessages();
+
     boolean isAfkListName();
 
     String getAfkListName();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -1350,6 +1350,11 @@ public class Settings implements net.ess3.api.ISettings {
         return config.getBoolean("sleep-ignores-vanished-player", true);
     }
 
+    @Override
+    public boolean isVanishHideMessages() {
+        return config.getBoolean("vanish-hide-messages", false);
+    }
+
     public String _getAfkListName() {
         return FormatUtil.replaceFormat(config.getString("afk-list-name", "none"));
     }

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -544,6 +544,9 @@ sleep-ignores-afk-players: true
 # Players with the permission 'essentials.sleepingignored' will always be ignored.
 sleep-ignores-vanished-player: true
 
+# Whether quit and death messages from vanished players should be hidden from ingame-chat.
+vanish-hide-messages: false
+
 # Change the player's /list name when they are AFK. This is none by default, which specifies that Essentials
 # should not interfere with the AFK player's /list name.
 # You may use color codes, {USERNAME} for the player's name, or {PLAYER} for the player's display name.


### PR DESCRIPTION
<!--

EssentialsX feature submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a new feature, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original feature 
      request. If there isn't an existing feature request, we strongly
      recommend opening a new feature request BEFORE opening your PR to
      implement it, as this allows us to review whether we're likely to accept
      your feature in advance, and also allows us to discuss possible
      implementations for the feature. If there is no associated feature
      request, your PR may be delayed or rejected without warning.
      
      You can open a new feature request by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose

2.  If you are fixing a performance issue, please use the "Bug fix" PR template
      instead. The "bug fix" template is better suited to performance issues.

3.  Include a demonstration.
      If you are adding commands, please provide screenshots and/or a video
      demonstration of the feature. Similarly, if you are adding a new API,
      please include a link to example code that takes advantage of your
      proposed API. This will aid us in reviewing PRs and speed up the process
      significantly.

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR implements
    features from multiple issues, you should repeat the phrase "closes #nnnn"
    for each issue. 
-->

This PR closes https://github.com/EssentialsX/Essentials/issues/6577. 

### Details

**Proposed feature:**  

If this config-option is enabled, death- and quit-messages are not sent to chat while in vanish-mode. The default value is set to `false`, as to not alter any existing functionality by remaining opt-in rather than opt-out.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Fedora Linux 42 (Workstation Edition)

<!-- Type the JDK version (from java -version) you have used below. -->
Java version:   Java 25

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [x] CraftBukkit/Spigot/Paper 1.12.2
- [x] CraftBukkit 1.8.8


**Demonstration:**  
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

It's a bit of a challenge to demonstrate the absence of these messages with mere pictures, so for now, I hope that it's okay if I omit the visual demonstration.
