### PR TITLE
Fix: `/back` onto nether roof exploit when destination is unsafe.

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/ISettings.java
@@ -136,6 +136,8 @@ public interface ISettings extends IConf {
 
     boolean isAlwaysTeleportSafety();
 
+    boolean isConsiderWorldHeightForTeleportSafety();
+
     boolean isTeleportPassengerDismount();
 
     boolean isForcePassengerTeleport();

--- a/Essentials/src/main/java/com/earth2me/essentials/Settings.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/Settings.java
@@ -298,6 +298,11 @@ public class Settings implements net.ess3.api.ISettings {
     }
 
     @Override
+    public boolean isConsiderWorldHeightForTeleportSafety() {
+        return config.getBoolean("consider-world-height-for-teleport-safety", false);
+    }
+
+    @Override
     public boolean isTeleportPassengerDismount() {
         return config.getBoolean("teleport-passenger-dismount", true);
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
@@ -125,13 +125,6 @@ public final class LocationUtil {
         return x < x1 || x > x2 || z < z1 || z > z2;
     }
 
-    public static boolean isAboveNetherRoof(final World world, final int x, final int y, final int z) {
-        if (world.getEnvironment() != World.Environment.NETHER) {
-            return false;
-        }
-        return y >= world.getHighestBlockYAt(x, z);
-    }
-
     public static int getXInsideWorldBorder(final World world, final int x) {
         final Location center = world.getWorldBorder().getCenter();
         final int radius = (int) world.getWorldBorder().getSize() / 2;
@@ -172,6 +165,10 @@ public final class LocationUtil {
 
     public static boolean isBlockUnsafe(IEssentials ess, final World world, final int x, final int y, final int z) {
         return isBlockDamaging(world, x, y, z) || isBlockAboveAir(ess, world, x, y, z);
+    }
+
+    private static boolean isBlockUnsafe(IEssentials ess, final World world, final int x, final int y, final int z, final int maxY) {
+        return y >= maxY || isBlockUnsafe(ess, world, x, y, z);
     }
 
     public static boolean isBlockDamaging(final World world, final int x, final int y, final int z) {
@@ -249,12 +246,12 @@ public final class LocationUtil {
                 break;
             }
         }
-        if (isBlockUnsafe(ess, world, x, y, z)) {
+        if (isBlockUnsafe(ess, world, x, y, z, worldMaxY)) {
             x = Math.round(loc.getX()) == origX ? x - 1 : x + 1;
             z = Math.round(loc.getZ()) == origZ ? z - 1 : z + 1;
         }
         int i = 0;
-        while (isBlockUnsafe(ess, world, x, y, z)) {
+        while (isBlockUnsafe(ess, world, x, y, z, worldMaxY)) {
             i++;
             if (i >= VOLUME.length) {
                 x = origX;
@@ -266,14 +263,14 @@ public final class LocationUtil {
             y = NumberUtil.constrainToRange(origY + VOLUME[i].y, worldMinY, worldMaxY);
             z = origZ + VOLUME[i].z;
         }
-        while (isBlockUnsafe(ess, world, x, y, z)) {
+        while (isBlockUnsafe(ess, world, x, y, z, worldMaxY)) {
             y += 1;
             if (y >= worldMaxY) {
                 x += 1;
                 break;
             }
         }
-        while (isBlockUnsafe(ess, world, x, y, z)) {
+        while (isBlockUnsafe(ess, world, x, y, z, worldMaxY)) {
             y -= 1;
             if (y <= worldMinY + 1) {
                 x += 1;
@@ -283,9 +280,6 @@ public final class LocationUtil {
                     throw new TranslatableException("holeInFloor");
                 }
             }
-        }
-        if (isAboveNetherRoof(world, x, y, z)) {
-            y = world.getHighestBlockYAt(x, z) - 1;
         }
         return new Location(world, x + 0.5, y, z + 0.5, loc.getYaw(), loc.getPitch());
     }

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
@@ -228,7 +228,9 @@ public final class LocationUtil {
         final World world = loc.getWorld();
         final int worldMinY = worldInfoProvider.getMinHeight(world);
         final int worldLogicalY = worldInfoProvider.getLogicalHeight(world);
-        final int worldMaxY = loc.getBlockY() < worldLogicalY ? worldLogicalY : worldInfoProvider.getMaxHeight(world);
+        final int worldMaxY = ess.getSettings().isConsiderWorldHeightForTeleportSafety() && loc.getBlockY() < worldLogicalY
+                ? worldLogicalY
+                : worldInfoProvider.getMaxHeight(world);
         int x = loc.getBlockX();
         int y = (int) Math.round(loc.getY());
         int z = loc.getBlockZ();

--- a/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/LocationUtil.java
@@ -125,6 +125,13 @@ public final class LocationUtil {
         return x < x1 || x > x2 || z < z1 || z > z2;
     }
 
+    public static boolean isAboveNetherRoof(final World world, final int x, final int y, final int z) {
+        if (world.getEnvironment() != World.Environment.NETHER) {
+            return false;
+        }
+        return y >= world.getHighestBlockYAt(x, z);
+    }
+
     public static int getXInsideWorldBorder(final World world, final int x) {
         final Location center = world.getWorldBorder().getCenter();
         final int radius = (int) world.getWorldBorder().getSize() / 2;
@@ -276,6 +283,9 @@ public final class LocationUtil {
                     throw new TranslatableException("holeInFloor");
                 }
             }
+        }
+        if (isAboveNetherRoof(world, x, y, z)) {
+            y = world.getHighestBlockYAt(x, z) - 1;
         }
         return new Location(world, x + 0.5, y, z + 0.5, loc.getYaw(), loc.getPitch());
     }

--- a/Essentials/src/main/resources/config.yml
+++ b/Essentials/src/main/resources/config.yml
@@ -99,6 +99,10 @@ force-disable-teleport-safety: false
 # safe location. If you'd like players to be teleported to a safe location all of the time, set this option to true.
 force-safe-teleport-location: false
 
+# When teleporting to an unsafe location, should Essentials consider the world's logical height when finding a safe destination?
+# This prevents safety checks from moving players above the Nether roof unless the requested destination is already above it.
+consider-world-height-for-teleport-safety: true
+
 # Consider water blocks as "safe", therefore allowing players to teleport
 # using commands such as /home or /spawn to a location that is occupied by water blocks.
 is-water-safe: false

--- a/Essentials/src/test/java/com/earth2me/essentials/UtilTest.java
+++ b/Essentials/src/test/java/com/earth2me/essentials/UtilTest.java
@@ -3,6 +3,12 @@ package com.earth2me.essentials;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.LocationUtil;
 import com.earth2me.essentials.utils.VersionUtil;
+import net.ess3.provider.WorldInfoProvider;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.WorldBorder;
+import org.bukkit.block.Block;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,6 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class UtilTest {
 
@@ -64,6 +73,38 @@ public class UtilTest {
         assertEquals(testSet.size(), count);
         final int diameter = LocationUtil.RADIUS * 2 + 1;
         assertEquals(diameter * diameter * diameter, count);
+    }
+
+    @Test
+    public void testSafeLocationRespectsLogicalHeight() throws Exception {
+        final IEssentials essentials = mock(IEssentials.class);
+        final WorldInfoProvider worldInfoProvider = mock(WorldInfoProvider.class);
+        final World world = mock(World.class);
+        final WorldBorder worldBorder = mock(WorldBorder.class);
+        final Block solid = mock(Block.class);
+        final Block hollow = mock(Block.class);
+
+        when(essentials.provider(WorldInfoProvider.class)).thenReturn(worldInfoProvider);
+        when(worldInfoProvider.getMinHeight(world)).thenReturn(0);
+        when(worldInfoProvider.getLogicalHeight(world)).thenReturn(128);
+        when(worldInfoProvider.getMaxHeight(world)).thenReturn(256);
+        when(world.getWorldBorder()).thenReturn(worldBorder);
+        when(worldBorder.getCenter()).thenReturn(new Location(world, 0, 0, 0));
+        when(worldBorder.getSize()).thenReturn(60_000_000D);
+        when(solid.getType()).thenReturn(Material.BEDROCK);
+        when(hollow.getType()).thenReturn(Material.LIGHT);
+        when(world.getBlockAt(anyInt(), anyInt(), anyInt())).thenAnswer(invocation -> {
+            final int x = invocation.getArgument(0);
+            final int y = invocation.getArgument(1);
+            final int z = invocation.getArgument(2);
+            return y >= 128 || x == 1 && z == 0 && (y == 100 || y == 101) ? hollow : solid;
+        });
+
+        final Location safe = LocationUtil.getSafeDestination(essentials, new Location(world, 0, 64, 0));
+
+        assertEquals(1, safe.getBlockX());
+        assertEquals(100, safe.getBlockY());
+        assertFalse(LocationUtil.isBlockUnsafe(essentials, world, safe.getBlockX(), safe.getBlockY(), safe.getBlockZ()));
     }
 
     @Test

--- a/Essentials/src/test/java/com/earth2me/essentials/UtilTest.java
+++ b/Essentials/src/test/java/com/earth2me/essentials/UtilTest.java
@@ -77,7 +77,23 @@ public class UtilTest {
 
     @Test
     public void testSafeLocationRespectsLogicalHeight() throws Exception {
+        final Location result = getSafeDestinationWithLogicalHeightSetting(true);
+
+        assertEquals(1, result.getBlockX());
+        assertEquals(100, result.getBlockY());
+    }
+
+    @Test
+    public void testSafeLocationIgnoresLogicalHeightWhenDisabled() throws Exception {
+        final Location result = getSafeDestinationWithLogicalHeightSetting(false);
+
+        assertEquals(0, result.getBlockX());
+        assertEquals(128, result.getBlockY());
+    }
+
+    private Location getSafeDestinationWithLogicalHeightSetting(final boolean considerWorldHeight) throws Exception {
         final IEssentials essentials = mock(IEssentials.class);
+        final ISettings settings = mock(ISettings.class);
         final WorldInfoProvider worldInfoProvider = mock(WorldInfoProvider.class);
         final World world = mock(World.class);
         final WorldBorder worldBorder = mock(WorldBorder.class);
@@ -85,6 +101,8 @@ public class UtilTest {
         final Block hollow = mock(Block.class);
 
         when(essentials.provider(WorldInfoProvider.class)).thenReturn(worldInfoProvider);
+        when(essentials.getSettings()).thenReturn(settings);
+        when(settings.isConsiderWorldHeightForTeleportSafety()).thenReturn(considerWorldHeight);
         when(worldInfoProvider.getMinHeight(world)).thenReturn(0);
         when(worldInfoProvider.getLogicalHeight(world)).thenReturn(128);
         when(worldInfoProvider.getMaxHeight(world)).thenReturn(256);
@@ -100,11 +118,7 @@ public class UtilTest {
             return y >= 128 || x == 1 && z == 0 && (y == 100 || y == 101) ? hollow : solid;
         });
 
-        final Location safe = LocationUtil.getSafeDestination(essentials, new Location(world, 0, 64, 0));
-
-        assertEquals(1, safe.getBlockX());
-        assertEquals(100, safe.getBlockY());
-        assertFalse(LocationUtil.isBlockUnsafe(essentials, world, safe.getBlockX(), safe.getBlockY(), safe.getBlockZ()));
+        return LocationUtil.getSafeDestination(essentials, new Location(world, 0, 64, 0));
     }
 
     @Test


### PR DESCRIPTION
<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes #3318 and fixes #4483.

### Details

**Proposed fix:**    
<!-- Type a description of your proposed fix below this line. -->
- Created a crude `isAboveNetherRoof` safeguard for `getSafeDestination`.

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Linux (Server and Client)

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: 25

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] ~~Most recent Paper version (XX.YY.Z, git-Paper-BUILD)~~
- [ ] ~~CraftBukkit/Spigot/Paper 1.12.2~~
- [ ] ~~CraftBukkit 1.8.8~~
- [x] Paper 1.21.11


**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Before:

https://github.com/user-attachments/assets/250a27cf-1f11-421b-9d9f-36e0965249d3

After:

https://github.com/user-attachments/assets/38fc1db6-c364-4866-b08b-bfaa27fdaf5e

