### PR TITLE
Remove useless try-catch in StringUtil joinList methods

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/utils/StringUtil.java
@@ -60,11 +60,7 @@ public final class StringUtil {
             if (each instanceof Collection) {
                 buf.append(joinList(seperator, ((Collection) each).toArray()));
             } else {
-                try {
-                    buf.append(each.toString());
-                } catch (final Exception e) {
-                    buf.append(each.toString());
-                }
+                buf.append(each.toString());
             }
         }
         return buf.toString();
@@ -84,11 +80,7 @@ public final class StringUtil {
             if (each instanceof Collection) {
                 buf.append(joinListSkip(seperator, skip, ((Collection) each).toArray()));
             } else {
-                try {
-                    buf.append(each.toString());
-                } catch (final Exception e) {
-                    buf.append(each.toString());
-                }
+                buf.append(each.toString());
             }
         }
         return buf.toString();


### PR DESCRIPTION
**### Information

This PR is not tied to an existing issue, the change was found while reading the source code

### Details

**Proposed fix:**    
The `try-catch` blocks in `StringUtil.joinList` and `StringUtil.joinListSkip` call `each.toString()` inside both the `try` and the `catch`. If the first call throws, the catch calls the exact same method on the same object and throws the same exception again, so the `try-catch` doesn't actually recover from anything.

Removed both blocks. Behavior is unchanged — if `toString()` throws, it will still propagate exactly as before.

**Environments tested:**    

OS: N/A — pure code cleanup no runtime behavior change to test

Java version: N/A — no behavior change.

- [ ] Most recent Paper version (XX.YY.Z, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8

~~All server versions~~ — this is a text-only source change with identical runtime behavior on every server version.

**Demonstration:**    
No screenshots — the `try-catch` was dead code, so removing it produces no visible difference at runtime. The diff itself demonstrates the change.**

