### PR TITLE
Fix MiniMessage and color formatting in disposal GUI title

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commanddisposal.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commanddisposal.java
@@ -12,7 +12,8 @@ public class Commanddisposal extends EssentialsCommand {
     @Override
     protected void run(final Server server, final User user, final String commandLabel, final String[] args) throws Exception {
         user.sendTl("openingDisposal");
-        user.getBase().openInventory(ess.getServer().createInventory(user.getBase(), 36, user.playerTl("disposal")));
+        final String title = ess.getAdventureFacet().miniToLegacy(user.playerTl("disposal"));
+        user.getBase().openInventory(ess.getServer().createInventory(user.getBase(), 36, title));
     }
 
 }

--- a/Essentials/src/main/java/com/earth2me/essentials/signs/SignDisposal.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/signs/SignDisposal.java
@@ -21,10 +21,8 @@ public class SignDisposal extends EssentialsSign {
 
     @Override
     protected boolean onSignInteract(final ISign sign, final User player, final String username, final IEssentials ess) {
-        String title = (sign.getLine(1) + " " + sign.getLine(2) + " " + sign.getLine(3)).trim();
-        if (title.isEmpty()) {
-            title = player.playerTl("disposal");
-        }
+        final String customTitle = (sign.getLine(1) + " " + sign.getLine(2) + " " + sign.getLine(3)).trim();
+        final String title = customTitle.isEmpty() ? ess.getAdventureFacet().miniToLegacy(player.playerTl("disposal")) : customTitle;
         player.getBase().openInventory(ess.getServer().createInventory(player.getBase(), 36, title));
         return true;
     }


### PR DESCRIPTION
### Information

This PR fixes #6606.

### Details

**Proposed fix:**  
Passes the localized `disposal` string through `AdventureFacet#miniToLegacy` before creating the chest inventory view in both `Commanddisposal.java` and `SignDisposal.java`. This ensures both legacy formatting codes (`&a&l`) and Adventure/MiniMessage tags (`<green><bold>`) parse and render correctly in the inventory title bar.

**Environments tested:**  

OS: Windows 11  
Java version: Java 21  

- [x] Most recent Paper version (26.2)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8

**Demonstration:**  
<img width="554" height="76" alt="image" src="https://github.com/user-attachments/assets/6bb5b6a2-2a7b-4cf8-8d54-15776e63e2dd" />

<img width="388" height="223" alt="image" src="https://github.com/user-attachments/assets/bc8f5dee-9faa-4a03-937e-37d64a283e4c" />
