### PR TITLE
Collapse whitespace around color tags in translations

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/I18n.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/I18n.java
@@ -36,6 +36,9 @@ import java.util.regex.Pattern;
 public class I18n implements net.ess3.api.II18n {
     private static final String MESSAGES = "messages";
     private static final Pattern NODOUBLEMARK = Pattern.compile("''");
+    // A color tag is invisible once rendered, so a translation with whitespace on
+    // both sides of one shows a double space in chat. Many locales carry this.
+    private static final Pattern SPACED_COLOR_TAG = Pattern.compile("\\s+(</?(?:primary|secondary)>)\\s+");
     private static volatile ExecutorService BUNDLE_LOADER_EXECUTOR = Executors.newFixedThreadPool(2);
     private static final ResourceBundle NULL_BUNDLE = new ResourceBundle() {
         @SuppressWarnings("NullableProblems")
@@ -193,7 +196,7 @@ public class I18n implements net.ess3.api.II18n {
     }
 
     private String format(final Locale locale, final String string, final Object... objects) {
-        String format = translate(locale, string);
+        String format = SPACED_COLOR_TAG.matcher(translate(locale, string)).replaceAll(" $1");
 
         MessageFormat messageFormat = messageFormatCache.computeIfAbsent(locale, l -> new HashMap<>()).get(format);
         if (messageFormat == null) {


### PR DESCRIPTION
### Information
This PR fixes double spaces in translated messages.

A color tag is invisible once rendered, so a translation with whitespace on both sides of one shows a double space in chat. Example from the Danish locale:

```
flyMode=<primary>Set flytilstand <secondary> {0} <primary>for {1}<primary>.
```

The space before `<secondary>` and the space after it both survive rendering, so this shows as `Set flytilstand  aktiveret for WhoToldYou.`

I compared every locale's rendered strings (tags stripped) against the English source: the same mistake appears in roughly 400 strings across 38 locales (pt 35, tr 26, he 25, uk 23, pt_BR 22, ... da 3). Fixing that string by string on Crowdin is not realistic, and new translations keep reintroducing it, so this handles it at render time instead: translated formats collapse whitespace surrounding a primary/secondary tag to a single space before hitting the format cache. Strings with the tag flush against a word on either side are unchanged.

Checked the transformation against the three affected Danish strings (single spaced afterwards) and a clean string (byte-identical), and I'm running the patched build on a Danish-locale server.