### PR TITLE
Prevent invalid command casing from starting cooldowns

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -776,7 +776,8 @@ public class EssentialsPlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerCommandPreprocess(final PlayerCommandPreprocessEvent event) {
-        final String cmd = event.getMessage().split(" ")[0].replace("/", "").toLowerCase(Locale.ENGLISH);
+        final String commandLabel = event.getMessage().split(" ")[0].replace("/", "");
+        final String cmd = commandLabel.toLowerCase(Locale.ENGLISH);
         final int argStartIndex = event.getMessage().indexOf(" ");
         final String args = argStartIndex == -1 ? "" // No arguments present
                 : event.getMessage().substring(argStartIndex); // arguments start at argStartIndex; substring from there.
@@ -784,7 +785,7 @@ public class EssentialsPlayerListener implements Listener {
         // If the plugin command does not exist, check if it is an alias from commands.yml
         if (ess.getServer().getPluginCommand(cmd) == null) {
             final Command knownCommand = ess.provider(KnownCommandsProvider.class).getKnownCommands().get(cmd);
-            if (knownCommand instanceof FormattedCommandAlias) {
+            if (isCommandRegistered(commandLabel) && knownCommand instanceof FormattedCommandAlias) {
                 final FormattedCommandAlias command = (FormattedCommandAlias) knownCommand;
                 for (String fullCommand : ess.provider(FormattedCommandAliasProvider.class).createCommands(command, event.getPlayer(), args.split(" "))) {
                     handlePlayerCommandPreprocess(event, fullCommand);
@@ -794,12 +795,13 @@ public class EssentialsPlayerListener implements Listener {
         }
 
         // Handle the command given from the event.
-        handlePlayerCommandPreprocess(event, cmd + args);
+        handlePlayerCommandPreprocess(event, commandLabel + args);
     }
 
     public void handlePlayerCommandPreprocess(final PlayerCommandPreprocessEvent event, final String effectiveCommand) {
         final Player player = event.getPlayer();
-        final String cmd = effectiveCommand.split(" ")[0].replace("/", "").toLowerCase(Locale.ENGLISH);
+        final String commandLabel = effectiveCommand.split(" ")[0].replace("/", "");
+        final String cmd = commandLabel.toLowerCase(Locale.ENGLISH);
         final PluginCommand pluginCommand = ess.getServer().getPluginCommand(cmd);
 
         if (ess.getSettings().getSocialSpyCommands().contains(cmd) || ess.getSettings().getSocialSpyCommands().contains("*")) {
@@ -862,7 +864,8 @@ public class EssentialsPlayerListener implements Listener {
             user.updateActivityOnInteract(broadcast);
         }
 
-        if (ess.getSettings().isCommandCooldownsEnabled()
+        if (isCommandRegistered(commandLabel)
+            && ess.getSettings().isCommandCooldownsEnabled()
             && !user.isAuthorized("essentials.commandcooldowns.bypass")
             && (pluginCommand == null || !user.isAuthorized("essentials.commandcooldowns.bypass." + pluginCommand.getName()))) {
             final int argStartIndex = effectiveCommand.indexOf(" ");
@@ -900,6 +903,12 @@ public class EssentialsPlayerListener implements Listener {
                 }
             }
         }
+    }
+
+    private boolean isCommandRegistered(final String commandLabel) {
+        final Map<String, Command> knownCommands = ess.provider(KnownCommandsProvider.class).getKnownCommands();
+        return knownCommands.containsKey(commandLabel)
+            || (VersionUtil.PRE_FLATTENING && knownCommands.containsKey(commandLabel.toLowerCase(Locale.ENGLISH)));
     }
 
     @EventHandler(priority = EventPriority.NORMAL)

--- a/Essentials/src/test/java/com/earth2me/essentials/EssentialsPlayerListenerTest.java
+++ b/Essentials/src/test/java/com/earth2me/essentials/EssentialsPlayerListenerTest.java
@@ -1,0 +1,82 @@
+package com.earth2me.essentials;
+
+import net.ess3.api.IEssentials;
+import net.ess3.provider.KnownCommandsProvider;
+import org.bukkit.Server;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Date;
+import java.util.regex.Pattern;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EssentialsPlayerListenerTest {
+    private IEssentials ess;
+    private ISettings settings;
+    private User user;
+    private Player player;
+    private Pattern cooldownPattern;
+    private EssentialsPlayerListener listener;
+
+    @BeforeEach
+    public void setUp() {
+        player = MockBukkit.mock().addPlayer();
+        ess = mock(IEssentials.class);
+        settings = mock(ISettings.class);
+        user = mock(User.class);
+        final Server commandServer = mock(Server.class);
+        final PluginCommand pluginCommand = mock(PluginCommand.class);
+        final KnownCommandsProvider knownCommandsProvider = mock(KnownCommandsProvider.class);
+        cooldownPattern = Pattern.compile("feed");
+
+        when(ess.getServer()).thenReturn(commandServer);
+        when(ess.getSettings()).thenReturn(settings);
+        when(ess.getUser(player)).thenReturn(user);
+        when(ess.provider(KnownCommandsProvider.class)).thenReturn(knownCommandsProvider);
+        when(knownCommandsProvider.getKnownCommands()).thenReturn(Collections.singletonMap("efeed", pluginCommand));
+        when(commandServer.getPluginCommand("efeed")).thenReturn(pluginCommand);
+        when(pluginCommand.getName()).thenReturn("feed");
+        when(settings.getSocialSpyCommands()).thenReturn(Collections.emptySet());
+        when(settings.getMuteCommands()).thenReturn(Collections.emptySet());
+        when(settings.isCommandCooldownsEnabled()).thenReturn(true);
+        when(settings.getCommandCooldownEntry("feed")).thenReturn(new AbstractMap.SimpleImmutableEntry<>(cooldownPattern, 60_000L));
+        when(user.getCommandCooldowns()).thenReturn(Collections.emptyMap());
+        listener = new EssentialsPlayerListener(ess);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    public void testUnregisteredCaseVariantDoesNotStartCooldown() {
+        listener.onPlayerCommandPreprocess(new PlayerCommandPreprocessEvent(player, "/EFEED"));
+
+        verify(settings, never()).getCommandCooldownEntry(anyString());
+        verify(user, never()).addCommandCooldown(any(Pattern.class), any(Date.class), anyBoolean());
+    }
+
+    @Test
+    public void testRegisteredAliasStartsCanonicalCommandCooldown() {
+        listener.onPlayerCommandPreprocess(new PlayerCommandPreprocessEvent(player, "/efeed"));
+
+        verify(settings).getCommandCooldownEntry("feed");
+        verify(user).addCommandCooldown(eq(cooldownPattern), any(Date.class), eq(false));
+    }
+}


### PR DESCRIPTION
### Information

This PR fixes #5915.

### Details

**Proposed fix:**

Preserve the command label as entered and verify that it is registered before expanding formatted aliases or applying command cooldowns. Valid lowercase aliases continue to resolve to their canonical command for cooldown matching, while invalid case variants no longer start a cooldown. The existing case-insensitive behavior is retained for pre-flattening server versions.

**Environments tested:**

OS: Windows 11

Java version: 21.0.10

- [ ] Most recent Paper version (XX.YY.Z, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8

**Demonstration:**

Added regression tests confirming that `/EFEED` does not start a cooldown when that case variant is not registered and `/efeed` still applies the canonical `feed` cooldown.

Validation:

- `.\gradlew.bat :EssentialsX:test --tests com.earth2me.essentials.EssentialsPlayerListenerTest --console=plain`
- `.\gradlew.bat :EssentialsX:checkstyleMain :EssentialsX:checkstyleTest --console=plain`

Both commands completed successfully. The focused suite passed 2 tests with no failures, errors, or skipped tests.
