### PR TITLE
Fix Discord blocking server startup during Cloudflare rate limits

### DIFF
--- a/EssentialsDiscord/src/main/java/net/essentialsx/discord/EssentialsDiscord.java
+++ b/EssentialsDiscord/src/main/java/net/essentialsx/discord/EssentialsDiscord.java
@@ -58,16 +58,20 @@ public class EssentialsDiscord extends JavaPlugin implements IEssentialsModule {
 
         if (jda == null) {
             jda = new JDADiscordService(this);
-            try {
-                jda.startup();
-                ess.scheduleSyncDelayedTask(() -> ((InteractionControllerImpl) jda.getInteractionController()).processBatchRegistration());
-            } catch (Exception e) {
-                getLogger().log(Level.SEVERE, ess.getAdventureFacet().miniToLegacy(tlLiteral("discordErrorLogin", e.getMessage())));
-                if (ess.getSettings().isDebug()) {
-                    e.printStackTrace();
-                }
-                jda.shutdown();
+            ess.runTaskAsynchronously(this::startupAsync);
+        }
+    }
+
+    private void startupAsync() {
+        try {
+            jda.startup();
+            ess.scheduleSyncDelayedTask(() -> ((InteractionControllerImpl) jda.getInteractionController()).processBatchRegistration());
+        } catch (Exception e) {
+            getLogger().log(Level.SEVERE, ess.getAdventureFacet().miniToLegacy(tlLiteral("discordErrorLogin", e.getMessage())));
+            if (ess.getSettings().isDebug()) {
+                e.printStackTrace();
             }
+            jda.shutdown();
         }
     }
 


### PR DESCRIPTION
### Information

This PR fixes #6591.

### Details

**Proposed fix:**
Passes `startupAsync()` through `ess.runTaskAsynchronously` in `EssentialsDiscord.java` rather than executing JDA login synchronously on the main thread during plugin enablement. 

Previously, when JDA encountered connection timeouts or Cloudflare HTTP 429 rate limits, the blocking retry delay stalled the main server thread, hanging startup indefinitely. Offloading the initialization to an asynchronous task allows the server to complete its boot sequence immediately while Discord logs in and handles rate-limit retries in the background. Once JDA connects, interaction registrations are scheduled back onto the main thread via `ess.scheduleSyncDelayedTask()`.

**Environments tested:**

OS: Windows 11
Java version: Java 21

- [x] Most recent Paper version (26.2)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8

**Demonstration:**
* **Before:** Server startup hanged during enablement at `[EssentialsDiscord] Attempting to login to Discord...` followed by JDA's `Encountered cloudflare rate limit! Retry-After: ...` on the main thread, blocking the server from finishing initialization.
* **After:** Server completed initialization immediately (`Done (...)! For help, type "help"`), with the rate-limit delay and subsequent Discord login handled gracefully in the background without affecting the tick loop.