### PR TITLE
Fix oversized kit leftovers being dropped unsplit

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/Kit.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Kit.java
@@ -266,12 +266,12 @@ public class Kit {
 
             for (final ItemStack itemStack : leftover.values()) {
                 int spillAmount = itemStack.getAmount();
+                final int itemMaxStackSize = itemStack.getMaxStackSize();
                 while (spillAmount > 0) {
-                    if (maxStackSize != 0) {
-                        itemStack.setAmount(Math.min(spillAmount, itemStack.getMaxStackSize()));
-                    }
-                    user.getWorld().dropItemNaturally(user.getLocation(), itemStack);
-                    spillAmount -= itemStack.getAmount();
+                    final ItemStack spillStack = itemStack.clone();
+                    spillStack.setAmount(Math.min(spillAmount, itemMaxStackSize));
+                    user.getWorld().dropItemNaturally(user.getLocation(), spillStack);
+                    spillAmount -= spillStack.getAmount();
                 }
                 spew = true;
             }


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes #6579. 

### Details

**Proposed fix:**    
<!-- Type a description of your proposed fix below this line. -->

Split kit leftovers before dropping them into the world.

When `drop-items-if-full` is enabled, leftover kit items may already be normalized into oversized internal `ItemStack`s. The fix clones each leftover stack and drops it in chunks no larger than the item's normal max stack size instead of passing the original leftover stack directly to `dropItemNaturally`.

This preserves the existing inventory insertion behavior, but prevents oversized leftover stacks such as `OBSIDIAN x128` from becoming item entities.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Linux

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: 25.0.3

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] ~~Most recent Paper version (1.21.4, git-Paper-BUILD)~~
- [ ] ~~CraftBukkit/Spigot/Paper 1.12.2~~
- [ ] ~~CraftBukkit 1.8.8~~
- [x] CraftBukkit/Spigot/Paper 1.21.4


**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

