### PR TITLE
reliably restore flight on safelogin to prevent airborne players fall…

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -522,6 +522,15 @@ public class EssentialsPlayerListener implements Listener {
             if (!inWater && LocationUtil.shouldFly(ess, user.getLocation())) {
                 user.getBase().setAllowFlight(true);
                 user.getBase().setFlying(true);
+                // The client sends a flight-abilities sync shortly after joining, which resets the flying state
+                // and drops the player out of the air. Re-apply the flight state a tick later so it sticks and the
+                // player keeps flying instead of falling (see the equivalent world-change handling below).
+                ess.scheduleSyncDelayedTask(() -> {
+                    if (user.getBase().isOnline()) {
+                        user.getBase().setAllowFlight(true);
+                        user.getBase().setFlying(true);
+                    }
+                }, 1);
                 if (!restoreFly && ess.getSettings().isSendFlyEnableOnJoin()) {
                     user.sendTl("flyMode", CommonPlaceholders.enableDisable(user.getSource(), true), user.getDisplayName());
                 }


### PR DESCRIPTION
This PR fixes #6587 

### Details

**Proposed fix:**
When a player with `essentials.fly.safelogin` rejoins while airborne, EssentialsX
restores their flight synchronously inside `PlayerJoinEvent`. On some server
versions the client sends a flight-abilities sync shortly after join that resets
the flying state, dropping the player out of the air despite the permission.

This PR re-applies the flight state one tick later via a delayed task (mirroring
the existing world-change flight handling in the same class), so it sticks after
the client settles and the player keeps flying instead of falling. The change is
scoped entirely within the existing `essentials.fly.safelogin` block, so players
without the permission are unaffected.
