### PR TITLE
Add essentials.chat.spy.exempt.block permission to fully block PMs to exempt players

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/messaging/IMessageRecipient.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/messaging/IMessageRecipient.java
@@ -127,7 +127,12 @@ public interface IMessageRecipient extends MailSender {
          * States that the message was <b>NOT</b> delivered as a result of the sender being muted. The message may
          * still have been shown to social spies.
          */
-        SENDER_MUTED;
+        SENDER_MUTED,
+        /**
+         * States that the message was <b>NOT</b> received as a result of the recipient blocking incoming private
+         * messages via {@code essentials.chat.spy.exempt.block}.
+         */
+        RECIPIENT_BLOCKED;
 
         /**
          * Returns whether this response is a success. In other words equal to {@link #SUCCESS} or {@link #SUCCESS_BUT_AFK}

--- a/Essentials/src/main/java/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/messaging/SimpleMessageRecipient.java
@@ -93,6 +93,17 @@ public class SimpleMessageRecipient implements IMessageRecipient {
         message = preSendEvent.getMessage();
 
         final User senderUser = getUser(this);
+        final User recipientUser = getUser(recipient);
+        // A recipient with essentials.chat.spy.exempt.block fully blocks incoming private messages,
+        // rather than merely being exempt from the socialspy broadcast. Since the message is never
+        // delivered, there is nothing for social spies to observe either.
+        // Note: PrivateMessageSentEvent is intentionally not fired here so the message is not relayed
+        // elsewhere (e.g. to Discord) as though it had actually been delivered.
+        if (recipientUser != null && recipientUser.isAuthorized("essentials.chat.spy.exempt.block")) {
+            sendTl("msgIgnore", recipient.getDisplayName());
+            return MessageResponse.RECIPIENT_BLOCKED;
+        }
+
         // A muted player must not have their message delivered to the recipient. However, social spies
         // may still observe the attempted message (see the socialspy-listen-muted-players setting).
         // Note: PrivateMessageSentEvent is intentionally not fired here so the message is not relayed
@@ -142,6 +153,9 @@ public class SimpleMessageRecipient implements IMessageRecipient {
 
     /**
      * Shows a private message to all online social spies, unless either party is exempt from being spied on.
+     * <p>
+     * Note: a recipient holding {@code essentials.chat.spy.exempt.block} never reaches this method, since
+     * their message is blocked before delivery in {@link #sendMessage(IMessageRecipient, String)}.
      *
      * @param recipient the recipient of the private message
      * @param message   the message that was sent
@@ -162,7 +176,8 @@ public class SimpleMessageRecipient implements IMessageRecipient {
         if (senderUser == null // not null if player.
                 || senderUser.isAuthorized("essentials.chat.spy.exempt")
                 || recipientUser == null
-                || recipientUser.isAuthorized("essentials.chat.spy.exempt")) {
+                || recipientUser.isAuthorized("essentials.chat.spy.exempt")
+                || recipientUser.isAuthorized("essentials.chat.spy.exempt.block")) {
             return;
         }
 

--- a/Essentials/src/main/resources/plugin.yml
+++ b/Essentials/src/main/resources/plugin.yml
@@ -710,6 +710,8 @@ permissions:
     description: Allows the bearers to see all local chat messages, regardless of their proximity to the sender
   essentials.chat.spy.exempt:
     description: Allows the bearer to be exempt from the local chat spy permission
+  essentials.chat.spy.exempt.block:
+    description: Allows the bearer to fully block incoming private messages, in addition to being exempt from the local chat spy permission
   essentials.clearinventory:
     description: Allows access to the /clearinventory command
   essentials.clearinventory.all:


### PR DESCRIPTION
### Information

This PR closes #6599.

### Details

**Proposed feature:**

Adds a new permission, `essentials.chat.spy.exempt.block`, that fully blocks incoming private messages to the holder, rather than only hiding them from `/socialspy`.

Currently, `essentials.chat.spy.exempt` only suppresses the socialspy broadcast copy of a private message sent to the exempt player — the message itself is still delivered to them. As raised in #6599, this doesn't fully protect the exempt player's privacy, since the sender's message content is still delivered and visible to the recipient (and, depending on setup, could still be observed/logged elsewhere).

Rather than changing the behavior of the existing `essentials.chat.spy.exempt` permission (which is widely used today purely to hide staff DMs from `/socialspy`, and changing it would break that behavior for existing servers), this adds a new, dedicated sub-permission that must be granted explicitly:

- `essentials.chat.spy.exempt.block`: fully blocks incoming PMs to the holder. The sender sees the same "has messages disabled" feedback used for `essentials.msgtoggle`, so the block doesn't leak that it's related to socialspy exemption. No socialspy broadcast occurs for blocked messages (there's nothing to observe, since the message is never delivered), and holding this permission also implies exemption from `/socialspy` even if `essentials.chat.spy.exempt` isn't separately granted.
- `essentials.chat.spy.exempt` behavior is completely unchanged — no existing server's permission setup is affected.

**Environments tested:**

OS: Windows 11
Java version: OpenJDK Temurin 25.0.3+9

- [x] Most recent Paper version (26.1.2, git-Paper-74)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8


**Demonstration:**

Tested manually using `./gradlew build :runServer` with LuckPerms installed, using three test players (A, B, C):

- Granted `essentials.chat.spy.exempt.block` to player B, and `essentials.socialspy` to player C (spy).
- Player A ran `/msg B <message>`: A received "PlayerB has messages disabled.", B received nothing, and C (spying) saw nothing.
- Player B was still able to send messages to A normally (block only applies to incoming messages, not outgoing).
- Regression-tested the existing `essentials.chat.spy.exempt` permission on its own (without `.block`): messages still deliver normally to the exempt player, and the socialspy broadcast is still suppressed, exactly as before this change.
- Regression-tested a player with no exemption permissions at all: messages deliver normally and are visible to the social spy, confirming spying still works as expected for non-exempt players.
